### PR TITLE
chore: bump `docker-compose` to `1.4.0-beta`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,8 @@ services:
   worker:
     # NOTE: to opt out of basic image pull tracking, comment out the current image
     # and uncomment the next line (which will pull from Docker Hub directly).
-    # image: mergestat/worker:1.3.1-beta
-    image: images.mergestat.com/mergestat/worker:1.3.1-beta
+    # image: mergestat/worker:1.4.0-beta
+    image: images.mergestat.com/mergestat/worker:1.4.0-beta
     stop_grace_period: 10m
     restart: always
     depends_on:
@@ -46,8 +46,8 @@ services:
 
   graphql:
     # See NOTE above in worker service.
-    # image: mergestat/graphql:1.3.1-beta
-    image: images.mergestat.com/mergestat/graphql:1.3.1-beta
+    # image: mergestat/graphql:1.4.0-beta
+    image: images.mergestat.com/mergestat/graphql:1.4.0-beta
     restart: always
     depends_on:
       postgres:
@@ -90,8 +90,8 @@ services:
 
   ui:
     # See NOTE above in worker service.
-    # image: mergestat/console:1.3.1-beta
-    image: images.mergestat.com/mergestat/console:1.3.1-beta
+    # image: mergestat/console:1.4.0-beta
+    image: images.mergestat.com/mergestat/console:1.4.0-beta
     restart: always
     depends_on:
       - graphql


### PR DESCRIPTION
In preparation for a new release