### PR TITLE
fix: refactor github rate limit handler to be settable

### DIFF
--- a/extensions/internal/github/branches.go
+++ b/extensions/internal/github/branches.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -25,7 +26,7 @@ type ref struct {
 }
 
 type fetchBranchResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	Edges       []*ref
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -33,7 +34,7 @@ type fetchBranchResults struct {
 
 func (i *iterBranches) fetchBranches(ctx context.Context, startCursor *githubv4.String) (*fetchBranchResults, error) {
 	var BranchQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/github.go
+++ b/extensions/internal/github/github.go
@@ -27,7 +27,7 @@ func Register(ext *sqlite.ExtensionApi, opt *options.Options) (_ sqlite.ErrorCod
 
 	githubOpts := &Options{
 		RateLimiter: rateLimiter,
-		RateLimitHandler: func(rlr *RateLimitResponse) {
+		RateLimitHandler: func(rlr *options.GitHubRateLimitResponse) {
 			// for now, just log to debug output current status of rate limit
 			secondsUntilReset := time.Until(rlr.ResetAt.Time).Seconds()
 			opt.Logger.Debug().
@@ -49,6 +49,10 @@ func Register(ext *sqlite.ExtensionApi, opt *options.Options) (_ sqlite.ErrorCod
 
 	if opt.GitHubClientGetter != nil {
 		githubOpts.Client = opt.GitHubClientGetter
+	}
+
+	if opt.GitHubRateLimitHandler != nil {
+		githubOpts.RateLimitHandler = opt.GitHubRateLimitHandler
 	}
 
 	var modules = map[string]sqlite.Module{

--- a/extensions/internal/github/issues_comments.go
+++ b/extensions/internal/github/issues_comments.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -38,7 +39,7 @@ type issueComment struct {
 }
 
 type fetchIssuesCommentsResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	Comments    *issueForComments
 	OrderBy     *githubv4.IssueCommentOrder
 	HasNextPage bool
@@ -47,7 +48,7 @@ type fetchIssuesCommentsResults struct {
 
 func (i *iterIssuesComments) fetchIssueComments(ctx context.Context, endCursor *githubv4.String) (*fetchIssuesCommentsResults, error) {
 	var issueQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/org_repos.go
+++ b/extensions/internal/github/org_repos.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
 )
 
 type fetchOrgReposResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	OrgRepos    []*orgRepo
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -80,7 +81,7 @@ type orgRepo struct {
 
 func (i *iterOrgRepos) fetchOrgRepos(ctx context.Context, startCursor *githubv4.String) (*fetchOrgReposResults, error) {
 	var reposQuery struct {
-		RateLimit    *RateLimitResponse
+		RateLimit    *options.GitHubRateLimitResponse
 		Organization struct {
 			Login        string
 			Repositories struct {

--- a/extensions/internal/github/pr_comments.go
+++ b/extensions/internal/github/pr_comments.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -38,7 +39,7 @@ type prComment struct {
 }
 
 type fetchPRCommentsResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	Comments    *pullRequestForComments
 	OrderBy     *githubv4.IssueCommentOrder
 	HasNextPage bool
@@ -47,7 +48,7 @@ type fetchPRCommentsResults struct {
 
 func (i *iterPRComments) fetchPRComments(ctx context.Context, endCursor *githubv4.String) (*fetchPRCommentsResults, error) {
 	var PRQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/pr_commits.go
+++ b/extensions/internal/github/pr_commits.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -46,7 +47,7 @@ type prCommit struct {
 }
 
 type fetchPRCommitsResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	PR          *pullRequestForCommits
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -54,7 +55,7 @@ type fetchPRCommitsResults struct {
 
 func (i *iterPRCommits) fetchPRCommits(ctx context.Context, endCursor *githubv4.String) (*fetchPRCommitsResults, error) {
 	var PRQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/repo.go
+++ b/extensions/internal/github/repo.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
 )
@@ -28,7 +29,7 @@ func (r *repoInfo) Apply(ctx *sqlite.Context, values ...sqlite.Value) {
 	// and then immediately re-marshal it into json for output...should probably make this simpler
 	// by using the graphQL query directly and returning the []byte result directly
 	var repoInfoQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			CreatedAt        time.Time
 			DefaultBranchRef struct {

--- a/extensions/internal/github/repo_branch_protection.go
+++ b/extensions/internal/github/repo_branch_protection.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -41,7 +42,7 @@ type protectionRules struct {
 }
 
 type fetchBranchProtectionResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	Edges       []*protectionRules
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -49,7 +50,7 @@ type fetchBranchProtectionResults struct {
 
 func (i *iterProtections) fetchProtections(ctx context.Context, startCursor *githubv4.String) (*fetchBranchProtectionResults, error) {
 	var Query struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/repo_commits.go
+++ b/extensions/internal/github/repo_commits.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -58,7 +59,7 @@ type objectCommit struct {
 }
 
 type fetchRepositoryCommitsResults struct {
-	RateLimit      *RateLimitResponse
+	RateLimit      *options.GitHubRateLimitResponse
 	defaultCommits *repositoryDefaultBranchForCommits
 	Commits        *repositoryForCommits
 	HasNextPage    bool
@@ -67,7 +68,7 @@ type fetchRepositoryCommitsResults struct {
 
 func (i *iterRepositoryCommits) fetchRepositoryCommits(ctx context.Context, endCursor *githubv4.String) (*fetchRepositoryCommitsResults, error) {
 	var repoQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string
@@ -77,7 +78,7 @@ func (i *iterRepositoryCommits) fetchRepositoryCommits(ctx context.Context, endC
 		} `graphql:"repository(owner: $owner, name: $name)"`
 	}
 	var repoBranchQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/repo_file_content.go
+++ b/extensions/internal/github/repo_file_content.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
 )
@@ -24,7 +25,7 @@ func (f *repoFileContent) Apply(ctx *sqlite.Context, values ...sqlite.Value) {
 	}
 
 	var fileContentsQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Object struct {
 				Blob struct {

--- a/extensions/internal/github/repo_issues.go
+++ b/extensions/internal/github/repo_issues.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -53,7 +54,7 @@ type issue struct {
 }
 
 type fetchIssuesResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	Edges       []*issueEdge
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -66,7 +67,7 @@ type issueEdge struct {
 
 func (i *iterIssues) fetchIssues(ctx context.Context, startCursor *githubv4.String) (*fetchIssuesResults, error) {
 	var issuesQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/repo_prs.go
+++ b/extensions/internal/github/repo_prs.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -76,7 +77,7 @@ type pullRequest struct {
 }
 
 type fetchPRResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	Edges       []*pullRequest
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -84,7 +85,7 @@ type fetchPRResults struct {
 
 func (i *iterPRs) fetchPRs(ctx context.Context, startCursor *githubv4.String) (*fetchPRResults, error) {
 	var PRQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/stargazer_count.go
+++ b/extensions/internal/github/stargazer_count.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
 )
@@ -23,7 +24,7 @@ func (s *starCount) Apply(ctx *sqlite.Context, values ...sqlite.Value) {
 	}
 
 	var starsCountQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			StargazerCount int
 		} `graphql:"repository(owner: $owner, name: $name)"`

--- a/extensions/internal/github/stargazers.go
+++ b/extensions/internal/github/stargazers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
@@ -31,7 +32,7 @@ type stargazerEdge struct {
 }
 
 type fetchStarsResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	Edges       []*stargazerEdge
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -39,7 +40,7 @@ type fetchStarsResults struct {
 
 func (i *iterStargazers) fetchStars(ctx context.Context, startCursor *githubv4.String) (*fetchStarsResults, error) {
 	var starsQuery struct {
-		RateLimit  *RateLimitResponse
+		RateLimit  *options.GitHubRateLimitResponse
 		Repository struct {
 			Owner struct {
 				Login string

--- a/extensions/internal/github/starred_repos.go
+++ b/extensions/internal/github/starred_repos.go
@@ -6,13 +6,14 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
 )
 
 type fetchStarredReposResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	Edges       []*starredRepoEdge
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -36,7 +37,7 @@ type starredRepoNode struct {
 
 func (i *iterStarredRepos) fetchStarredRepos(ctx context.Context, startCursor *githubv4.String) (*fetchStarredReposResults, error) {
 	var reposQuery struct {
-		RateLimit *RateLimitResponse
+		RateLimit *options.GitHubRateLimitResponse
 		User      struct {
 			Login               string
 			StarredRepositories struct {

--- a/extensions/internal/github/user_info.go
+++ b/extensions/internal/github/user_info.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
 )
@@ -25,7 +26,7 @@ func (s *userInfo) Apply(ctx *sqlite.Context, value ...sqlite.Value) {
 	}
 	login := value[0].Text()
 	var query struct {
-		RateLimit *RateLimitResponse
+		RateLimit *options.GitHubRateLimitResponse
 		User      struct {
 			Bio             string            `json:"bio"`
 			AvatarUrl       githubv4.URI      `json:"avatarUrl"`

--- a/extensions/internal/github/user_repos.go
+++ b/extensions/internal/github/user_repos.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"github.com/augmentable-dev/vtab"
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
 	"go.riyazali.net/sqlite"
 )
 
 type fetchUserReposResults struct {
-	RateLimit   *RateLimitResponse
+	RateLimit   *options.GitHubRateLimitResponse
 	UserRepos   []*userRepo
 	HasNextPage bool
 	EndCursor   *githubv4.String
@@ -80,7 +81,7 @@ type userRepo struct {
 
 func (i *iterUserRepos) fetchUserRepos(ctx context.Context, startCursor *githubv4.String) (*fetchUserReposResults, error) {
 	var reposQuery struct {
-		RateLimit *RateLimitResponse
+		RateLimit *options.GitHubRateLimitResponse
 		User      struct {
 			Login        string
 			Repositories struct {

--- a/extensions/internal/github/utils.go
+++ b/extensions/internal/github/utils.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mergestat/mergestat/extensions/options"
 	"github.com/mergestat/mergestat/extensions/services"
 	"github.com/rs/zerolog"
 	"github.com/shurcooL/githubv4"
@@ -15,20 +16,10 @@ import (
 type Options struct {
 	Client           func() *githubv4.Client
 	RateLimiter      *rate.Limiter
-	RateLimitHandler func(*RateLimitResponse)
+	RateLimitHandler func(*options.GitHubRateLimitResponse)
 	// PerPage is the default number of items per page to use when making a paginated GitHub API request
 	PerPage int
 	Logger  *zerolog.Logger
-}
-
-// RateLimiteResponse represents metadata about the caller's rate limit, returned by the GitHub GraphQL API
-type RateLimitResponse struct {
-	Cost      int
-	Limit     int
-	NodeCount int
-	Remaining int
-	ResetAt   githubv4.DateTime
-	Used      int
 }
 
 // GetGitHubTokenFromCtx looks up the githubToken key in the supplied context and returns it if set

--- a/extensions/options/github.go
+++ b/extensions/options/github.go
@@ -1,0 +1,13 @@
+package options
+
+import "github.com/shurcooL/githubv4"
+
+// GitHubRateLimitResponse represents metadata about the caller's rate limit, returned by the GitHub GraphQL API
+type GitHubRateLimitResponse struct {
+	Cost      int
+	Limit     int
+	NodeCount int
+	Remaining int
+	ResetAt   githubv4.DateTime
+	Used      int
+}

--- a/extensions/options/options.go
+++ b/extensions/options/options.go
@@ -31,6 +31,9 @@ type Options struct {
 	// GitHubClientGetter overrides the default GitHub v4 client
 	GitHubClientGetter func() *githubv4.Client
 
+	// GitHubRateLimitHandler overrides the default GitHub API rate limit response handler
+	GitHubRateLimitHandler func(*GitHubRateLimitResponse)
+
 	// Sourcegraph set to true to register Sourcegraph tables/func
 	Sourcegraph bool
 
@@ -72,6 +75,11 @@ func WithGitHub() OptionFn {
 // WithGitHubClientGetter configures a way to use a custom GitHubv4 client
 func WithGitHubClientGetter(getter func() *githubv4.Client) OptionFn {
 	return func(o *Options) { o.GitHubClientGetter = getter }
+}
+
+// WithGitHubRateLimitHandler configures a way to use a custom GitHub API rate limit handler
+func WithGitHubRateLimitHandler(handler func(*GitHubRateLimitResponse)) OptionFn {
+	return func(o *Options) { o.GitHubRateLimitHandler = handler }
 }
 
 // WithSourcegraph configures the extension to also register the Sourcegraph related tables and funcs


### PR DESCRIPTION
allow library consumers to supply their own github rate limit handler