### PR TITLE
feat(worker): Changing error logs to warnings

### DIFF
--- a/internal/syncer/git_commit_stats.go
+++ b/internal/syncer/git_commit_stats.go
@@ -150,7 +150,7 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 		}
 		defer func() {
 			if err := diff.Free(); err != nil {
-				w.logger.Err(err).Msgf("error freeing diff")
+				w.logger.Warn().AnErr("Error", err).Msgf("error freeing diff")
 			}
 		}()
 
@@ -190,7 +190,7 @@ func (w *worker) handleGitCommitStats(ctx context.Context, j *db.DequeueSyncJobR
 			}, nil
 		}, libgit2.DiffDetailLines)
 		if err != nil {
-			w.logger.Err(err).Msgf("error iterating over diff")
+			w.logger.Warn().AnErr("Error", err).Msgf("error iterating over diff")
 			return false
 		}
 

--- a/internal/syncer/syft_repo_scan.go
+++ b/internal/syncer/syft_repo_scan.go
@@ -50,7 +50,7 @@ func (w *worker) handleSyftRepoScan(ctx context.Context, j *db.DequeueSyncJobRow
 	var output []byte
 	if output, err = cmd.Output(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			w.logger.Err(exitErr).Str("stderr", string(exitErr.Stderr)).Msgf("error running syft repo scan")
+			w.logger.Warn().AnErr("Error", exitErr).Str("stderr", string(exitErr.Stderr)).Msgf("error running syft repo scan")
 		}
 		return fmt.Errorf("running syft scan: %w", err)
 	}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -102,7 +102,7 @@ func (w *worker) exec(ctx context.Context, id string) {
 					continue
 				}
 
-				w.logger.Err(err).Msgf("error dequeuing job: %v", err)
+				w.logger.Warn().AnErr("Error", err).Msgf("error dequeuing job: %v", err)
 				continue
 			}
 
@@ -110,7 +110,7 @@ func (w *worker) exec(ctx context.Context, id string) {
 
 			if err := w.handle(ctx, j); err != nil {
 				if !errors.Is(err, context.Canceled) {
-					w.logger.Err(err).Msgf("error handling job: %v", j)
+					w.logger.Warn().AnErr("Error", err).Msgf("error handling job: %v", j)
 
 					if err := w.db.InsertSyncJobLog(context.TODO(), db.InsertSyncJobLogParams{
 						LogType:         string(SyncLogTypeError),

--- a/internal/syncer/trivy_repo_scan.go
+++ b/internal/syncer/trivy_repo_scan.go
@@ -34,7 +34,7 @@ func (w *worker) handleTrivyRepoScan(ctx context.Context, j *db.DequeueSyncJobRo
 	var output []byte
 	if output, err = cmd.Output(); err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
-			w.logger.Err(exitErr).Str("stderr", string(exitErr.Stderr)).Msgf("error running trivy scan")
+			w.logger.Warn().AnErr("Error", exitErr).Str("stderr", string(exitErr.Stderr)).Msgf("error running trivy scan")
 		}
 		return fmt.Errorf("running trivy scan: %w", err)
 	}

--- a/internal/warehouse/github_actions.go
+++ b/internal/warehouse/github_actions.go
@@ -269,7 +269,7 @@ func (w *warehouse) handleWorkflowJobLogs(ctx context.Context, owner, repo strin
 	// we this fn we clean all in that tmp dir
 	defer func() {
 		if err = cleanup(); err != nil {
-			w.logger.Err(err).Msgf("error cleaning up repo at: %s, %v", filepath, err)
+			w.logger.Warn().AnErr("Error", err).Msgf("error cleaning up repo at: %s, %v", filepath, err)
 		}
 	}()
 


### PR DESCRIPTION
In order to mitigate more our alert channel  we are changing the log type of many  error types to warn types
In this way our alert channel  is actually catching alerts  not intermitent errors 

@patrickdevivo  @amenowanna  if you consider other places to make this change , please let me know  .The only places that are still logging as error type are transactions rollback errors and job keep alive errors .
resolves #597 