### PR TITLE
fix: add target blank to learn more link

### DIFF
--- a/ui/src/views/repository-data-details/components/repo-data-type-logs/index.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-logs/index.tsx
@@ -20,7 +20,9 @@ export const RepoDataLogs = ({ syncData, logs }: RepoDataLogsProps) => {
             {syncData?.brief}
           </p>
           <Link href='https://docs.mergestat.com/'>
-            <Button skin='borderless' label='Learn more' />
+            <a target='_blank' href='https://docs.mergestat.com/' rel='noopener noreferrer' className="t-button t-button-borderless">
+              Learn more
+            </a>
           </Link>
         </Panel.Body>
       </Panel>


### PR DESCRIPTION
The learn more link didn't open in a new tab
<img width="1583" alt="image" src="https://user-images.githubusercontent.com/36261498/195831098-fb4e027a-771b-499f-b76d-5e6c82ccbf1d.png">
