### PR TITLE
fix: remove `.env-worker` requirement for `docker-compose`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,7 @@ services:
       POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres?sslmode=disable
       GITHUB_RATE_LIMIT: 1/2
       ENCRYPTION_SECRET: password
+      DEBUG: 1
     ports:
       - 3301:8080
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,8 +21,6 @@ services:
       POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres?sslmode=disable
       GITHUB_RATE_LIMIT: 1/2
       ENCRYPTION_SECRET: password
-    env_file:
-      - .env-worker
     ports:
       - 3301:8080
 


### PR DESCRIPTION
For now, just use inline env vars in the `docker-compose.yaml` file. We can configure a `make` target for a more complex setup that uses `.env-worker` later if we need it.

This allows the app to be brought up on a "fresh" clone of the repo with just `docker-compose up`. Closes #418