### PR TITLE
Small tweaks to the GitHub Actions test setup

### DIFF
--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -9,27 +9,17 @@ import (
 	"github.com/google/go-github/v47/github"
 )
 
-// GetRepoOwnerAndRepoName extracts the owner and repo name from a GitHub repo url
+// GetRepoOwnerAndRepoName extracts the owner and repo name from a GitHub-like repo url
 // and returns the owner and repo respectively
 func GetRepoOwnerAndRepoName(repoUrl string) (string, string, error) {
-	var sr string
-	var s []string
 	parsedURL, err := url.Parse(repoUrl)
 
 	if err != nil {
 		return "", "", err
 	}
 
-	if strings.Compare(parsedURL.Scheme, "http") == 0 {
-		sr = strings.Replace(repoUrl, "http://github.com/", "", -1)
-		s := strings.Split(sr, "/")
-
-		return s[0], s[1], nil
-
-	}
-
-	sr = strings.Replace(repoUrl, "https://github.com/", "", -1)
-	s = strings.Split(sr, "/")
+	t := strings.TrimPrefix(parsedURL.EscapedPath(), "/")
+	s := strings.Split(t, "/")
 
 	return s[0], s[1], nil
 }

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -52,7 +52,7 @@ func CreateTempDir(basePath, pattern string) (string, func() error, error) {
 }
 
 // GetInt32FromInt is a helper function created to handle mutations of a *int value
-// to *int32 value,every nil value should be ignored to return a new *int32 value
+// to *int32 value, every nil value should be ignored to return a new *int32 value
 func GetInt32FromInt(i *int) *int32 {
 	var i32 int32
 	if i == nil {


### PR DESCRIPTION
- Some renaming in the tests for clarity
- Simplify the `GetRepoOwnerAndRepoName` helper to be a bit more generic