### PR TITLE
feat: allow user to set directory where repos are cloned to

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 var format string                                     // output format flag
 var presetQuery string                                // named / preset query flag
 var repo string                                       // path to repo on disk
+var cloneDir string                                   // path to directory to clone repos in
 var githubToken = os.Getenv("GITHUB_TOKEN")           // GitHub auth token for GitHub tables
 var sourcegraphToken = os.Getenv("SOURCEGRAPH_TOKEN") // Sourcegraph auth token for Sourcegraph queries
 var verbose bool                                      // whether or not to print logs to stderr
@@ -26,6 +27,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&format, "format", "f", "table", "specify the output format. Options are 'csv' 'tsv' 'table' 'single' and 'json'")
 	rootCmd.Flags().StringVarP(&presetQuery, "preset", "p", "", "used to pick a preset query")
 	rootCmd.PersistentFlags().StringVarP(&repo, "repo", "r", ".", "specify a path to a default repo on disk. This will be used if no repo is supplied as an argument to a git table")
+	rootCmd.PersistentFlags().StringVarP(&cloneDir, "clone-dir", "c", "", "specify a path to a directory on disk to use when cloning repos, instead of a tmp dir. Should be empty to avoid path conflicts.")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "whether or not to print query execution logs to stderr")
 
 	// register the sqlite extension ahead of any command

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -15,11 +15,11 @@ import (
 )
 
 func registerExt() {
-	var multiLocOpt *locator.MultiLocatorOptions
+	multiLocOpt := &locator.MultiLocatorOptions{
+		CloneDir: cloneDir,
+	}
 	if githubToken != "" {
-		multiLocOpt = &locator.MultiLocatorOptions{
-			HTTPAuth: &http.BasicAuth{Username: githubToken},
-		}
+		multiLocOpt.HTTPAuth = &http.BasicAuth{Username: githubToken}
 	}
 
 	sqlite.Register(

--- a/extensions/internal/git/clone.go
+++ b/extensions/internal/git/clone.go
@@ -1,0 +1,49 @@
+package git
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/mergestat/mergestat/extensions/internal/git/utils"
+	"github.com/pkg/errors"
+	"go.riyazali.net/sqlite"
+)
+
+// CloneFn is essentially a no-op
+type CloneFn struct {
+	Options *utils.ModuleOptions
+}
+
+func NewCloneFn(opt *utils.ModuleOptions) *CloneFn {
+	return &CloneFn{Options: opt}
+}
+
+func (*CloneFn) Deterministic() bool { return false }
+func (*CloneFn) Args() int           { return 1 }
+func (fn *CloneFn) Apply(c *sqlite.Context, values ...sqlite.Value) {
+	path := values[0].Text()
+
+	var err error
+	if path == "" {
+		path, err = utils.GetDefaultRepoFromCtx(fn.Options.Context)
+		if err != nil {
+			c.ResultError(err)
+			return
+		}
+	}
+
+	var repo *git.Repository
+	if repo, err = fn.Options.Locator.Open(context.Background(), path); err != nil {
+		c.ResultError(errors.Wrapf(err, "failed to open %q", path))
+		return
+	}
+
+	fsStorer, ok := repo.Storer.(*filesystem.Storage)
+	if !ok {
+		c.ResultError(fmt.Errorf("clone scalar function can only open filesystem backed git repos"))
+	}
+
+	c.ResultText(fsStorer.Filesystem().Root())
+}

--- a/extensions/internal/git/clone.go
+++ b/extensions/internal/git/clone.go
@@ -11,11 +11,13 @@ import (
 	"go.riyazali.net/sqlite"
 )
 
-// CloneFn is essentially a no-op
+// CloneFn is essentially a no-op that's useful for cloning remote repos
+// by opening them (and calling the Locator)
 type CloneFn struct {
 	Options *utils.ModuleOptions
 }
 
+// NewCloneFn returns a new CloneFn implementation
 func NewCloneFn(opt *utils.ModuleOptions) *CloneFn {
 	return &CloneFn{Options: opt}
 }

--- a/extensions/internal/git/git.go
+++ b/extensions/internal/git/git.go
@@ -40,6 +40,7 @@ func Register(ext *sqlite.ExtensionApi, opt *options.Options) (_ sqlite.ErrorCod
 
 	var fns = map[string]sqlite.Function{
 		"commit_from_tag": &CommitFromTagFn{},
+		"clone":           NewCloneFn(moduleOpts),
 	}
 
 	for name, fn := range fns {

--- a/shared.go
+++ b/shared.go
@@ -17,16 +17,16 @@ import (
 
 func init() {
 	githubToken := os.Getenv("GITHUB_TOKEN")
-	var multiLocOpt *locator.MultiLocatorOptions
+	var multiLocOpt locator.MultiLocatorOptions
 	if githubToken != "" {
-		multiLocOpt = &locator.MultiLocatorOptions{
+		multiLocOpt = locator.MultiLocatorOptions{
 			HTTPAuth: &http.BasicAuth{Username: githubToken},
 		}
 	}
 
 	sqlite.Register(extensions.RegisterFn(
 		options.WithExtraFunctions(),
-		options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator(multiLocOpt))),
+		options.WithRepoLocator(locator.CachedLocator(locator.MultiLocator(&multiLocOpt))),
 		options.WithGitHub(),
 		options.WithContextValue("githubToken", githubToken),
 		options.WithContextValue("githubPerPage", os.Getenv("GITHUB_PER_PAGE")),


### PR DESCRIPTION
by default (if no `--clone-dir` flag is set) `mergestat` will just create a temporary directory for cloning the repo before executing a query