### PR TITLE
feat: call `encodeURI` when validating pg credentials

### DIFF
--- a/ui/src/pages/api/admin-auth.ts
+++ b/ui/src/pages/api/admin-auth.ts
@@ -33,7 +33,8 @@ const adminAuth = async (req: NextApiRequest, res: NextApiResponse) => {
     try {
       const client = new Client({
         // use the connection info supplied by the parsed POSTGRES_CONNECTION url
-        connectionString: url.toString(),
+        // encodeURI since the password (or user) may contain special characters
+        connectionString: encodeURI(url.toString()),
 
         // by default this is "no timeout"
         // so we set it here to have a hard limit


### PR DESCRIPTION
to allow for passwords (and usernames) with special characters. Closes #426 