### PR TITLE
feat: use `GITHUB_TOKEN` env for cloning `https` repos

### DIFF
--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/mergestat/mergestat/extensions"
 	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/mergestat/mergestat/pkg/locator"
@@ -14,10 +15,20 @@ import (
 )
 
 func registerExt() {
+	var multiLocOpt *locator.MultiLocatorOptions
+	if githubToken != "" {
+		multiLocOpt = &locator.MultiLocatorOptions{
+			HTTPAuth: &http.BasicAuth{Username: githubToken},
+		}
+	}
+
 	sqlite.Register(
 		extensions.RegisterFn(
 			options.WithExtraFunctions(),
-			options.WithRepoLocator(locator.CachedLocator(locator.LoggingLocator(&logger, locator.MultiLocator()))),
+			options.WithRepoLocator(locator.CachedLocator(locator.LoggingLocator(
+				&logger,
+				locator.MultiLocator(multiLocOpt),
+			))),
 			options.WithContextValue("defaultRepoPath", repo),
 			options.WithGitHub(),
 			options.WithContextValue("githubToken", githubToken),

--- a/extensions/internal/git/git_test.go
+++ b/extensions/internal/git/git_test.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	// register sqlite extension when this package is loaded
 	sqlite.Register(extensions.RegisterFn(
-		options.WithExtraFunctions(), options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator())),
+		options.WithExtraFunctions(), options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator(nil))),
 	))
 }
 

--- a/extensions/internal/git/native/native_test.go
+++ b/extensions/internal/git/native/native_test.go
@@ -16,7 +16,7 @@ import (
 func init() {
 	// register sqlite extension when this package is loaded
 	sqlite.Register(extensions.RegisterFn(
-		options.WithExtraFunctions(), options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator())),
+		options.WithExtraFunctions(), options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator(nil))),
 	))
 }
 

--- a/shared.go
+++ b/shared.go
@@ -8,6 +8,7 @@ package main
 import (
 	"os"
 
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/mergestat/mergestat/extensions"
 	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/mergestat/mergestat/pkg/locator"
@@ -15,11 +16,19 @@ import (
 )
 
 func init() {
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	var multiLocOpt *locator.MultiLocatorOptions
+	if githubToken != "" {
+		multiLocOpt = &locator.MultiLocatorOptions{
+			HTTPAuth: &http.BasicAuth{Username: githubToken},
+		}
+	}
+
 	sqlite.Register(extensions.RegisterFn(
 		options.WithExtraFunctions(),
-		options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator())),
+		options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator(multiLocOpt))),
 		options.WithGitHub(),
-		options.WithContextValue("githubToken", os.Getenv("GITHUB_TOKEN")),
+		options.WithContextValue("githubToken", githubToken),
 		options.WithContextValue("githubPerPage", os.Getenv("GITHUB_PER_PAGE")),
 		options.WithContextValue("githubRateLimit", os.Getenv("GITHUB_RATE_LIMIT")),
 		options.WithSourcegraph(),


### PR DESCRIPTION
If it's set by the user. Makes it a bit easier to work with private repos via a `GITHUB_TOKEN`, which may already be supplied for GitHub API tables.