### PR TITLE
fix: update the `docker-compose` file to address startup timing issues

### DIFF
--- a/.github/workflows/lint_sql.yml
+++ b/.github/workflows/lint_sql.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install SQLFluff
+        # TODO(patrickdevivo) consider updating this https://github.com/sqlfluff/sqlfluff/releases
         run: "pip install sqlfluff==1.3.2"
       - name: Reusable Lint SQL
         run: "sqlfluff lint"

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ pkg/sqlite/sqlite3.c:
 	@mv $(SQLITE_DOWNLOAD_DIR)/sqlite-amalgamation-3370000/* pkg/sqlite
 
 ui-dev:
-	docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up
+	docker-compose -f docker-compose.yaml -f docker-compose.ui-dev.yaml up
 
 dev:
 	docker-compose -f docker-compose.dev.yaml -f docker-compose.yaml up

--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,10 @@ pkg/sqlite/sqlite3.c:
 	@mv $(SQLITE_DOWNLOAD_DIR)/sqlite-amalgamation-3370000/* pkg/sqlite
 
 ui-dev:
-	docker compose -f docker-compose.yaml -f docker-compose.ui-dev.yaml up
+	docker-compose -f docker-compose.yaml -f docker-compose.dev.yaml up
+
+dev:
+	docker-compose -f docker-compose.dev.yaml -f docker-compose.yaml up
+
+dev-build:
+	docker-compose -f docker-compose.dev.yaml -f docker-compose.yaml build

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,7 @@
+services:
+  worker:
+    build: .
+  graphql:
+    build: ./graphql
+  ui:
+    build: ./ui

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.6"
 services:
   postgres:
-    image: postgres:12
+    image: postgres:14
     restart: always
     ports:
       - 5432:5432
@@ -16,8 +16,7 @@ services:
       POSTGRES_PASSWORD: password
 
   worker:
-    build:
-      context: .
+    image: mergestat/worker:1.2.0-beta
     stop_grace_period: 10m
     restart: always
     depends_on:
@@ -43,9 +42,8 @@ services:
       - 3301:8080
 
   graphql:
+    image: mergestat/graphql:1.2.0-beta
     restart: always
-    build:
-      context: ./graphql
     depends_on:
       postgres:
         condition: service_healthy
@@ -85,6 +83,7 @@ services:
       DISPLAY_PG_USER: postgres
 
   ui:
+    image: mergestat/console:1.2.0-beta
     restart: always
     build:
       context: ./ui

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,11 @@ services:
       - 5432:5432
     volumes:
       - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     environment:
       POSTGRES_PASSWORD: password
 
@@ -16,12 +21,20 @@ services:
     stop_grace_period: 10m
     restart: always
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/metrics"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     environment:
       POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres?sslmode=disable
+      CONCURRENCY: 5
       GITHUB_RATE_LIMIT: 1/2
       ENCRYPTION_SECRET: password
       LOG_LEVEL: debug
+      DEBUG: 1
       PRETTY_LOGS: 1
       GITHUB_WORKFLOW_PER_PAGE: 30
       GITHUB_WORKFLOW_RUNS_PER_PAGE: 30
@@ -34,8 +47,12 @@ services:
     build:
       context: ./graphql
     depends_on:
-      - postgres
-      - worker # this is to ensure all migrations are run before the API starts up
+      postgres:
+        condition: service_healthy
+      worker: # this is to ensure all migrations are run before the API starts up
+        condition: service_healthy
+    links:
+      - worker
     ports:
       - 5433:5433
     command:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,7 +16,10 @@ services:
       POSTGRES_PASSWORD: password
 
   worker:
-    image: mergestat/worker:1.2.0-beta
+    # NOTE: to opt out of basic image pull tracking, comment out the current image
+    # and uncomment the next line (which will pull from Docker Hub directly).
+    # image: mergestat/worker:1.2.0-beta
+    image: images.mergestat.com/mergestat/worker:1.2.0-beta
     stop_grace_period: 10m
     restart: always
     depends_on:
@@ -42,7 +45,9 @@ services:
       - 3301:8080
 
   graphql:
-    image: mergestat/graphql:1.2.0-beta
+    # See NOTE above in worker service.
+    # image: mergestat/graphql:1.2.0-beta
+    image: images.mergestat.com/mergestat/graphql:1.2.0-beta
     restart: always
     depends_on:
       postgres:
@@ -83,7 +88,9 @@ services:
       DISPLAY_PG_USER: postgres
 
   ui:
-    image: mergestat/console:1.2.0-beta
+    # See NOTE above in worker service.
+    # image: mergestat/console:1.2.0-beta
+    image: images.mergestat.com/mergestat/console:1.2.0-beta
     restart: always
     build:
       context: ./ui


### PR DESCRIPTION
we were seeing problems when running `docker-compose up`, in particular the `graphql` service would start before the migrations in the `worker` service were complete. This would lead to an invalid GraphQL API schema being served (no entities) and errors displaying in the UI. Not a great UX. The solution was to just rerun `docker-compose up` and hope the timing issue didn't occur again.

This addresses that (it should anyways) by adding health checks to some services and `condition: service_healthy` in the `depends_on` config in some spots.

Note it also brings back the `DEBUG=1` env var, which is what enables the `/metrics` endpoint in the `worker`, which is what we're using a healthcheck now - this is probably worth improving.

- use pinned, pre-built images from docker hub
- bumps the default `CONCURRENCY` to `5` for `docker-compose` runs.
- upgrade to pg 14
- add some `make` targets for local dev

Closes #432 (most of it - being clearer on the default username/password will have to be part of the docs)