### PR TITLE
feat: last error query performance enhancements

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -11,7 +11,7 @@ templater = raw
 # Comma separated list of rules to check, default to all
 rules = all
 # Comma separated list of rules to exclude, or None
-exclude_rules = L016,L044,L006,L028,L014,L025,L010,L029,L027,L030
+exclude_rules = L016,L044,L006,L028,L014,L025,L010,L029,L027,L030,L022
 # The depth to recursively parse to (0 for unlimited)
 recurse = 0
 # Below controls SQLFluff output, see max_line_length for SQL output

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -561,12 +561,13 @@ type MergestatRepoImportType struct {
 }
 
 type MergestatRepoSync struct {
-	RepoID          uuid.UUID
-	SyncType        string
-	Settings        pgtype.JSONB
-	ID              uuid.UUID
-	ScheduleEnabled bool
-	Priority        int32
+	RepoID                       uuid.UUID
+	SyncType                     string
+	Settings                     pgtype.JSONB
+	ID                           uuid.UUID
+	ScheduleEnabled              bool
+	Priority                     int32
+	LastCompletedRepoSyncQueueID sql.NullInt64
 }
 
 type MergestatRepoSyncLog struct {

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -81,8 +81,7 @@ INSERT INTO public.github_repo_info (
 INSERT INTO mergestat.repo_sync_logs (log_type, message, repo_sync_queue_id) VALUES ($1, $2, $3);
 
 -- name: SetSyncJobStatus :exec
-UPDATE mergestat.repo_sync_queue SET status = $1 
-WHERE id = (SELECT id FROM mergestat.repo_sync_queue WHERE repo_sync_queue.id = $2 LIMIT 1);
+SELECT mergestat.set_sync_job_status(@Status::TEXT, @ID::BIGINT);
 
 -- We use a CTE here to retrieve all the repo_sync_jobs that were previously enqueued, to make sure that we *do not* re-enqueue anything new until the previously enqueued jobs are *completed*.
 -- This allows us to make sure all repo syncs complete before we reschedule a new batch.

--- a/migrations/900000000000003_add_set_sync_job_status.up.sql
+++ b/migrations/900000000000003_add_set_sync_job_status.up.sql
@@ -33,10 +33,10 @@ RETURNS UUID
 AS
 $$
 DECLARE _repo_sync_id UUID;
-begin
+BEGIN
     IF new_status = 'DONE' THEN
             WITH update_queue AS (
-                UPDATE mergestat.repo_sync_queue SET "status" = new_status where mergestat.repo_sync_queue.id = repo_sync_queue_id
+                UPDATE mergestat.repo_sync_queue SET "status" = new_status WHERE mergestat.repo_sync_queue.id = repo_sync_queue_id
                 RETURNING *
             )
             UPDATE mergestat.repo_syncs set last_completed_repo_sync_queue_id = repo_sync_queue_id
@@ -44,12 +44,12 @@ begin
             WHERE mergestat.repo_syncs.id = update_queue.repo_sync_id
             RETURNING mergestat.repo_syncs.id INTO _repo_sync_id;
     ELSE    
-            UPDATE mergestat.repo_sync_queue SET "status" = new_status where mergestat.repo_sync_queue.id = repo_sync_queue_id
+            UPDATE mergestat.repo_sync_queue SET "status" = new_status WHERE mergestat.repo_sync_queue.id = repo_sync_queue_id
             RETURNING repo_sync_id INTO _repo_sync_id;
     END IF;
     
     RETURN _repo_sync_id;    
-end;
+END;
 $$ LANGUAGE plpgsql;
 
 COMMIT;

--- a/migrations/900000000000003_add_set_sync_job_status.up.sql
+++ b/migrations/900000000000003_add_set_sync_job_status.up.sql
@@ -1,0 +1,54 @@
+BEGIN;
+
+ALTER TABLE mergestat.repo_syncs
+ADD COLUMN IF NOT EXISTS last_completed_repo_sync_queue_id BIGINT;
+
+WITH
+  ranked_completed_syncs AS (
+  SELECT
+    rsq.id,
+    rsq.repo_sync_id,
+    rsq.done_at,
+    RANK() OVER(PARTITION BY rsq.repo_sync_id ORDER BY rsq.done_at DESC) AS rank_num
+  FROM
+    mergestat.repo_sync_queue AS rsq
+  WHERE
+    rsq.repo_sync_id NOT IN (
+    SELECT
+      repo_sync_id
+    FROM
+      mergestat.repo_sync_queue
+    WHERE
+      status = 'QUEUED'
+      OR status = 'RUNNING') )
+UPDATE mergestat.repo_syncs
+SET last_completed_repo_sync_queue_id = rcs.id
+FROM ranked_completed_syncs rcs
+WHERE rcs.rank_num = 1
+AND rcs.repo_sync_id = mergestat.repo_syncs.id;
+
+CREATE OR REPLACE FUNCTION mergestat.set_sync_job_status(new_status TEXT, repo_sync_queue_id BIGINT)
+RETURNS UUID
+AS
+$$
+DECLARE _repo_sync_id UUID;
+begin
+    IF new_status = 'DONE' THEN
+            WITH update_queue AS (
+                UPDATE mergestat.repo_sync_queue SET "status" = new_status where mergestat.repo_sync_queue.id = repo_sync_queue_id
+                RETURNING *
+            )
+            UPDATE mergestat.repo_syncs set last_completed_repo_sync_queue_id = repo_sync_queue_id
+            FROM update_queue
+            WHERE mergestat.repo_syncs.id = update_queue.repo_sync_id
+            RETURNING mergestat.repo_syncs.id INTO _repo_sync_id;
+    ELSE    
+            UPDATE mergestat.repo_sync_queue SET "status" = new_status where mergestat.repo_sync_queue.id = repo_sync_queue_id
+            RETURNING repo_sync_id INTO _repo_sync_id;
+    END IF;
+    
+    RETURN _repo_sync_id;    
+end;
+$$ LANGUAGE plpgsql;
+
+COMMIT;

--- a/ui/src/api-logic/graphql/queries/get-repos.query.ts
+++ b/ui/src/api-logic/graphql/queries/get-repos.query.ts
@@ -18,7 +18,7 @@ const GET_ALL_ENABLED_REPOS = gql`
 
 const GET_SYNC_ERRORS = gql`
   query getSyncErrors {
-    syncErrors: execSQL(query: "WITH ranked_completed_syncs AS ( SELECT rsq.id, rsq.repo_sync_id, rsq.done_at, RANK() OVER(PARTITION BY rsq.repo_sync_id ORDER BY rsq.done_at DESC) AS rank_num FROM mergestat.repo_sync_queue AS rsq WHERE rsq.repo_sync_id NOT IN (SELECT repo_sync_id FROM mergestat.repo_sync_queue WHERE status = 'RUNNING' OR status = 'QUEUED') ) SELECT COUNT(DISTINCT rcs.id) AS syncs_error_count FROM ranked_completed_syncs AS rcs INNER JOIN mergestat.repo_sync_logs AS rsl ON rcs.id = rsl.repo_sync_queue_id WHERE rank_num = 1 AND log_type = 'ERROR'")
+    syncErrors: execSQL(query: "SELECT COUNT(DISTINCT rs.id) AS syncs_error_count FROM mergestat.repo_syncs AS rs INNER JOIN mergestat.repo_sync_logs AS rsl ON rs.last_completed_repo_sync_queue_id = rsl.repo_sync_queue_id AND log_type = 'ERROR' WHERE rs.id NOT IN (SELECT repo_sync_id FROM mergestat.repo_sync_queue WHERE status IN ('QUEUED', 'RUNNING'))")
   }
 `
 


### PR DESCRIPTION
Changing logic to store the queue id for the last completion of each repo sync. This will allow us to check for errors with in the sync runs without having to rank all of the jobs in the queue which is a very expensive query. I tested with several different indexing changes but our current indexing continued to be chosen by the database engine. The most expensive part of this query is still having to check the queue to not query syncs that are currently `QUEUED` or `RUNNING`.


Resolves #483 