### PR TITLE
fix: fix scroll bug settings

### DIFF
--- a/ui/src/views/settings/repo-auto-imports/index.tsx
+++ b/ui/src/views/settings/repo-auto-imports/index.tsx
@@ -33,7 +33,7 @@ const AutoImports: NextPage = () => {
             </div>
             {loading
               ? <Loading />
-              : <div className='flex-1 p-8'>
+              : <div className='flex-1 overflow-auto p-8'>
                 <Alert type="default" className="mb-10 bg-gray-100">
                   <strong className="font-semibold">Repo auto imports</strong> automatically import repositories from a GitHub org or user, allowing MergeStat to pickup new repositories (and remove deleted ones) as they are added in GitHub.
                 </Alert>


### PR DESCRIPTION
There was a small bug: the auto import settings overview was not scrollable yet causing the toolbar to shrink when there are many items. This should be fixed by this PR:

<img width="1620" alt="Screenshot 2022-10-21 at 11 18 38" src="https://user-images.githubusercontent.com/36261498/197161569-3fa5c345-e829-4397-b785-2d6b1d0f3d6a.png">
