### PR TITLE
feat: refine how we handle setting log level in the worker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,8 @@ services:
       POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres?sslmode=disable
       GITHUB_RATE_LIMIT: 1/2
       ENCRYPTION_SECRET: password
-      DEBUG: 1
+      LOG_LEVEL: debug
+      PRETTY_LOGS: 1
     ports:
       - 3301:8080
 


### PR DESCRIPTION
changes the `DEBUG` env var into `LOG_LEVEL` which would allow an operator to set the minimum log level they want to see structured logs for (defaults to `info`).

Also adds the `PRETTY_LOGS` env var (if set to `1`) to enable console friendly (more human readable) log output.