### PR TITLE
chore(loaders): Adding feedback actions for the user

### DIFF
--- a/ui/src/views/repository-data/components/sync-types-table/index.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/index.tsx
@@ -78,7 +78,7 @@ export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ repoId, data }: 
                           <Toggle
                             isChecked={sync.data.scheduleEnabled}
                             onChange={() => {
-                              showSuccessAlert(`Sync ${sync.data.scheduleEnabled ? 'Off' : 'On'}`)
+                              showSuccessAlert(`Sync schedule turned ${sync.data.scheduleEnabled ? 'off' : 'on'}`)
                               sync.data.id
                                 ? updateSchedule({ variables: { syncId: sync.data.id, schedule: !sync.data.scheduleEnabled } })
                                 : addSyncType({ variables: { repoId, syncType: sync.data.type, schedule: true } })

--- a/ui/src/views/repository-data/components/sync-types-table/index.tsx
+++ b/ui/src/views/repository-data/components/sync-types-table/index.tsx
@@ -4,6 +4,7 @@ import React, { PropsWithChildren, useId } from 'react'
 import { RepoSyncDataType } from 'src/@types'
 import { RelativeTimeField } from 'src/components/Fields/relative-time-field'
 import { RepoSyncIcon } from 'src/components/RepoSyncIcon'
+import { showSuccessAlert } from 'src/utils/alerts'
 import { SYNC_STATUS, TEST_IDS } from 'src/utils/constants'
 import useSyncNow from 'src/views/hooks/useSyncNow'
 import { RepositoryData, RepositorySyncNow, RepositorySyncStatus, RepositoryTableRowOptions } from './components'
@@ -77,6 +78,7 @@ export const SycnTypesTable: React.FC<SycnTypesTableProps> = ({ repoId, data }: 
                           <Toggle
                             isChecked={sync.data.scheduleEnabled}
                             onChange={() => {
+                              showSuccessAlert(`Sync ${sync.data.scheduleEnabled ? 'Off' : 'On'}`)
                               sync.data.id
                                 ? updateSchedule({ variables: { syncId: sync.data.id, schedule: !sync.data.scheduleEnabled } })
                                 : addSyncType({ variables: { repoId, syncType: sync.data.type, schedule: true } })


### PR DESCRIPTION
Adding feedback actions for the user. (Resolves #473)

Fixed:
- Adding fast feedback when sync button is pressed (leaving it in queued state)
- Showing an alert when schedule toggle is switched. (Sync On/Sync Off)

Couldn't reproduce them:
- Blue banner with the spinner is being showed immediately.
- Auto import list in settings is being showed well if a new import is added. For this one I remember I did a fix.

