### PR TITLE
fix: the `docker-compose.dev.yaml` override file

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,7 +1,10 @@
 services:
   worker:
+    image: ""
     build: .
   graphql:
+    image: ""
     build: ./graphql
   ui:
+    image: ""
     build: ./ui


### PR DESCRIPTION
should _not_ use the `image` spec when using this file