### PR TITLE
feat: vendor `libgit2` (via `git2go`)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,11 @@ jobs:
 
     - name: Check out source
       uses: actions/checkout@v1
+      with:
+        submodules: recursive
 
     - name: Install libgit2
-      run: git submodule update --init && make libgit2
+      run: make libgit2
 
     - name: Build
       run: make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Check out source
       uses: actions/checkout@v1
 
-    - name: Update submodules
-      run: git submodule update --init
+    - name: Install libgit2
+      run: git submodule update --init && make libgit2
 
     - name: Build
-      run: make libgit2 && make
+      run: make
 
     - name: Compress
       run: tar -czvf mergestat.tar.gz -C .build/ .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,11 @@ jobs:
     - name: Check out source
       uses: actions/checkout@v1
 
-    - name: Install libgit2
-      run: sudo ./scripts/install_libgit2.sh
+    - name: Update submodules
+      run: git submodule update --init
 
     - name: Build
-      run: make
+      run: make libgit2 && make
 
     - name: Compress
       run: tar -czvf mergestat.tar.gz -C .build/ .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Check out source
       uses: actions/checkout@v1
 
-    - name: Install libgit2
-      run: sudo ./scripts/install_libgit2.sh
+    - name: Update submodules
+      run: git submodule update --init
 
     - name: Vet
       run: make vet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,11 @@ jobs:
 
     - name: Check out source
       uses: actions/checkout@v1
+      with:
+        submodules: recursive
 
     - name: Install libgit2
-      run: git submodule update --init && make libgit2
+      run: make libgit2
 
     - name: Vet
       run: make vet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Check out source
       uses: actions/checkout@v1
 
-    - name: Update submodules
-      run: git submodule update --init
+    - name: Install libgit2
+      run: git submodule update --init && make libgit2
 
     - name: Vet
       run: make vet

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "git2go"]
+	path = git2go
+	url = https://github.com/libgit2/git2go

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "go.buildFlags": [
         "-tags='libsqlite3'"
     ],
-    "go.testFlags":  ["-v", "-tags=libsqlite3,static,system_libgit2"],
+    "go.testFlags":  ["-v", "-tags=libsqlite3,static"],
     "go.vetFlags": ["-tags=libsqlite3"],
     "go.toolsEnvVars": {
         "GOFLAGS": "-tags='libsqlite3'",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
 FROM golang:1.17-buster as builder
 WORKDIR /app
-COPY scripts .
 RUN apt-get update && apt-get -y install cmake libssl-dev
-RUN ./install_libgit2.sh
-COPY go.mod go.sum ./
-RUN go mod download
 COPY . .
+RUN make libgit2
 RUN make
 
 FROM debian:buster-slim

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ clean:
 # target for common golang tasks
 
 # go build tags used by test, vet and more
-TAGS = "static,system_libgit2"
+TAGS = "static"
 
 update:
 	go get -tags=$(TAGS) -u ./...

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,20 @@ ifeq ($(shell uname -s),Darwin)
 	export CGO_LDFLAGS = -Wl,-undefined,dynamic_lookup
 endif
 
+# target to build and install libgit2
+libgit2:
+	cd git2go; make install-static
+
 # target to build a dynamic extension that can be loaded at runtime
 .build/libmergestat.so: $(shell find . -type f -name '*.go' -o -name '*.c')
 	$(call log, $(CYAN), "building $@")
-	@go build -buildmode=c-shared -o $@ -tags="system_libgit2,shared" shared.go
+	@go build -buildmode=c-shared -o $@ -tags="static,shared" shared.go
 	$(call log, $(GREEN), "built $@")
 
 # target to compile mergestat executable
 .build/mergestat: $(shell find . -type f -name '*.go' -o -name '*.c')
 	$(call log, $(CYAN), "building $@")
-	@go build -o $@ -tags="static,system_libgit2" mergestat.go
+	@go build -o $@ -tags="static" mergestat.go
 	$(call log, $(GREEN), "built $@")
 
 # target to download latest sqlite3 amalgamation code

--- a/go.mod
+++ b/go.mod
@@ -75,3 +75,5 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/libgit2/git2go/v33 => ./git2go

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,6 @@ github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/libgit2/git2go/v33 v33.0.9 h1:4ch2DJed6IhJO28BEohkUoGvxLsRzUjxljoNFJ6/O78=
-github.com/libgit2/git2go/v33 v33.0.9/go.mod h1:KdpqkU+6+++4oHna/MIOgx4GCQ92IPCdpVRMRI80J+4=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=


### PR DESCRIPTION
Uses the instructions [here](https://github.com/libgit2/git2go/#main-branch-or-vendored-static-linking) (`main` branch, or vendored static linking) to vendor `libgit2` and `git2go` into this repo.

We're encountering an [issue](https://github.com/mergestat/homebrew-mergestat/issues/21) with homebrew installations when the upstream `libgit2` gets an update and we haven't upgraded `mergestat` to support the new `libgit2` version. Homebrew doesn't seem to allow us to pin to a particular version, so installations begin breaking.

I see two possible solutions:

1. Vendor `libgit2` (and `git2go`) into this repo so that builds will statically link it, no need to depend on a system `libgit2` (what this PR does)
2. Update the `homebrew` installation to just copy a pre-built binary

Or maybe both...