### PR TITLE
docs: add some additional SQL examples

### DIFF
--- a/examples/git/docker-images/sql/docker-base-image-versions.sql
+++ b/examples/git/docker-images/sql/docker-base-image-versions.sql
@@ -1,0 +1,15 @@
+-- Find all base Docker images references and pull out their versions
+WITH docker_base_images AS (
+    SELECT
+        repos.repo AS repo,
+        path,
+        (regexp_matches(contents, 'FROM (.*):(.*) AS', 'gm')) AS docker_image
+    FROM git_files
+    INNER JOIN repos ON git_files.repo_id = repos.id
+    WHERE path LIKE '%Dockerfile%'
+)
+SELECT
+    *,
+    docker_image[1] AS image,
+    docker_image[2] AS version
+FROM docker_base_images

--- a/examples/git/go/env-vars/sql/go-env-vars.sql
+++ b/examples/git/go/env-vars/sql/go-env-vars.sql
@@ -2,7 +2,7 @@
 SELECT
     repos.repo,
     path,
-    array_to_string(regexp_matches(contents, 'os.Getenv\(\"(.*?)\"\)', 'g'), ',')
+    array_to_string(regexp_matches(contents, 'os.Getenv\(\"(.*?)\"\)', 'g'), ',') AS matches
 FROM git_files
 INNER JOIN repos ON git_files.repo_id = repos.id
 WHERE path LIKE '%.go'

--- a/examples/git/go/env-vars/sql/go-env-vars.sql
+++ b/examples/git/go/env-vars/sql/go-env-vars.sql
@@ -1,0 +1,8 @@
+-- Find places in Go code where os.Getenv(...) is called to list where ENV vars are accessed
+SELECT
+    repos.repo,
+    path,
+    array_to_string(regexp_matches(contents, 'os.Getenv\(\"(.*?)\"\)', 'g'), ',')
+FROM git_files
+INNER JOIN repos ON git_files.repo_id = repos.id
+WHERE path LIKE '%.go'

--- a/examples/github/repos/sql/repo-counts-by-language.sql
+++ b/examples/github/repos/sql/repo-counts-by-language.sql
@@ -1,7 +1,7 @@
 -- Count of repos by primary language (as determined by GitHub)
 SELECT
     primary_language,
-    count(*)
+    count(*) AS repo_count
 FROM github_repo_info
 GROUP BY primary_language
-ORDER BY count(*) DESC
+ORDER BY repo_count DESC

--- a/examples/github/repos/sql/repo-counts-by-language.sql
+++ b/examples/github/repos/sql/repo-counts-by-language.sql
@@ -1,0 +1,7 @@
+-- Count of repos by primary language (as determined by GitHub)
+SELECT
+    primary_language,
+    count(*)
+FROM github_repo_info
+GROUP BY primary_language
+ORDER BY count(*) DESC

--- a/examples/github/repos/sql/repo-counts-by-license.sql
+++ b/examples/github/repos/sql/repo-counts-by-license.sql
@@ -1,7 +1,7 @@
 -- Count of repos by license (as determined by GitHub)
 SELECT
     license_name,
-    count(*)
+    count(*) AS repo_count
 FROM github_repo_info
 GROUP BY license_name
-ORDER BY count(*) DESC
+ORDER BY repo_count DESC

--- a/examples/github/repos/sql/repo-counts-by-license.sql
+++ b/examples/github/repos/sql/repo-counts-by-license.sql
@@ -1,0 +1,7 @@
+-- Count of repos by license (as determined by GitHub)
+SELECT
+    license_name,
+    count(*)
+FROM github_repo_info
+GROUP BY license_name
+ORDER BY count(*) DESC


### PR DESCRIPTION
Adds some more example queries to the `examples/` directory:

- Docker image version querying
- Go ENV var code search
- Repo counts by language
- Repo counts by license