### PR TITLE
fix: try back modifying the initial migration

### DIFF
--- a/migrations/20220511014018_init.up.sql
+++ b/migrations/20220511014018_init.up.sql
@@ -1,6 +1,6 @@
 SET check_function_bodies = false;
-CREATE EXTENSION pgcrypto;
-CREATE SCHEMA mergestat;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE SCHEMA IF NOT EXISTS mergestat;
 CREATE FUNCTION mergestat.set_current_timestamp_updated_at() RETURNS trigger
 LANGUAGE plpgsql
 AS $$


### PR DESCRIPTION
to make part of it idempotent (see if it addresses the error we see when running migrations using a different default pg user)