### PR TITLE
feat: rename current `json` output format to `ndjson`

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,7 @@ var logger = zerolog.Nop()                            // By default use a NOOP l
 
 func init() {
 	// local (root command only) flags
-	rootCmd.Flags().StringVarP(&format, "format", "f", "table", "specify the output format. Options are 'csv' 'tsv' 'table' 'single' and 'json'")
+	rootCmd.Flags().StringVarP(&format, "format", "f", "table", "specify the output format. Options are 'csv' 'tsv' 'table' 'single' 'ndjson' and 'json'")
 	rootCmd.Flags().StringVarP(&presetQuery, "preset", "p", "", "used to pick a preset query")
 	rootCmd.PersistentFlags().StringVarP(&repo, "repo", "r", ".", "specify a path to a default repo on disk. This will be used if no repo is supplied as an argument to a git table")
 	rootCmd.PersistentFlags().StringVarP(&cloneDir, "clone-dir", "c", "", "specify a path to a directory on disk to use when cloning repos, instead of a tmp dir. Should be empty to avoid path conflicts.")

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/dnaeon/go-vcr/v2 v2.0.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-enry/go-enry/v2 v2.8.0
-	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-openapi/errors v0.20.1 // indirect
 	github.com/go-openapi/strfmt v0.21.1 // indirect

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -184,7 +184,9 @@ func jsonDisplay(rows *sql.Rows, writer io.Writer) error {
 	if out, err := json.Marshal(buffer); err != nil {
 		return err
 	} else {
-		writer.Write(out)
+		if _, err := writer.Write(out); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/display/display_test.go
+++ b/pkg/display/display_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/csv"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -131,6 +132,39 @@ func TestDisplayJSON(t *testing.T) {
 
 	var b bytes.Buffer
 	err := WriteTo(rows, &b, "json", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	o := make([]map[string]interface{}, 0)
+	err = json.Unmarshal(b.Bytes(), &o)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(o) != 3 {
+		t.Fatalf("expected 3 rows of output, got: %d", len(o))
+	}
+
+	if o[0]["name"] != "name 1" {
+		t.Fatalf(`expected "name" in first row to be "name 1", got: %s`, o[0]["name"])
+	}
+}
+
+func TestDisplayNDJSON(t *testing.T) {
+	db, mock, _ := sqlmock.New()
+
+	mockRows := sqlmock.NewRows([]string{"id", "name", "value"}).
+		AddRow("1", "name 1", "value 1").
+		AddRow("2", "name 2", "value 2").
+		AddRow("3", "name 3", "value 3")
+
+	mock.ExpectQuery("select").WillReturnRows(mockRows)
+
+	rows, _ := db.Query("select")
+
+	var b bytes.Buffer
+	err := WriteTo(rows, &b, "ndjson", false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
and make the `json` format output a JSON array of objects (instead of line-delimited json objects)

Closes #230 