### PR TITLE
fix(warehouse): Making changes to the default return value getting  the logs

### DIFF
--- a/internal/warehouse/github_actions.go
+++ b/internal/warehouse/github_actions.go
@@ -244,7 +244,7 @@ func (w *warehouse) handleWorkflowJobLogs(ctx context.Context, owner, repo strin
 
 	}
 
-	return err
+	return nil
 }
 
 func (w *warehouse) handleWorkflowsUpsert(ctx context.Context, workflows []*github.Workflow, repoID uuid.UUID) error {


### PR DESCRIPTION
this err value was causing the break the proccess on first error  .
With this a experimental change because now we don't check for errors removing the donwloaded   files we only log them .
A better approach should be implemented 