### PR TITLE
fix: set readaccess defaults 

### DIFF
--- a/migrations/900000000000001_readaccess_defaults.up.sql
+++ b/migrations/900000000000001_readaccess_defaults.up.sql
@@ -1,0 +1,26 @@
+-- https://stackoverflow.com/questions/8092086/create-postgresql-role-user-if-it-doesnt-exist
+-- idempotent role creation
+DO
+$do$
+BEGIN
+IF EXISTS (
+  SELECT FROM pg_catalog.pg_roles
+  WHERE  rolname = 'readaccess') THEN
+  RAISE NOTICE 'Role "readaccess" already exists. Skipping.';
+ELSE
+  CREATE ROLE readaccess;
+END IF;
+END
+$do$;
+
+--ensure all tables have select privilege
+GRANT USAGE ON SCHEMA public TO readaccess;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO readaccess;
+--ensure all tables created in the future have select privilege
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO readaccess;
+
+--ensure all tables have select privilege
+GRANT USAGE ON SCHEMA mergestat TO readaccess;
+GRANT SELECT ON ALL TABLES IN SCHEMA mergestat TO readaccess;
+--ensure all tables created in the future have select privilege
+ALTER DEFAULT PRIVILEGES IN SCHEMA mergestat GRANT SELECT ON TABLES TO readaccess;

--- a/migrations/900000000000001_readaccess_defaults.up.sql
+++ b/migrations/900000000000001_readaccess_defaults.up.sql
@@ -13,14 +13,18 @@ END IF;
 END
 $do$;
 
---ensure all tables have select privilege
+--ensure all tables and sequences have select privilege
 GRANT USAGE ON SCHEMA public TO readaccess;
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO readaccess;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO readaccess;
 --ensure all tables created in the future have select privilege
 ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO readaccess;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON SEQUENCES TO readaccess;
 
---ensure all tables have select privilege
+--ensure all tables and sequences have select privilege
 GRANT USAGE ON SCHEMA mergestat TO readaccess;
 GRANT SELECT ON ALL TABLES IN SCHEMA mergestat TO readaccess;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA mergestat TO readaccess;
 --ensure all tables created in the future have select privilege
 ALTER DEFAULT PRIVILEGES IN SCHEMA mergestat GRANT SELECT ON TABLES TO readaccess;
+ALTER DEFAULT PRIVILEGES IN SCHEMA mergestat GRANT SELECT ON SEQUENCES TO readaccess;


### PR DESCRIPTION
Added defaults for readaccess select privileges. Changed the migrations numbers to be a sequence instead of date driven to address bad name given on previous migration as well as to force us to use a sequence and enforce merging of migrations when there is a conflict.

Tested by creating a new table in public schema and being able to still select it from the Queries section in the UI.
![image](https://user-images.githubusercontent.com/10135546/197614694-5ea3cf7d-9f38-4935-a5c0-dc13dc246bac.png)

resolves #428 
