### PR TITLE
feat: add date filtering and `--json` output to the `summary` sub command

### DIFF
--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -9,6 +9,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	dateFilterStart string
+	dateFilterEnd   string
+)
+
+func init() {
+	summaryCmd.Flags().StringVarP(&dateFilterStart, "start", "s", "", "specify a start date to filter by. Can be of format YYYY-MM-DD, or a SQLite \"date modifier,\" relative to 'now'")
+	summaryCmd.Flags().StringVarP(&dateFilterEnd, "end", "e", "", "specify an end date to filter by. Can be of format YYYY-MM-DD, or a SQLite \"date modifier,\" relative to 'now'")
+}
+
 var summaryCmd = &cobra.Command{
 	Use:   "summary [file pattern]",
 	Short: "Print a summary of commit activity",
@@ -26,7 +36,7 @@ Read more here: https://sqlite.org/lang_expr.html#the_like_glob_regexp_and_match
 
 		var ui *summary.TermUI
 		var err error
-		if ui, err = summary.NewTermUI(pathPattern); err != nil {
+		if ui, err = summary.NewTermUI(pathPattern, dateFilterStart, dateFilterEnd); err != nil {
 			handleExitError(err)
 		}
 		defer ui.Close()

--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -12,11 +12,13 @@ import (
 var (
 	dateFilterStart string
 	dateFilterEnd   string
+	outputJSON      bool
 )
 
 func init() {
 	summaryCmd.Flags().StringVarP(&dateFilterStart, "start", "s", "", "specify a start date to filter by. Can be of format YYYY-MM-DD, or a SQLite \"date modifier,\" relative to 'now'")
 	summaryCmd.Flags().StringVarP(&dateFilterEnd, "end", "e", "", "specify an end date to filter by. Can be of format YYYY-MM-DD, or a SQLite \"date modifier,\" relative to 'now'")
+	summaryCmd.Flags().BoolVar(&outputJSON, "json", false, "output as JSON")
 }
 
 var summaryCmd = &cobra.Command{
@@ -40,6 +42,11 @@ Read more here: https://sqlite.org/lang_expr.html#the_like_glob_regexp_and_match
 			handleExitError(err)
 		}
 		defer ui.Close()
+
+		if outputJSON {
+			fmt.Println(ui.PrintJSON())
+			return
+		}
 
 		// check if output is a terminal (https://rosettacode.org/wiki/Check_output_device_is_a_terminal#Go)
 		if fileInfo, _ := os.Stdout.Stat(); (fileInfo.Mode() & os.ModeCharDevice) != 0 {

--- a/cmd/summary/summary.go
+++ b/cmd/summary/summary.go
@@ -379,19 +379,18 @@ func (t *TermUI) PrintJSON() string {
 		"lastCommit":      t.commitSummary.LastCommit.String,
 	}
 
-	p := message.NewPrinter(language.English)
-	authorSummaries := make([]map[string]string, len(*t.commitAuthorSummaries))
+	authorSummaries := make([]map[string]interface{}, len(*t.commitAuthorSummaries))
 
 	for i, authorSummary := range *t.commitAuthorSummaries {
 		commitPercent := (float32(authorSummary.Commits) / float32(t.commitSummary.Total)) * 100.0
-		authorSummaries[i] = map[string]string{
+		authorSummaries[i] = map[string]interface{}{
 			"name":          authorSummary.AuthorName,
 			"email":         authorSummary.AuthorEmail,
-			"commits":       p.Sprintf("%d", authorSummary.Commits),
-			"commitPercent": p.Sprintf("%.2f%%", commitPercent),
-			"filesModified": p.Sprintf("%d", authorSummary.DistinctFiles),
-			"additions":     p.Sprintf("%d", authorSummary.Additions),
-			"deletions":     p.Sprintf("%d", authorSummary.Deletions),
+			"commits":       authorSummary.Commits,
+			"commitPercent": commitPercent,
+			"filesModified": authorSummary.DistinctFiles,
+			"additions":     authorSummary.Additions,
+			"deletions":     authorSummary.Deletions,
 		}
 	}
 

--- a/cmd/summary/summary.go
+++ b/cmd/summary/summary.go
@@ -345,6 +345,7 @@ func (t *TermUI) View() string {
 	return b.String()
 }
 
+// PrintNoTTY prints a version of output with no terminal styles
 func (t *TermUI) PrintNoTTY() string {
 	t.preloadCommits()
 	t.loadCommitSummary()
@@ -361,6 +362,7 @@ func (t *TermUI) PrintNoTTY() string {
 	return b.String()
 }
 
+// PrintJSON outputs summary results as a JSON object
 func (t *TermUI) PrintJSON() string {
 	t.preloadCommits()
 	t.loadCommitSummary()

--- a/cmd/summary/summary.go
+++ b/cmd/summary/summary.go
@@ -38,7 +38,7 @@ SELECT
 	(SELECT author_when FROM preloaded_commits ORDER BY author_when ASC LIMIT 1) AS first_commit,
 	(SELECT author_when FROM preloaded_commits ORDER BY author_when DESC LIMIT 1) AS last_commit,
 	(SELECT count(distinct(author_email || author_name)) FROM preloaded_commits) AS distinct_authors,
-	(SELECT count(distinct(path)) FROM files WHERE path LIKE ?) AS distinct_files
+	(SELECT count(distinct(file_path)) FROM preloaded_commit_stats WHERE file_path LIKE ?) AS distinct_files
 `
 
 type CommitAuthorSummary struct {
@@ -223,7 +223,7 @@ func (t *TermUI) renderCommitSummaryTable(boldHeader bool) string {
 	rows := []string{
 		strings.Join([]string{headingStyle.Render("Commits"), total}, "\t"),
 		strings.Join([]string{headingStyle.Render("Non-Merge Commits"), totalNonMerges}, "\t"),
-		strings.Join([]string{headingStyle.Render("Files"), distinctFiles}, "\t"),
+		strings.Join([]string{headingStyle.Render("Files Δ"), distinctFiles}, "\t"),
 		strings.Join([]string{headingStyle.Render("Unique Authors"), distinctAuthors}, "\t"),
 		strings.Join([]string{headingStyle.Render("First Commit"), firstCommit}, "\t"),
 		strings.Join([]string{headingStyle.Render("Latest Commit"), lastCommit}, "\t"),


### PR DESCRIPTION
Adds date filters to the `summary` subcommand (`--start` and `--end`) to let users specify a date range of commits to consider (using the `author_when` column).

The expected format is `YYYY-MM-DD`. Can also be a SQLite "[date modifier](https://www.sqlite.org/lang_datefunc.html)" relative to `now`. So `--start "-30 days"` will only consider commits authors in the last 30 days.

Also adds a `--json` flag, which outputs the `summary` tables but as a JSON object.