### PR TITLE
fix(migrations):create schema migration only if not exits

### DIFF
--- a/.github/workflows/lint_sql.yml
+++ b/.github/workflows/lint_sql.yml
@@ -11,6 +11,6 @@ jobs:
         with:
           python-version: "3.x"
       - name: Install SQLFluff
-        run: "pip install sqlfluff"
+        run: "pip install sqlfluff==1.3.2"
       - name: Reusable Lint SQL
         run: "sqlfluff lint"

--- a/migrations/20220511014018_init.up.sql
+++ b/migrations/20220511014018_init.up.sql
@@ -451,7 +451,7 @@ DROP TRIGGER IF EXISTS track_applied_migrations ON public.schema_migrations;
 CREATE TRIGGER track_applied_migrations AFTER INSERT ON public.schema_migrations FOR EACH ROW EXECUTE PROCEDURE track_applied_migration();
 
 -- SCHEMA MIGRATIONS
-CREATE TABLE schema_migrations (
+CREATE TABLE IF NOT EXISTS schema_migrations (
     version bigint NOT NULL PRIMARY KEY,
     dirty boolean NOT NULL
 )


### PR DESCRIPTION
fixing this errors on main 
`(details: pq: relation "schema_migrations" already exists) error="migration failed: relation \"schema_migrations\" already exists in line 0`