### PR TITLE
fix(syncers):Adding os.getenv to tmp dir param

### DIFF
--- a/internal/syncer/syft_repo_scan.go
+++ b/internal/syncer/syft_repo_scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/jackc/pgx/v4"
@@ -22,7 +23,7 @@ func (w *worker) handleSyftRepoScan(ctx context.Context, j *db.DequeueSyncJobRow
 		return fmt.Errorf("log messages: %w", err)
 	}
 
-	tmpPath, cleanup, err := helper.CreateTempDir("GIT_CLONE_PATH", "mergestat-repo-")
+	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
 	}


### PR DESCRIPTION
this  param was hardcoded to the env variable string not the value 