### PR TITLE
fix(actions):fixing possible nill values

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -179,7 +179,7 @@ type GithubActionsWorkflowRun struct {
 	Event             sql.NullString
 	Status            sql.NullString
 	Conclusion        sql.NullString
-	WorkflowID        int64
+	WorkflowID        sql.NullInt64
 	CheckSuiteID      sql.NullInt64
 	CheckSuiteNodeID  sql.NullString
 	Url               sql.NullString
@@ -204,7 +204,7 @@ type GithubActionsWorkflowRun struct {
 type GithubActionsWorkflowRunJob struct {
 	RepoID            uuid.UUID
 	ID                int64
-	RunID             int64
+	RunID             sql.NullInt64
 	Log               sql.NullString
 	RunUrl            sql.NullString
 	JobNodeID         sql.NullString

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -585,7 +585,7 @@ FROM t
 type UpsertWorkflowRunJobsParams struct {
 	Repoid          uuid.UUID
 	ID              int64
-	Runid           int64
+	Runid           sql.NullInt64
 	Log             sql.NullString
 	Runurl          sql.NullString
 	Jobnodeid       sql.NullString
@@ -752,7 +752,7 @@ type UpsertWorkflowRunsParams struct {
 	Event             sql.NullString
 	Status            sql.NullString
 	Conclusion        sql.NullString
-	Workflowid        int64
+	Workflowid        sql.NullInt64
 	Checksuiteid      sql.NullInt64
 	Checksuitenodeid  sql.NullString
 	Url               sql.NullString

--- a/internal/mocks/mock_actions.go
+++ b/internal/mocks/mock_actions.go
@@ -26,7 +26,7 @@ func GetWorkflowRunEmptyData() *github.WorkflowRun {
 	var workflowURL *string
 	var runNumber *int
 	var runAttempt *int
-	var workflowID = new(int64)
+	var workflowID *int64
 	var checkSuiteID *int64
 	var headCommit *github.HeadCommit
 	var pullRequest []*github.PullRequest
@@ -96,7 +96,7 @@ func GetWorkflowEmptyJob() *github.WorkflowJob {
 	var runURL *string
 	var checkRunURL *string
 	var labels []string
-	var runID = new(int64)
+	var runID *int64
 	var runnedID *int64
 	var runnerGroupID *int64
 	var runnerName *string

--- a/internal/warehouse/github_actions.go
+++ b/internal/warehouse/github_actions.go
@@ -374,7 +374,7 @@ func (w *warehouse) handleWorkflowRunsUpsert(ctx context.Context, workflowRunPag
 			Event:             helper.StringToSqlNullString(workflowRun.Event),
 			Status:            helper.StringToSqlNullString(workflowRun.Status),
 			Conclusion:        helper.StringToSqlNullString(workflowRun.Conclusion),
-			Workflowid:        *workflowRun.WorkflowID,
+			Workflowid:        helper.Int64ToSqlNullInt64(workflowRun.WorkflowID),
 			Checksuiteid:      helper.Int64ToSqlNullInt64(workflowRun.CheckSuiteID),
 			Checksuitenodeid:  helper.StringToSqlNullString(workflowRun.CheckSuiteNodeID),
 			Url:               helper.StringToSqlNullString(workflowRun.URL),
@@ -431,7 +431,7 @@ func (w *warehouse) handleWorkflowJobUpsert(ctx context.Context, workflowJob *gi
 	if err := w.db.WithTx(tx).UpsertWorkflowRunJobs(ctx, db.UpsertWorkflowRunJobsParams{
 		Repoid:          repoID,
 		ID:              *workflowJob.ID,
-		Runid:           *workflowJob.RunID,
+		Runid:           helper.Int64ToSqlNullInt64(workflowJob.RunID),
 		Log:             helper.StringToSqlNullString(&log),
 		Runurl:          helper.StringToSqlNullString(workflowJob.RunURL),
 		Jobnodeid:       helper.StringToSqlNullString(workflowJob.NodeID),

--- a/internal/warehouse/github_actions_test.go
+++ b/internal/warehouse/github_actions_test.go
@@ -272,7 +272,7 @@ func TestWarehouseWorkflowRunsOK(t *testing.T) {
 					Event:             helper.StringToSqlNullString(testRuns.Event),
 					Status:            helper.StringToSqlNullString(testRuns.Status),
 					Conclusion:        helper.StringToSqlNullString(testRuns.Conclusion),
-					Workflowid:        *testRuns.WorkflowID,
+					Workflowid:        helper.Int64ToSqlNullInt64(testRuns.WorkflowID),
 					Checksuiteid:      helper.Int64ToSqlNullInt64(testRuns.CheckSuiteID),
 					Checksuitenodeid:  helper.StringToSqlNullString(testRuns.CheckSuiteNodeID),
 					Url:               helper.StringToSqlNullString(testRuns.URL),
@@ -389,7 +389,7 @@ func TestWarehouseWorkflowJobsOK(t *testing.T) {
 				mockedDb.EXPECT().UpsertWorkflowRunJobs(ctx, db.UpsertWorkflowRunJobsParams{
 					Repoid:          repoID,
 					ID:              *testJobs.ID,
-					Runid:           *testJobs.RunID,
+					Runid:           helper.Int64ToSqlNullInt64(testJobs.RunID),
 					Log:             helper.StringToSqlNullString(&log),
 					Runurl:          helper.StringToSqlNullString(testJobs.RunURL),
 					Jobnodeid:       helper.StringToSqlNullString(testJobs.NodeID),

--- a/migrations/900000000000010_actions_null.up.sql
+++ b/migrations/900000000000010_actions_null.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+ALTER TABLE public.github_actions_workflow_runs
+ALTER COLUMN workflow_id DROP NOT NULL;
+   
+ALTER TABLE public.github_actions_workflow_run_jobs 
+ALTER COLUMN run_id DROP NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
We think this solve this bug reported in the alerts , we are not 100%  because we cannot replicate the error  for lack of information .
Logically speaking whe you see the track on the nil pointer   in starts  on the handleJobsUpsert and the only nillable  value is the one we are changing in the content 

resolves #535 