### PR TITLE
feat: refactor how some of the DB logging formatting works

### DIFF
--- a/internal/syncer/git_commit_stats.go
+++ b/internal/syncer/git_commit_stats.go
@@ -74,9 +74,10 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
@@ -242,9 +243,10 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	err = tx.Commit(ctx)

--- a/internal/syncer/git_commits.go
+++ b/internal/syncer/git_commits.go
@@ -107,9 +107,10 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
@@ -180,9 +181,10 @@ func (w *worker) handleGitCommits(ctx context.Context, j *db.DequeueSyncJobRow) 
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	err = tx.Commit(ctx)

--- a/internal/syncer/git_files.go
+++ b/internal/syncer/git_files.go
@@ -57,9 +57,10 @@ func (w *worker) handleGitFiles(ctx context.Context, j *db.DequeueSyncJobRow) er
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
@@ -130,9 +131,10 @@ func (w *worker) handleGitFiles(ctx context.Context, j *db.DequeueSyncJobRow) er
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	err = tx.Commit(ctx)

--- a/internal/syncer/git_refs.go
+++ b/internal/syncer/git_refs.go
@@ -80,9 +80,10 @@ func (w *worker) handleGitRefs(ctx context.Context, j *db.DequeueSyncJobRow) err
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
@@ -155,9 +156,10 @@ func (w *worker) handleGitRefs(ctx context.Context, j *db.DequeueSyncJobRow) err
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	err = tx.Commit(ctx)

--- a/internal/syncer/github_actions.go
+++ b/internal/syncer/github_actions.go
@@ -15,9 +15,10 @@ func (w *worker) handleGithubActions(ctx context.Context, j *db.DequeueSyncJobRo
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	var ghToken string
@@ -48,9 +49,10 @@ func (w *worker) handleGithubActions(ctx context.Context, j *db.DequeueSyncJobRo
 		return fmt.Errorf("update status done: %w", err)
 	}
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	return tx.Commit(ctx)

--- a/internal/syncer/github_pr_commits.go
+++ b/internal/syncer/github_pr_commits.go
@@ -81,9 +81,10 @@ func (w *worker) handleGitHubPRCommits(ctx context.Context, j *db.DequeueSyncJob
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())
@@ -148,9 +149,10 @@ func (w *worker) handleGitHubPRCommits(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	return tx.Commit(ctx)

--- a/internal/syncer/github_pr_reviews.go
+++ b/internal/syncer/github_pr_reviews.go
@@ -92,9 +92,10 @@ func (w *worker) handleGitHubPRReviews(ctx context.Context, j *db.DequeueSyncJob
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())
@@ -160,9 +161,10 @@ func (w *worker) handleGitHubPRReviews(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	return tx.Commit(ctx)

--- a/internal/syncer/github_repo_issues.go
+++ b/internal/syncer/github_repo_issues.go
@@ -119,9 +119,10 @@ func (w *worker) handleGitHubRepoIssues(ctx context.Context, j *db.DequeueSyncJo
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())
@@ -185,9 +186,10 @@ func (w *worker) handleGitHubRepoIssues(ctx context.Context, j *db.DequeueSyncJo
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	return tx.Commit(ctx)

--- a/internal/syncer/github_repo_metadata.go
+++ b/internal/syncer/github_repo_metadata.go
@@ -53,9 +53,10 @@ func (w *worker) handleGitHubRepoMetadata(ctx context.Context, j *db.DequeueSync
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	var u *url.URL
@@ -215,9 +216,10 @@ func (w *worker) handleGitHubRepoMetadata(ctx context.Context, j *db.DequeueSync
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	return tx.Commit(ctx)

--- a/internal/syncer/github_repo_prs.go
+++ b/internal/syncer/github_repo_prs.go
@@ -170,9 +170,10 @@ func (w *worker) handleGitHubRepoPRs(ctx context.Context, j *db.DequeueSyncJobRo
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())
@@ -236,9 +237,10 @@ func (w *worker) handleGitHubRepoPRs(ctx context.Context, j *db.DequeueSyncJobRo
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	return tx.Commit(ctx)

--- a/internal/syncer/github_repo_stars.go
+++ b/internal/syncer/github_repo_stars.go
@@ -78,9 +78,10 @@ func (w *worker) handleGitHubRepoStars(ctx context.Context, j *db.DequeueSyncJob
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())
@@ -144,9 +145,10 @@ func (w *worker) handleGitHubRepoStars(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	return tx.Commit(ctx)

--- a/internal/syncer/handlers.go
+++ b/internal/syncer/handlers.go
@@ -2,7 +2,6 @@ package syncer
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v4"
@@ -12,8 +11,6 @@ import (
 
 type syncLogType string
 
-type jobStatus string
-
 const (
 	SyncLogTypeInfo  syncLogType = "INFO"
 	SyncLogTypeWarn  syncLogType = "WARNING"
@@ -21,24 +18,20 @@ const (
 )
 
 const (
-	jobStatusTypeInit   jobStatus = "starting"
-	jobStatusTypeFinish jobStatus = "finishing"
-	unexpectedBehavior  jobStatus = "unexpected behavior"
+	// LogFormatStartingSync is the message for the start of a sync job
+	LogFormatStartingSync = "starting repo sync: %s for repo: %s"
+
+	// LogFormatFinishingSync is the message for the end of a sync job
+	LogFormatFinishingSync = "finishing repo sync: %s for repo: %s"
+
+	// LogFormatErrorWarningMessage is for formatting a warning message when an error was encountered during a repo sync
+	LogFormatErrorWarningMessage = "warning: %s (%v)"
 )
 
 type syncLog struct {
 	Type            syncLogType
 	Message         string
 	RepoSyncQueueID int64
-}
-
-// formartBatchLogMessages generates a standardize message for sync logs
-func (w *worker) formatBatchLogMessages(ctx context.Context, syncLogTypeOption syncLogType, j *db.DequeueSyncJobRow, status jobStatus, operation string) error {
-	return w.sendBatchLogMessages(ctx, []*syncLog{{
-		Type:            syncLogTypeOption,
-		RepoSyncQueueID: j.ID,
-		Message:         fmt.Sprintf("%s %s", status, operation),
-	}})
 }
 
 // sendBatchLogMessages uses the pg COPY protocol to send a batch of sync logs

--- a/internal/syncer/syft_repo_scan.go
+++ b/internal/syncer/syft_repo_scan.go
@@ -19,9 +19,10 @@ func (w *worker) handleSyftRepoScan(ctx context.Context, j *db.DequeueSyncJobRow
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
-	operation := fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeInit, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
@@ -98,9 +99,10 @@ func (w *worker) handleSyftRepoScan(ctx context.Context, j *db.DequeueSyncJobRow
 	}
 
 	// indicate that we're finishing query execution
-	operation = fmt.Sprintf("%s sync for %s", j.SyncType, j.Repo)
-	if err := w.formatBatchLogMessages(ctx, SyncLogTypeInfo, j, jobStatusTypeFinish, operation); err != nil {
-		return fmt.Errorf("log messages: %w", err)
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
 	}
 
 	err = tx.Commit(ctx)


### PR DESCRIPTION
Instead of a "catch all" function, use constant value format strings. Slightly more verbose, but I think helps clarify what the resulting log line will look like.