### PR TITLE
Update breadcrumb thumbnail size

### DIFF
--- a/ui/src/pages/settings/repo-auto-imports/[importId].tsx
+++ b/ui/src/pages/settings/repo-auto-imports/[importId].tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@apollo/client'
-import { BreadcrumbNav, Button, Checkbox, ColoredBox, Panel, Toolbar } from '@mergestat/blocks'
+import { BreadcrumbNav, Button, Checkbox, Panel, Toolbar } from '@mergestat/blocks'
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { useRouter } from 'next/router'

--- a/ui/src/pages/settings/repo-auto-imports/[importId].tsx
+++ b/ui/src/pages/settings/repo-auto-imports/[importId].tsx
@@ -72,9 +72,7 @@ const AutoImportsDetail: NextPage = () => {
     {
       text: name,
       startIcon: (
-        <ColoredBox size='10'>
-          <RepoImage repoType='github' orgName={name} size="10" />
-        </ColoredBox>
+        <RepoImage repoType='github' orgName={name} size="8" />
       ),
     },
   ]


### PR DESCRIPTION
The thumbnail size was inconsistent with the other breadcrumbs and there was a duplicate ColoredBox wrapper

#### Previously
<img width="476" alt="image" src="https://user-images.githubusercontent.com/36261498/195831300-51436390-0ce3-4ea6-b066-c1d41210b381.png">

#### After
<img width="432" alt="image" src="https://user-images.githubusercontent.com/36261498/195831772-d3b44408-326a-4d77-b985-2fe83ee2837e.png">
