### PR TITLE
Update package

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,10 +10,11 @@
       "dependencies": {
         "@apollo/client": "^3.7.0",
         "@apollo/react-testing": "^4.0.0",
-        "@mergestat/blocks": "^1.4.2",
+        "@mergestat/blocks": "^1.4.3",
         "@mergestat/icons": "^1.2.2",
         "@monaco-editor/react": "^4.4.6",
         "@next/bundle-analyzer": "^12.1.4",
+        "@tailwindcss/line-clamp": "^0.4.2",
         "axios": "^0.27.2",
         "classnames": "^2.3.1",
         "cookies-next": "^2.1.1",
@@ -2321,9 +2322,9 @@
       }
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.4.2.tgz",
-      "integrity": "sha512-joZRX8VP05XZD7BIvNMoFQco7EoZYW2a7RMDJ3k4XmjVmtC3eZrLlkLoZ4zCi7JLaHTBpnvDiGuxXvo2yp5f1g==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.4.3.tgz",
+      "integrity": "sha512-RpSeQGvFqUbRmKdhmq37JWGE8iFq2iVQ5EqBMDACJDqNar6HDU4vSqc7327f4Fb3d4jovZNId7j71vJM71P2vQ==",
       "dependencies": {
         "@headlessui/react": "^1.4.1",
         "@mergestat/icons": "^1.2.2",
@@ -2739,6 +2740,14 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz",
+      "integrity": "sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -13053,9 +13062,9 @@
       }
     },
     "@mergestat/blocks": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.4.2.tgz",
-      "integrity": "sha512-joZRX8VP05XZD7BIvNMoFQco7EoZYW2a7RMDJ3k4XmjVmtC3eZrLlkLoZ4zCi7JLaHTBpnvDiGuxXvo2yp5f1g==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.4.3.tgz",
+      "integrity": "sha512-RpSeQGvFqUbRmKdhmq37JWGE8iFq2iVQ5EqBMDACJDqNar6HDU4vSqc7327f4Fb3d4jovZNId7j71vJM71P2vQ==",
       "requires": {
         "@headlessui/react": "^1.4.1",
         "@mergestat/icons": "^1.2.2",
@@ -13285,6 +13294,12 @@
       "requires": {
         "tslib": "^2.4.0"
       }
+    },
+    "@tailwindcss/line-clamp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.2.tgz",
+      "integrity": "sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==",
+      "requires": {}
     },
     "@tailwindcss/typography": {
       "version": "0.4.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -17,10 +17,11 @@
   "dependencies": {
     "@apollo/client": "^3.7.0",
     "@apollo/react-testing": "^4.0.0",
-    "@mergestat/blocks": "^1.4.2",
+    "@mergestat/blocks": "^1.4.3",
     "@mergestat/icons": "^1.2.2",
     "@monaco-editor/react": "^4.4.6",
     "@next/bundle-analyzer": "^12.1.4",
+    "@tailwindcss/line-clamp": "^0.4.2",
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
     "cookies-next": "^2.1.1",

--- a/ui/src/components/RepoImage.tsx
+++ b/ui/src/components/RepoImage.tsx
@@ -33,7 +33,7 @@ const RepoImage: React.FC<RepoImagePropsT> = ({
           className="rounded"
           alt=''
         />
-        : <RepositoryIcon className="t-icon text-semantic-icon" />
+        : <RepositoryIcon className="t-icon t-icon-default" />
       }
     </ColoredBox>
   )

--- a/ui/src/components/RepoSyncIcon.tsx
+++ b/ui/src/components/RepoSyncIcon.tsx
@@ -27,19 +27,19 @@ export const RepoSyncIcon = ({ type, className = '' }: RepoSyncIconPropsT) => {
   switch (type) {
     case SYNC_STATUS.disabled:
       text = 'Sync is disabled'
-      icon = <CircleInformationFilledIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      icon = <CircleInformationFilledIcon className={cx('t-icon t-icon-muted', { [className]: className !== '' })} />
       break
     case SYNC_STATUS.succeeded:
       text = 'Last sync was successful'
-      icon = <CircleCheckFilledIcon className={cx('t-icon text-semantic-success', { [className]: className !== '' })} />
+      icon = <CircleCheckFilledIcon className={cx('t-icon t-icon-success', { [className]: className !== '' })} />
       break
     case SYNC_STATUS.error:
       text = 'Last sync had an error'
-      icon = <CircleErrorFilledIcon className={cx('t-icon text-semantic-danger', { [className]: className !== '' })} />
+      icon = <CircleErrorFilledIcon className={cx('t-icon t-icon-danger', { [className]: className !== '' })} />
       break
     case SYNC_STATUS.queued:
       text = 'Sync is queued to run'
-      icon = <ClockIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      icon = <ClockIcon className={cx('t-icon t-icon-muted', { [className]: className !== '' })} />
       break
     case SYNC_STATUS.running:
       text = 'Sync is currently running'
@@ -47,7 +47,7 @@ export const RepoSyncIcon = ({ type, className = '' }: RepoSyncIconPropsT) => {
       break
     default:
       text = 'No sync history'
-      icon = <MinusIcon className={cx('t-icon text-semantic-mutedIcon', { [className]: className !== '' })} />
+      icon = <MinusIcon className={cx('t-icon t-icon-muted', { [className]: className !== '' })} />
       break
   }
   return <WithTooltip status={text} icon={icon} />

--- a/ui/src/pages/settings/index.tsx
+++ b/ui/src/pages/settings/index.tsx
@@ -35,16 +35,18 @@ const Settings: NextPage = () => {
           </div>
           <div className='flex-1 p-8 overflow-auto'>
             <Panel className='shadow-sm'>
-              <Panel.Body className='py-8'>
-                <h3 className='t-h3'>GitHub Personal Access Token</h3>
-                <Alert type='info' theme='light' className='mb-5'>
+              <Panel.Header>
+                <h3 className='t-panel-title'>GitHub Personal Access Token</h3>
+              </Panel.Header>
+              <Panel.Body>
+                <Alert type='default' theme='light' className='mb-6'>
                   <span>
                     In order to access the GitHub API and any private GitHub
                     repositories, we need to authenticate with{' '}
                     <a
                       target='_blank'
                       href={LINKS_TO.createPAt}
-                      className='t-link font-bold'
+                      className='t-link font-semibold'
                       rel='noopener noreferrer'
                     >
                       a personal access token
@@ -53,7 +55,7 @@ const Settings: NextPage = () => {
                     flow) may become available in the future.
                   </span>
                 </Alert>
-                <form className='mb-6'>
+                <form className='mb-4'>
                   <div className='flex items-center space-x-3'>
                     <Input
                       className='max-w-lg'

--- a/ui/src/pages/settings/repo-auto-imports/[importId].tsx
+++ b/ui/src/pages/settings/repo-auto-imports/[importId].tsx
@@ -116,7 +116,7 @@ const AutoImportsDetail: NextPage = () => {
                             </td>
                             <td className='py-3 pl-4 pr-8'>
                               <h4 className='font-medium mb-0.5'>{syncType.shortName}</h4>
-                              <p className='text-semantic-mutedText text-sm'>{syncType.description}</p>
+                              <p className='t-text-muted text-sm'>{syncType.description}</p>
                             </td>
                           </tr>
                         ))}

--- a/ui/src/pages/settings/repo-auto-imports/[importId].tsx
+++ b/ui/src/pages/settings/repo-auto-imports/[importId].tsx
@@ -104,7 +104,7 @@ const AutoImportsDetail: NextPage = () => {
                     <h4 className='t-h4 mb-0'>Select default syncs</h4>
                   </Panel.Header>
                   <Panel.Body className='p-0'>
-                    <table className='t-table-default t-table-clickable'>
+                    <table className='t-table-default t-table-hover'>
                       <tbody className='bg-white'>
                         {syncsTypesArray.map((syncType, index) => (
                           <tr key={index} onClick={() => handleCheckBox(syncType.type)}>

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -25,76 +25,12 @@
 */
 
 
-
-/* TODO: Move to blocks */
-.t-link {
-  @apply underline
-         text-blue-600
-         hover_text-blue-700;
-}
-
-.t-input-with-prepend {
-  @apply flex
-         items-center;
-}
-
-.t-input-with-prepend *:first-child {
-  @apply z-10;
-}
-
-.t-input-with-prepend .t-button {
-  @apply rounded-r-none;
-}
-
-.t-input-with-prepend .t-input {
-  @apply rounded-l-none
-         -ml-px;
-}
-
+/* TODO(emily): fix override max-h-full class in t-modal styles in blocks */
 .t-modal {
   max-height: calc(100vh - 4.8rem);
 }
 
-.t-table-clickable tbody tr:hover,
-.t-table-clickable tbody tr:focus-within {
-  @apply bg-gray-50;
-}
-
-.t-table-clickable tbody .t-table-row-muted:hover,
-.t-table-clickable tbody .t-table-row-muted:focus-within {
-  @apply bg-gray-100;
-}
-
-.t-table-row-link {
-  @apply h-full
-         w-full
-         absolute
-         outline-none
-         top-0
-         left-0
-         right-0
-         bottom-0;
-}
-
-.t-table-row-muted {
-  @apply bg-gray-50;
-}
-
-.t-table-default td,
-.t-table-default th {
-  @apply px-6;
-}
-
-.t-table-default td:first-child,
-.t-table-default th:first-child {
-  @apply pl-8;
-}
-
-.t-table-default td:last-child,
-.t-table-default th:last-child {
-  @apply pr-8;
-}
-
+/* TODO(emily): add button styles to blocks */
 .t-nav-item > a,
 .t-nav-item > button {
     @apply px-5
@@ -113,115 +49,8 @@
            cursor-pointer;
 }
 
-.t-sr-only {
-  position: absolute !important;
-  left: -10000px !important;
-  top: auto !important;
-  width: 1px !important;
-  height: 1px !important;
-  overflow: hidden !important;
-}
-
-.t-table-default th {
-  @apply bg-gray-50
-          text-gray-700
-          font-semibold;
-}
-
-.t-table-bordered td,
-.t-table-bordered th {
-  @apply border
-         border-gray-250;
-}
-
-.t-table-bordered th {
-  @apply border-t-0
-         border-b-2;
-}
-
-.t-table-bordered tr:last-child td {
-  @apply  border-r
-          border-l
-          border-b;
-}
-
-.t-table-bordered td:first-child,
-.t-table-bordered th:first-child,
-.t-table-bordered tr:last-child td:first-child  {
-  @apply border-l-0;
-}
-
-.t-table-bordered td:last-child,
-.t-table-bordered th:last-child,
-.t-table-bordered tr:last-child td:last-child  {
-  @apply border-r-0;
-}
-
-.t-table-dense td {
-  @apply py-2.5
-         text-sm;
-}
-
-.t-table-dense th {
-  @apply pt-3.5
-         pb-2
-         text-sm;
-}
-
-.t-table-sticky-header {
-  border-collapse: collapse;
-}
-
-.t-table-sticky-header thead tr th:before {
-  content: '';
-  @apply absolute
-         left-0
-         w-full
-         -bottom-px
-         border-b-2;
-}
-
+/* TODO(emily) re-add missing resizer styles to blocks */
 .t-resizer {
-  @apply bg-gray-50
-         mix-blend-multiply
-         py-1;
-}
-
-
-.t-resizer:before {
-    content: '';
-    @apply w-10
-           mx-auto
-           h-1
-           rounded-full
-           block
-           border-0
-           bg-gray-400;
-}
-
-.t-resizer:active,
-.t-resizer:hover {
-    @apply bg-gray-100;
-}
-
-
-.t-resizer:active:before,
-.t-resizer:hover:before {
-    @apply bg-gray-450
-            border-gray-450;
-}
-
-.t-alert-full-width {
-  @apply border-0
-         border-b
-         text-sm
-         py-2.5
-         px-8
-         rounded-none;
-}
-
-.t-alert-warning {
-  background: #FEF7EB;
-  color: #705F43;
-  border-color: #FCE2B6;
+  cursor: row-resize;
+  @apply w-full;
 }

--- a/ui/src/views/repositories/components/empty-repository-table.tsx
+++ b/ui/src/views/repositories/components/empty-repository-table.tsx
@@ -29,7 +29,7 @@ export const EmptyRepositoryTable: React.FC = () => {
               <div className="w-full lg_w-6/12 p-8 lg_p-10 flex flex-col items-center lg_items-start">
                 {/* <Avatar className="mb-6" icon={<CogIcon className="t-icon" />} size="md" /> */}
                 <h3 className="t-h3 mb-2">GitHub Authentication Token</h3>
-                <p className="text-semantic-mutedText">Add a personal access token to start importing from GitHub (and to work with private repos).</p>
+                <p className="t-text-muted">Add a personal access token to start importing from GitHub (and to work with private repos).</p>
                 <div className="t-button-toolbar mt-8">
                   <Link href="/settings">
                     <Button label="Authenticate GitHub" endIcon={<GithubIcon className="t-icon" />} />

--- a/ui/src/views/repositories/components/empty-repository.tsx
+++ b/ui/src/views/repositories/components/empty-repository.tsx
@@ -11,7 +11,7 @@ export const EmptyRepository: React.FC = () => {
     <div data-testid={TEST_IDS.emptyRepository} className="flex items-center justify-center h-full w-full">
       <div className="flex flex-col items-center">
         <Avatar icon={<RepositoryIcon className='t-icon' />} size='lg' />
-        <p className="text-semantic-mutedText py-5">No repositories added yet</p>
+        <p className="t-text-muted py-5">No repositories added yet</p>
         <Button
           startIcon={<PlusIcon className="t-icon" />}
           onClick={() => setShowAddRepositoryModal(true)}

--- a/ui/src/views/repositories/components/repositories-table/index.tsx
+++ b/ui/src/views/repositories/components/repositories-table/index.tsx
@@ -67,7 +67,7 @@ export const RepositoriesTable: React.FC<RepositoriesTableProps> = ({ data }: Re
                         {repo.status.length
                           ? <>
                             <td className='h-20'>
-                              <RelativeTimeField date={repo.lastSync} styles={'text-semantic-mutedText whitespace-nowrap'} />
+                              <RelativeTimeField date={repo.lastSync} styles={'t-text-muted whitespace-nowrap'} />
                             </td>
                             <td className='h-20 w-0'>
                               <div className='flex items-center justify-center'>
@@ -129,7 +129,7 @@ export const RepositoriesTable: React.FC<RepositoriesTableProps> = ({ data }: Re
                             <div className='t-button-toolbar gap-6'>
                               <div className='flex items-center justify-center gap-2'>
                                 <CircleInformationFilledIcon className='t-icon t-icon-muted' />
-                                <span className='text-semantic-mutedText'>Set up sync types</span>
+                                <span className='t-text-muted'>Set up sync types</span>
                                 <ChevronRightIcon className='t-icon t-icon-muted' />
                               </div>
                               <Button skin="borderless-muted" startIcon={<TrashIcon className="t-icon" />} isIconOnly onClick={() => prepareToRemove(repo.id, repo.name, !!repo.autoImportFrom)} />

--- a/ui/src/views/repositories/components/repositories-table/index.tsx
+++ b/ui/src/views/repositories/components/repositories-table/index.tsx
@@ -37,7 +37,7 @@ export const RepositoriesTable: React.FC<RepositoriesTableProps> = ({ data }: Re
             </div>
             : <div className='flex flex-col min-w-0 bg-white h-full'>
               <div className='flex-1 overflow-x-auto overflow-y-hidden'>
-                <table data-testid={TEST_IDS.repoTableList} className='t-table-default t-table-clickable'>
+                <table data-testid={TEST_IDS.repoTableList} className='t-table-default t-table-hover'>
                   <thead>
                     <tr className='bg-white'>
                       <th scope='col' key='name' className='whitespace-nowrap'>Repository</th>

--- a/ui/src/views/repositories/components/repositories-table/repositories-table-columns/repository-name.tsx
+++ b/ui/src/views/repositories/components/repositories-table/repositories-table-columns/repository-name.tsx
@@ -22,11 +22,11 @@ export const RepositoryName: React.FC<RepositoryNameProps> = (props) => {
       case 'gitlab':
       case 'bitbucket':
       case 'other':
-        return <RepositoryIcon className='t-icon text-semantic-mutedIcon w-4' />
+        return <RepositoryIcon className='t-icon t-icon-muted w-4' />
       default:
         return (
           <a target='_blank' href={GITHUB_URL + props.name} rel='noopener noreferrer'>
-            <GithubIcon className='t-icon text-semantic-mutedIcon w-4' />
+            <GithubIcon className='t-icon t-icon-muted w-4' />
           </a>
         )
     }
@@ -41,12 +41,12 @@ export const RepositoryName: React.FC<RepositoryNameProps> = (props) => {
       />
       <div>
         <Link href={`/repos/${props.id}`}>
-          <h4 data-testid={TEST_IDS.repoNameTable} className='font-medium mb-0.5 text-semantic-text cursor-pointer hover_text-blue-600'>
+          <h4 data-testid={TEST_IDS.repoNameTable} className='font-medium mb-0.5 t-text-default cursor-pointer hover_text-blue-600'>
             {props.name}
           </h4>
         </Link>
         <div className='flex items-center'>
-          <span className='pr-2 text-sm text-semantic-mutedText'>
+          <span className='pr-2 text-sm t-text-muted'>
             <Tooltip
               content={`Added ${format(props.createdAt, 'PPp')}`}
               placement='bottom'
@@ -69,7 +69,7 @@ export const RepositoryName: React.FC<RepositoryNameProps> = (props) => {
                 placement='bottom'
               >
                 <Link href='/settings/repo-auto-imports' passHref>
-                  <AutoImportIcon className='t-icon text-semantic-mutedIcon w-4 cursor-pointer' />
+                  <AutoImportIcon className='t-icon t-icon-muted w-4 cursor-pointer' />
                 </Link>
               </Tooltip>
             </div>

--- a/ui/src/views/repositories/drop-downs/edit-tags-list-drop-down.tsx
+++ b/ui/src/views/repositories/drop-downs/edit-tags-list-drop-down.tsx
@@ -28,7 +28,7 @@ export const EditTagsListDropDown: React.FC<RepositoryTagListProps> = ({ showMor
               <span>+{moreTags}</span>
             </div>
           )}
-          <DotsHorizontalIcon className="t-icon t-icon-small h-full text-semantic-icon" />
+          <DotsHorizontalIcon className="t-icon t-icon-small h-full t-icon-default" />
         </div>
       }
       zIndex={11}

--- a/ui/src/views/repositories/drop-downs/repo-data-drop-down.tsx
+++ b/ui/src/views/repositories/drop-downs/repo-data-drop-down.tsx
@@ -23,11 +23,11 @@ export const RepoDataDropDown: React.FC<RepoDataDropDownProps> = ({ data, status
                 <div className="flex items-center gap-3">
                   <RepoSyncIcon type={status} className="t-icon" />
                   <div className='flex flex-col text-left'>
-                    <span className='text-sm font-medium text-semantic-text mb-0.5'>{item.title}</span>
-                    <span className='text-sm text-semantic-mutedText'>{item.lastSync}</span>
+                    <span className='text-sm font-medium t-text-default mb-0.5'>{item.title}</span>
+                    <span className='text-sm t-text-muted'>{item.lastSync}</span>
                   </div>
                 </div>
-                <ChevronRightIcon className='t-icon text-semantic-icon' />
+                <ChevronRightIcon className='t-icon t-icon-default' />
               </div>
             </Link>
           ))}
@@ -42,15 +42,15 @@ function getRepoStatusComponent(status: RepoSyncStateT, count: number): React.Re
   switch (status) {
     case SYNC_STATUS.succeeded:
       return <IconAndQuantity count={count}>
-        <CircleCheckFilledIcon className="t-icon text-semantic-success" />
+        <CircleCheckFilledIcon className="t-icon t-icon-success" />
       </IconAndQuantity>
     case SYNC_STATUS.error:
       return <IconAndQuantity count={count}>
-        <CircleErrorFilledIcon className="t-icon text-semantic-danger" />
+        <CircleErrorFilledIcon className="t-icon t-icon-danger" />
       </IconAndQuantity>
     case SYNC_STATUS.queued:
       return <IconAndQuantity count={count}>
-        <ClockIcon className='t-icon text-semantic-mutedIcon' />
+        <ClockIcon className='t-icon t-icon-muted' />
       </IconAndQuantity>
     case SYNC_STATUS.running:
       return <IconAndQuantity count={count}>

--- a/ui/src/views/repositories/drop-downs/sync-repos-data-drop-down/sync-data-table.tsx/columns.tsx
+++ b/ui/src/views/repositories/drop-downs/sync-repos-data-drop-down/sync-data-table.tsx/columns.tsx
@@ -5,7 +5,7 @@ import { RowOptions } from './row-options'
 export const columns: Array<Record<string, unknown>> = [
   {
     title: (
-      <Typography.Title className='text-semantic-header font-semibold ml-6'>
+      <Typography.Title className='t-text-header font-semibold ml-6'>
         Sync Data
       </Typography.Title>
     ),
@@ -14,10 +14,10 @@ export const columns: Array<Record<string, unknown>> = [
     key: 'dataType',
     render: (params: { title: string, brief?: string }) => (
       <div className='ml-6 my-3'>
-        <h4 className="font-medium mb-0.5 text-semantic-text cursor-pointer hover_text-blue-600">
+        <h4 className="font-medium mb-0.5 t-text-default cursor-pointer hover_text-blue-600">
           {params.title}
         </h4>
-        <p className="text-sm text-semantic-mutedText whitespace-nowrap">
+        <p className="text-sm t-text-muted whitespace-nowrap">
           {params.brief}
         </p>
       </div>
@@ -32,7 +32,7 @@ export const columns: Array<Record<string, unknown>> = [
         skin='secondary'
         size="small"
         startIcon={
-          <RefreshIcon className={`t-icon ${params.disabled ? 'text-semantic-mutedIcon' : 'text-semantic-icon'}`} />
+          <RefreshIcon className={`t-icon ${params.disabled ? 't-icon-muted' : 't-icon-default'}`} />
         }
         onClick={params.doSync}
         disabled={params.disabled}

--- a/ui/src/views/repositories/drop-downs/sync-repos-data-drop-down/sync-data-table.tsx/row-options.tsx
+++ b/ui/src/views/repositories/drop-downs/sync-repos-data-drop-down/sync-data-table.tsx/row-options.tsx
@@ -11,7 +11,7 @@ export const RowOptions: React.FC = () => {
           <Menu.Item text="Enable For All" />
         </Menu>
       )}
-      trigger={<DotsHorizontalIcon className="t-icon cursor-pointer text-semantic-icon" />}
+      trigger={<DotsHorizontalIcon className="t-icon cursor-pointer t-icon-default" />}
     />
   )
 }

--- a/ui/src/views/repositories/modals/add-repository-modal/auto-import-from-git-modal.tsx
+++ b/ui/src/views/repositories/modals/add-repository-modal/auto-import-from-git-modal.tsx
@@ -9,7 +9,7 @@ const EmptyState: React.FC = () => {
   return (
     <div className='h-80'>
       <div className='flex items-center justify-center h-20 p-10 border border-gray-200 rounded'>
-        <p className='text-semantic-mutedText text-center text-sm'>
+        <p className='t-text-muted text-center text-sm'>
           Enter GitHub organization or username to configure the auto import settings.
         </p>
       </div>
@@ -28,7 +28,7 @@ export const AutoImportFromGitModal: React.FC = () => {
       <div className='p-6 flex-1 overflow-auto'>
         <div className='mb-6'>
           <h3 className='t-h3'>Auto import from GitHub</h3>
-          <p className='text-semantic-mutedText'>This will automatically import all repos from your GitHub organization or GitHub User.</p>
+          <p className='t-text-muted'>This will automatically import all repos from your GitHub organization or GitHub User.</p>
         </div>
         <div className='flex items-center gap-2 mb-6'>
           <div className='t-input-with-prepend flex-1'>
@@ -102,7 +102,7 @@ export const AutoImportFromGitModal: React.FC = () => {
                         </td>
                         <td className='py-3 pl-4 pr-8'>
                           <h4 className='font-medium mb-0.5'>{syncType.shortName}</h4>
-                          <p className='text-semantic-mutedText text-sm'>{syncType.description}</p>
+                          <p className='t-text-muted text-sm'>{syncType.description}</p>
                         </td>
                       </tr>
                     ))}

--- a/ui/src/views/repositories/modals/add-repository-modal/auto-import-from-git-modal.tsx
+++ b/ui/src/views/repositories/modals/add-repository-modal/auto-import-from-git-modal.tsx
@@ -90,7 +90,7 @@ export const AutoImportFromGitModal: React.FC = () => {
               </div>
               {imp.opened && <Panel.Body className='p-0'>
                 <Alert type='info' className='m-3' title='Default syncs are enabled for repos that are imported.' />
-                <table className='t-table-default t-table-clickable'>
+                <table className='t-table-default t-table-hover'>
                   <tbody className='bg-white'>
                     {imp.defaultSyncs.map((syncType, index) => (
                       <tr key={index} onClick={() => handleCheckBox(imp.name, imp.defaultSyncs, syncType.type)}>

--- a/ui/src/views/repositories/modals/remove-import-modal/index.tsx
+++ b/ui/src/views/repositories/modals/remove-import-modal/index.tsx
@@ -47,7 +47,7 @@ export const RemoveImportModal: React.FC = () => {
       </Modal.Header>
       <Modal.Body>
         <div className='px-6 py-6'>
-          Are you sure you want to remove the GitHub repo auto import for the <b>{importToRemove?.name}</b> {importToRemove?.type === SYNC_REPO_METHOD.GH_ORG ? 'organization' : 'user'}?
+          Are you sure you want to remove the GitHub repo auto import for the <strong className="font-semibold text-gray-800">{importToRemove?.name}</strong> {importToRemove?.type === SYNC_REPO_METHOD.GH_ORG ? 'organization' : 'user'}?
         </div>
       </Modal.Body>
       <Modal.Footer>

--- a/ui/src/views/repositories/modals/remove-repository-modal/index.tsx
+++ b/ui/src/views/repositories/modals/remove-repository-modal/index.tsx
@@ -55,8 +55,8 @@ export const RemoveRepositoryModal: React.FC = () => {
             This repo was added by an automatic import, it will be re-added on the next run, unless the repo auto import is removed.
           </Alert>
         }
-        <div className={cx({ 'pt-2': repoToRemove?.autoImported }, { 'pt-6': !repoToRemove?.autoImported })}>
-          Are you sure you want to remove <b>{repoToRemove?.name}</b>?
+        <div>
+          Are you sure you want to remove <strong className="font-semibold text-gray-800">{repoToRemove?.name}</strong>?
         </div>
       </Modal.Body>
       <Modal.Footer>

--- a/ui/src/views/repositories/modals/remove-repository-modal/index.tsx
+++ b/ui/src/views/repositories/modals/remove-repository-modal/index.tsx
@@ -49,7 +49,7 @@ export const RemoveRepositoryModal: React.FC = () => {
           </Toolbar.Right>
         </Toolbar>
       </Modal.Header>
-      <Modal.Body className='p-8'>
+      <Modal.Body className='p-6'>
         {repoToRemove?.autoImported &&
           <Alert type="warning" theme="light" className='mb-6'>
             This repo was added by an automatic import, it will be re-added on the next run, unless the repo auto import is removed.

--- a/ui/src/views/repository-data-details/components/repo-data-type-logs/index.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-logs/index.tsx
@@ -16,7 +16,7 @@ export const RepoDataLogs = ({ syncData, logs }: RepoDataLogsProps) => {
           <h4 className='t-h4 mb-2'>
             {syncData?.title}
           </h4>
-          <p className='text-semantic-mutedText mb-4'>
+          <p className='t-text-muted mb-4'>
             {syncData?.brief}
           </p>
           <Link href='https://docs.mergestat.com/'>

--- a/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/columns.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/columns.tsx
@@ -18,7 +18,7 @@ export const columns: Array<Record<string, unknown>> = [
     dataIndex: 'records',
     key: 'records',
     render: (records?: string) => (
-      records ? <span className='text-semantic-mutedText'>{records}</span> : '-'
+      records ? <span className='t-text-muted'>{records}</span> : '-'
     )
   },
   {
@@ -28,7 +28,7 @@ export const columns: Array<Record<string, unknown>> = [
     dataIndex: 'duration',
     key: 'duration',
     render: (duration: string) => (
-      <span className='text-semantic-mutedText'>{duration}</span>
+      <span className='t-text-muted'>{duration}</span>
     )
   },
   {
@@ -38,7 +38,7 @@ export const columns: Array<Record<string, unknown>> = [
     dataIndex: 'syncStart',
     key: 'syncStart',
     render: (syncStart: string) => (
-      <span className='text-semantic-mutedText'>{syncStart}</span>
+      <span className='t-text-muted'>{syncStart}</span>
     )
   }
 ]

--- a/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/components/row-options.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/components/row-options.tsx
@@ -6,7 +6,7 @@ export const LogsTableRowOptions: React.FC = () => {
   return (
     <Dropdown
       alignEnd
-      trigger={<DotsHorizontalIcon className="t-icon cursor-pointer text-semantic-icon ml-6" />}
+      trigger={<DotsHorizontalIcon className="t-icon cursor-pointer t-icon-default ml-6" />}
       overlay={() => (
         <Menu className='whitespace-nowrap'>
           <Menu.Item text="Cancel Sync" disabled />

--- a/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/components/sync-type.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/components/sync-type.tsx
@@ -19,7 +19,7 @@ export const SyncType: React.FC<SyncTypeProps> = (props) => {
     <div className="flex gap-2 items-center">
       <RepoSyncIcon type={syncType} />
       <Link href={`/repos/${repository}/${syncTypeId}/${id}`}>
-        <span className="font-medium hover_text-blue-600 text-semantic-text capitalize cursor-pointer">
+        <span className="font-medium hover_text-blue-600 t-text-default capitalize cursor-pointer">
           {syncType}
         </span>
       </Link>

--- a/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/index.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/index.tsx
@@ -39,7 +39,7 @@ export const LogsTable: React.FC<LogsTableProps> = ({ logs }: LogsTableProps) =>
             </div>
             : <div className='flex flex-col min-w-0 bg-white h-full'>
                 <div className='flex-1 overflow-x-auto overflow-y-hidden'>
-                <table className='t-table-default t-table-clickable'>
+                <table className='t-table-default t-table-hover'>
                   <thead>
                     <tr className='bg-white'>
                       <th className='w-0'></th>

--- a/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/index.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-logs/logs-table/index.tsx
@@ -82,21 +82,21 @@ export const LogsTable: React.FC<LogsTableProps> = ({ logs }: LogsTableProps) =>
                           </td>
 
                           <td className='text-gray-500'>
-                            {log.records ? <span className='text-semantic-mutedText'>{log.records}</span> : '-'}
+                            {log.records ? <span className='t-text-muted'>{log.records}</span> : '-'}
                           </td>
 
                           <td className='text-gray-500'>
-                            <span className='text-semantic-mutedText'>{log.duration}</span>
+                            <span className='t-text-muted'>{log.duration}</span>
                           </td>
 
                           <td className='text-gray-500'>
-                            <RelativeTimeField date={log.syncStart} styles={'text-semantic-mutedText whitespace-nowrap'} />
+                            <RelativeTimeField date={log.syncStart} styles={'t-text-muted whitespace-nowrap'} />
                           </td>
                         </tr>
                         {log.collapsed && (
                           <tr>
                             <td colSpan={6} className='p-6 bg-gray-50'>
-                              {log.logs?.length ? <LogBox logs={log.logs || []} onCopy={() => null} /> : <span className='text-semantic-mutedText text-sm'>No log entries yet</span>}
+                              {log.logs?.length ? <LogBox logs={log.logs || []} onCopy={() => null} /> : <span className='t-text-muted text-sm'>No log entries yet</span>}
                             </td>
                           </tr>
                         )}

--- a/ui/src/views/repository-data-details/components/repo-data-type-sync-settings/sync-settings-form.tsx
+++ b/ui/src/views/repository-data-details/components/repo-data-type-sync-settings/sync-settings-form.tsx
@@ -1,4 +1,4 @@
-import { Label, Panel, Toggle, Typography } from '@mergestat/blocks'
+import { Label, Panel, Toggle } from '@mergestat/blocks'
 import React, { PropsWithChildren } from 'react'
 import Loading from 'src/components/Loading'
 import useSyncsLogs from 'src/views/hooks/useSyncsLogs'
@@ -12,7 +12,7 @@ export const SyncSettingsForm = () => {
         ? <Loading />
         : <Panel className="shadow-sm">
           <Panel.Header>
-            <Typography.Title className='text-semantic-header font-semibold'>Sync settings</Typography.Title>
+            <h3 className="t-panel-title">Sync settings</h3>
           </Panel.Header>
           <Panel.Body>
             <form className="flex flex-col gap-2">
@@ -25,7 +25,7 @@ export const SyncSettingsForm = () => {
                       variables: { syncId: syncTypeId, schedule: !repoData.sync?.scheduleEnabled }
                     })}
                   />
-                  <span className="text-semantic-text">Enable</span>
+                  <span className="t-text-default">Enable</span>
                 </div>
               </Formrow>
             </form>

--- a/ui/src/views/repository-data-details/index.tsx
+++ b/ui/src/views/repository-data-details/index.tsx
@@ -22,7 +22,7 @@ const RepoDataTypeView: React.FC<SyncTypeData> = ({ repo, sync, logs, syncNow })
       startIcon: <RepoImage repoType={repo.type} orgName={repoName} />,
       endIcon: (
         <a target="_blank" href={repo.type === 'github' ? GITHUB_URL + repoName : repoName} rel="noopener noreferrer">
-          <ExternalLinkIcon className='t-icon t-icon-small' />
+          <ExternalLinkIcon className='t-icon t-icon-muted t-icon-small' />
         </a>
       ),
       onClick: () => router.push(`/repos/${repo.id}`),

--- a/ui/src/views/repository-data-logs-details/index.tsx
+++ b/ui/src/views/repository-data-logs-details/index.tsx
@@ -23,7 +23,7 @@ const RepoDataLogsDetailsView: React.FC<SyncTypeData> = ({ repo, sync, logs }) =
       startIcon: <RepoImage repoType={repo.type} orgName={repoName} />,
       endIcon: (
         <a target='_blank' href={repo.type === 'github' ? GITHUB_URL + repoName : repoName} rel="noopener noreferrer">
-          <ExternalLinkIcon className='t-icon t-icon-small' />
+          <ExternalLinkIcon className='t-icon t-icon-muted t-icon-small' />
         </a>
       ),
       onClick: () => router.push(`/repos/${repo.id}`),
@@ -54,7 +54,7 @@ const RepoDataLogsDetailsView: React.FC<SyncTypeData> = ({ repo, sync, logs }) =
           : (
             <Panel>
               <Panel.Body className="flex items-center justify-center py-8">
-                <span className='text-semantic-mutedText text-sm'>No log entries yet</span>
+                <span className='t-text-muted text-sm'>No log entries yet</span>
               </Panel.Body>
             </Panel>)}
       </div>

--- a/ui/src/views/repository-data/components/page-header.tsx
+++ b/ui/src/views/repository-data/components/page-header.tsx
@@ -23,7 +23,7 @@ export const PageHeader = ({ name, type }: PageHeaderProps) => {
       startIcon: <RepoImage repoType={type} orgName={repoName} />,
       endIcon: (
         <a target='_blank' href={type === 'github' ? GITHUB_URL + repoName : repoName} rel='noopener noreferrer'>
-          <ExternalLinkIcon className='t-icon t-icon-small' />
+          <ExternalLinkIcon className='t-icon t-icon-muted t-icon-small' />
         </a>
       ),
     }

--- a/ui/src/views/repository-data/components/sync-types-table/components/repository-data.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/components/repository-data.tsx
@@ -17,16 +17,16 @@ export const RepositoryData: React.FC<RepositoryDataProps> = (props) => {
     <div className={cx('py-5 flex flex-col justify-center items-start h-full', { 'bg-gray-50': props.disabled })}>
       {props.id
         ? <Link href={`/repos/${repository}/${props.id}`}>
-          <h4 className="font-medium mb-0.5 text-semantic-text cursor-pointer hover_text-blue-600">
+          <h4 className="font-medium mb-0.5 t-text-default cursor-pointer hover_text-blue-600">
             {props.title}
           </h4>
         </Link>
-        : <h4 className="font-medium mb-0.5 text-semantic-text">
+        : <h4 className="font-medium mb-0.5 t-text-default">
           {props.title}
         </h4>
       }
 
-      <p className="text-sm text-semantic-mutedText">
+      <p className="text-sm t-text-muted">
         {props.brief}
       </p>
     </div>

--- a/ui/src/views/repository-data/components/sync-types-table/components/repository-sync-now.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/components/repository-sync-now.tsx
@@ -26,10 +26,10 @@ export const RepositorySyncNow: React.FC<RepositorySyncNowProps> = ({ repoId, sy
       skin="secondary"
       data-testid={TEST_IDS.syncsTypesSyncNowButton}
       startIcon={syncStatus === SYNC_STATUS.queued
-        ? <ClockIcon className='t-icon text-semantic-mutedIcon' />
+        ? <ClockIcon className='t-icon t-icon-muted' />
         : syncStatus === SYNC_STATUS.running
           ? <Spinner size='sm' className='mr-2' />
-          : <RefreshIcon className="t-icon text-semantic-icon" />
+          : <RefreshIcon className="t-icon t-icon-default" />
       }
       size="small"
       onClick={() => {

--- a/ui/src/views/repository-data/components/sync-types-table/index.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/index.tsx
@@ -28,7 +28,7 @@ export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ repoId, data }: 
           </div>
           : <div className='flex flex-col min-w-0 bg-white h-full'>
             <div className='flex-1 overflow-x-auto overflow-y-hidden'>
-              <table className='t-table-default t-table-clickable'>
+              <table className='t-table-default t-table-hover'>
                 <thead>
                   <tr className='bg-white'>
                     <th scope='col' key='syncStateIcon' className='whitespace-nowrap w-0'>Status</th>

--- a/ui/src/views/repository-data/components/sync-types-table/index.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/index.tsx
@@ -60,11 +60,11 @@ export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ repoId, data }: 
                       </td>
 
                       <td className='text-gray-500 h-20'>
-                        <RelativeTimeField date={sync.latestRun} syncData={sync} styles={'text-semantic-mutedText whitespace-nowrap'} />
+                        <RelativeTimeField date={sync.latestRun} syncData={sync} styles={'t-text-muted whitespace-nowrap'} />
                       </td>
 
                       <td className='text-gray-500 h-20'>
-                        <div className='text-semantic-mutedText'>
+                        <div className='t-text-muted'>
                           {sync.avgRunningTime}
                         </div>
                       </td>

--- a/ui/src/views/settings/repo-auto-imports/index.tsx
+++ b/ui/src/views/settings/repo-auto-imports/index.tsx
@@ -34,8 +34,8 @@ const AutoImports: NextPage = () => {
             {loading
               ? <Loading />
               : <div className='flex-1 p-8'>
-                <Alert type="info" className="mb-10">
-                  <strong>Repo auto imports</strong> automatically import repositories from a GitHub org or user, allowing MergeStat to pickup new repositories (and remove deleted ones) as they are added in GitHub.
+                <Alert type="default" className="mb-10 bg-gray-100">
+                  <strong className="font-semibold">Repo auto imports</strong> automatically import repositories from a GitHub org or user, allowing MergeStat to pickup new repositories (and remove deleted ones) as they are added in GitHub.
                 </Alert>
 
                 <Panel className='rounded-md w-full shadow-sm'>

--- a/ui/src/views/settings/repo-auto-imports/index.tsx
+++ b/ui/src/views/settings/repo-auto-imports/index.tsx
@@ -59,8 +59,8 @@ const AutoImports: NextPage = () => {
                             <tr key={index}>
                               <td className='py-4 pl-8 pr-4 w-0'>
                                 {imp.importDone
-                                  ? <CircleCheckFilledIcon className="t-icon text-semantic-success" />
-                                  : <ClockIcon className='t-icon text-semantic-mutedIcon' />
+                                  ? <CircleCheckFilledIcon className="t-icon t-icon-success" />
+                                  : <ClockIcon className='t-icon t-icon-muted' />
                                 }
                               </td>
                               <td className='p-4'>
@@ -70,11 +70,11 @@ const AutoImports: NextPage = () => {
                                   </ColoredBox>
                                   <div>
                                     <Link href={`/settings/repo-auto-imports/${imp.id}`}>
-                                      <h4 className='font-medium mb-0.5 text-semantic-text cursor-pointer hover_text-blue-600'>
+                                      <h4 className='font-medium mb-0.5 t-text-default cursor-pointer hover_text-blue-600'>
                                         {imp.source}
                                       </h4>
                                     </Link>
-                                    <p className='text-sm text-semantic-mutedText'>
+                                    <p className='text-sm t-text-muted'>
                                       {imp.type === SYNC_REPO_METHOD.GH_USER ? 'GitHub User' : 'GitHub Organization'}
                                     </p>
                                   </div>

--- a/ui/src/views/settings/repo-auto-imports/index.tsx
+++ b/ui/src/views/settings/repo-auto-imports/index.tsx
@@ -44,7 +44,7 @@ const AutoImports: NextPage = () => {
                       ? <div className='flex justify-center items-center bg-white py-5'>
                         No data available!
                       </div>
-                      : <table className='t-table-default t-table-clickable'>
+                      : <table className='t-table-default t-table-hover'>
                         <thead>
                           <tr className='bg-white'>
                             <th scope='col' key='status' className='whitespace-nowrap px-4'>Status</th>

--- a/ui/src/views/sql-query-editor/components/state-empty.tsx
+++ b/ui/src/views/sql-query-editor/components/state-empty.tsx
@@ -5,7 +5,7 @@ const QueryEditorEmpty: React.FC = () => {
   return (
     <div className='flex-1 h-1/2 flex flex-col items-center justify-center p-8'>
       <Avatar icon={<CircleInformationIcon className='t-icon' />} />
-      <p className='text-semantic-mutedText mt-6'>
+      <p className='t-text-muted mt-6'>
         Execute query to show results.
       </p>
     </div>

--- a/ui/src/views/sql-query-editor/components/state-error.tsx
+++ b/ui/src/views/sql-query-editor/components/state-error.tsx
@@ -36,7 +36,7 @@ const QueryEditorError: React.FC<QueryEditorErrorProps> = ({ errors }: QueryEdit
         />
         <div className='text-center mt-6'>
           <h4 className='t-h4'>Error executing query</h4>
-          <p className='text-semantic-mutedText'>
+          <p className='t-text-muted'>
             {errors?.message}
           </p>
         </div>

--- a/ui/src/views/sql-query-editor/components/state-filled.tsx
+++ b/ui/src/views/sql-query-editor/components/state-filled.tsx
@@ -209,7 +209,7 @@ const QueryEditorFilled: React.FC<QueryEditorFilledProps> = ({ rowLimit, rowLimi
             </Toolbar.Item>
             <Toolbar.Item className='pl-4'>
               <div className='flex items-center space-x-2'>
-                <p className='text-semantic-mutedText whitespace-nowrap text-sm'>
+                <p className='t-text-muted whitespace-nowrap text-sm'>
                   {`${(page * rows) + 1}-${getMax()} of ${total}`}
                 </p>
                 <Button

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -86,6 +86,6 @@ module.exports = {
       gradientColorStops: ['active'],
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/line-clamp')],
   separator: '_',
 }

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -15,16 +15,6 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        semantic: {
-          header: '#111827',
-          text: '#374151',
-          mutedText: '#727C8D',
-          mutedIcon: '#9CA3AF',
-          border: '#E5E7EB',
-          icon: '#6B7280',
-          danger: '#DC2626',
-          success: '#10B981',
-        },
         gray: {
           150: '#EBECEF',
           250: '#DDDFE4',


### PR DESCRIPTION
- Updated `@mergestat/blocks` to 1.4.3 version
- Removed duplicate styles in `global.css` file, there are some minor things left that I'll sync back to `blocks` now
- Some small styling improvements
   - Spacing fix in remove modals
   - Using semibold font weight instead of bold for `strong` elements
   - Using new default alert in settings


#### Styling updates:
<img width="1717" alt="image" src="https://user-images.githubusercontent.com/36261498/196911692-fb739657-f2e7-4d67-af5f-96483099d453.png">

<img width="1721" alt="image" src="https://user-images.githubusercontent.com/36261498/196911764-2b45f7a3-8fa7-43cd-8fd9-5035ec504d8d.png">


(Resolves #60)