### PR TITLE
fix: use `encodeURIComponent` instead of `encodeURI`

### DIFF
--- a/ui/src/pages/api/admin-auth.ts
+++ b/ui/src/pages/api/admin-auth.ts
@@ -28,13 +28,12 @@ const adminAuth = async (req: NextApiRequest, res: NextApiResponse) => {
 
     // override the user and password in the connection string with the ones provided by the client
     url.username = user
-    url.password = password
+    url.password = encodeURIComponent(password) // password may contain special characters
 
     try {
       const client = new Client({
         // use the connection info supplied by the parsed POSTGRES_CONNECTION url
-        // encodeURI since the password (or user) may contain special characters
-        connectionString: encodeURI(url.toString()),
+        connectionString: url.toString(),
 
         // by default this is "no timeout"
         // so we set it here to have a hard limit


### PR DESCRIPTION
in the login API. There are 11 characters (according to this page: https://thisthat.dev/encode-uri-vs-encode-uri-component/) not encoded by `encodeURIComponent` which may appear in PG passwords, causing issues logging in for users with those in their password.

This should address that, closes #453