### PR TITLE
feat: tweak the graphql query used by `getRepos(...)`

### DIFF
--- a/migrations/900000000000011_last_repo_sync_queue_fk_null.up.sql
+++ b/migrations/900000000000011_last_repo_sync_queue_fk_null.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE "mergestat"."repo_syncs"
+ADD CONSTRAINT "last_completed_repo_sync_queue_id_fk"
+FOREIGN KEY ("last_completed_repo_sync_queue_id")
+REFERENCES "mergestat"."repo_sync_queue"("id");
+
+COMMIT;

--- a/ui/src/__mocks__/repos.mock.ts
+++ b/ui/src/__mocks__/repos.mock.ts
@@ -44,67 +44,62 @@ export const mockRepoData: GetReposQuery = {
             {
               id: faker.datatype.uuid(),
               syncType: 'GIT_COMMIT_STATS',
-              repoSyncQueues: {
-                nodes: [
-                  {
-                    id: faker.random.numeric(4),
-                    status: 'DONE',
-                    createdAt: faker.date.recent(9),
-                  }
-                ],
+              lastCompletedRepoSyncQueue: {
+                id: faker.random.numeric(4),
+                status: 'DONE',
+                createdAt: faker.date.recent(9),
+                repoSyncLogs: {
+                  totalCount: 0
+                }
               },
             },
             {
               id: faker.datatype.uuid(),
               syncType: 'GIT_FILES',
-              repoSyncQueues: {
-                nodes: [
-                  {
-                    id: faker.random.numeric(4),
-                    status: 'RUNNING',
-                    createdAt: faker.date.recent(),
-                  }
-                ],
-              },
+              lastCompletedRepoSyncQueue: {
+                id: faker.random.numeric(4),
+                status: 'RUNNING',
+                createdAt: faker.date.recent(),
+                repoSyncLogs: {
+                  totalCount: 0
+                }
+              }
             },
             {
               id: faker.datatype.uuid(),
               syncType: 'GITHUB_REPO_METADATA',
-              repoSyncQueues: {
-                nodes: [
-                  {
-                    id: faker.random.numeric(4),
-                    status: 'DONE',
-                    createdAt: faker.date.recent(8),
-                  }
-                ],
-              },
+              lastCompletedRepoSyncQueue: {
+                id: faker.random.numeric(4),
+                status: 'DONE',
+                createdAt: faker.date.recent(8),
+                repoSyncLogs: {
+                  totalCount: 0
+                }
+              }
             },
             {
               id: faker.datatype.uuid(),
               syncType: 'GIT_REFS',
-              repoSyncQueues: {
-                nodes: [
-                  {
-                    id: faker.random.numeric(4),
-                    status: 'DONE',
-                    createdAt: faker.date.recent(7),
-                  }
-                ],
-              },
+              lastCompletedRepoSyncQueue: {
+                id: faker.random.numeric(4),
+                status: 'DONE',
+                createdAt: faker.date.recent(7),
+                repoSyncLogs: {
+                  totalCount: 0
+                }
+              }
             },
             {
               id: faker.datatype.uuid(),
               syncType: 'GIT_COMMITS',
-              repoSyncQueues: {
-                nodes: [
-                  {
-                    id: faker.random.numeric(4),
-                    status: 'DONE',
-                    createdAt: faker.date.recent(6),
-                  }
-                ],
-              },
+              lastCompletedRepoSyncQueue: {
+                id: faker.random.numeric(4),
+                status: 'DONE',
+                createdAt: faker.date.recent(6),
+                repoSyncLogs: {
+                  totalCount: 0
+                }
+              }
             }
           ],
         },

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -13586,7 +13586,7 @@ export type GetReposQueryVariables = Exact<{
 }>;
 
 
-export type GetReposQuery = { serviceAuthCredentials?: { totalCount: number } | null, repoImports?: { totalCount: number } | null, repos?: { totalCount: number, nodes: Array<{ id: any, repo: string, createdAt: any, isGithub?: boolean | null, tags: any, repoImport?: { type: string, settings: any } | null, repoSyncs: { totalCount: number, nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string } | null, lastCompletedRepoSyncQueue?: { id: any, status: string, doneAt?: any | null, createdAt: any, errors: { totalCount: number } } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, doneAt?: any | null, createdAt: any, hasError?: boolean | null }> } }> } }> } | null };
+export type GetReposQuery = { serviceAuthCredentials?: { totalCount: number } | null, repoImports?: { totalCount: number } | null, repos?: { totalCount: number, nodes: Array<{ id: any, repo: string, createdAt: any, isGithub?: boolean | null, tags: any, repoImport?: { type: string, settings: any } | null, repoSyncs: { totalCount: number, nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string } | null, lastCompletedRepoSyncQueue?: { id: any, status: string, doneAt?: any | null, createdAt: any, repoSyncLogs: { totalCount: number } } | null }> } }> } | null };
 
 export type GetSyncHistoryLogsQueryVariables = Exact<{
   repoId: Scalars['UUID'];

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -829,6 +829,8 @@ export type CreateRepoSyncPayload = {
    * unchanged and unused. May be used by a client to track mutations.
    */
   clientMutationId?: Maybe<Scalars['String']>;
+  /** Reads a single `RepoSyncQueue` that is related to this `RepoSync`. */
+  lastCompletedRepoSyncQueue?: Maybe<RepoSyncQueue>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
   /** Reads a single `Repo` that is related to this `RepoSync`. */
@@ -2183,6 +2185,8 @@ export type DeleteRepoSyncPayload = {
    */
   clientMutationId?: Maybe<Scalars['String']>;
   deletedRepoSyncNodeId?: Maybe<Scalars['ID']>;
+  /** Reads a single `RepoSyncQueue` that is related to this `RepoSync`. */
+  lastCompletedRepoSyncQueue?: Maybe<RepoSyncQueue>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
   /** Reads a single `Repo` that is related to this `RepoSync`. */
@@ -3862,7 +3866,7 @@ export type GithubActionsWorkflowRun = Node & {
   status?: Maybe<Scalars['String']>;
   updatedAt?: Maybe<Scalars['Datetime']>;
   url?: Maybe<Scalars['String']>;
-  workflowId: Scalars['BigInt'];
+  workflowId?: Maybe<Scalars['BigInt']>;
   workflowRunNodeId?: Maybe<Scalars['String']>;
   workflowUrl?: Maybe<Scalars['String']>;
 };
@@ -4033,7 +4037,7 @@ export type GithubActionsWorkflowRunInput = {
   status?: InputMaybe<Scalars['String']>;
   updatedAt?: InputMaybe<Scalars['Datetime']>;
   url?: InputMaybe<Scalars['String']>;
-  workflowId: Scalars['BigInt'];
+  workflowId?: InputMaybe<Scalars['BigInt']>;
   workflowRunNodeId?: InputMaybe<Scalars['String']>;
   workflowUrl?: InputMaybe<Scalars['String']>;
 };
@@ -4054,7 +4058,7 @@ export type GithubActionsWorkflowRunJob = Node & {
   /** Reads a single `Repo` that is related to this `GithubActionsWorkflowRunJob`. */
   repo?: Maybe<Repo>;
   repoId: Scalars['UUID'];
-  runId: Scalars['BigInt'];
+  runId?: Maybe<Scalars['BigInt']>;
   runUrl?: Maybe<Scalars['String']>;
   runnerGroupId?: Maybe<Scalars['BigInt']>;
   runnerGroupName?: Maybe<Scalars['String']>;
@@ -4185,7 +4189,7 @@ export type GithubActionsWorkflowRunJobInput = {
   labels?: InputMaybe<Scalars['JSON']>;
   log?: InputMaybe<Scalars['String']>;
   repoId: Scalars['UUID'];
-  runId: Scalars['BigInt'];
+  runId?: InputMaybe<Scalars['BigInt']>;
   runUrl?: InputMaybe<Scalars['String']>;
   runnerGroupId?: InputMaybe<Scalars['BigInt']>;
   runnerGroupName?: InputMaybe<Scalars['String']>;
@@ -9486,7 +9490,9 @@ export type RepoFilter = {
 export type RepoImport = Node & {
   createdAt: Scalars['Datetime'];
   id: Scalars['UUID'];
+  importError?: Maybe<Scalars['String']>;
   importInterval?: Maybe<Interval>;
+  importStatus?: Maybe<Scalars['String']>;
   lastImport?: Maybe<Scalars['Datetime']>;
   lastImportStartedAt?: Maybe<Scalars['Datetime']>;
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
@@ -9522,8 +9528,12 @@ export type RepoImportCondition = {
   createdAt?: InputMaybe<Scalars['Datetime']>;
   /** Checks for equality with the object’s `id` field. */
   id?: InputMaybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `importError` field. */
+  importError?: InputMaybe<Scalars['String']>;
   /** Checks for equality with the object’s `importInterval` field. */
   importInterval?: InputMaybe<IntervalInput>;
+  /** Checks for equality with the object’s `importStatus` field. */
+  importStatus?: InputMaybe<Scalars['String']>;
   /** Checks for equality with the object’s `lastImport` field. */
   lastImport?: InputMaybe<Scalars['Datetime']>;
   /** Checks for equality with the object’s `lastImportStartedAt` field. */
@@ -9544,8 +9554,12 @@ export type RepoImportFilter = {
   createdAt?: InputMaybe<DatetimeFilter>;
   /** Filter by the object’s `id` field. */
   id?: InputMaybe<UuidFilter>;
+  /** Filter by the object’s `importError` field. */
+  importError?: InputMaybe<StringFilter>;
   /** Filter by the object’s `importInterval` field. */
   importInterval?: InputMaybe<IntervalFilter>;
+  /** Filter by the object’s `importStatus` field. */
+  importStatus?: InputMaybe<StringFilter>;
   /** Filter by the object’s `lastImport` field. */
   lastImport?: InputMaybe<DatetimeFilter>;
   /** Filter by the object’s `lastImportStartedAt` field. */
@@ -9566,7 +9580,9 @@ export type RepoImportFilter = {
 export type RepoImportInput = {
   createdAt?: InputMaybe<Scalars['Datetime']>;
   id?: InputMaybe<Scalars['UUID']>;
+  importError?: InputMaybe<Scalars['String']>;
   importInterval?: InputMaybe<IntervalInput>;
+  importStatus?: InputMaybe<Scalars['String']>;
   lastImport?: InputMaybe<Scalars['Datetime']>;
   lastImportStartedAt?: InputMaybe<Scalars['Datetime']>;
   settings?: InputMaybe<Scalars['JSON']>;
@@ -9578,7 +9594,9 @@ export type RepoImportInput = {
 export type RepoImportPatch = {
   createdAt?: InputMaybe<Scalars['Datetime']>;
   id?: InputMaybe<Scalars['UUID']>;
+  importError?: InputMaybe<Scalars['String']>;
   importInterval?: InputMaybe<IntervalInput>;
+  importStatus?: InputMaybe<Scalars['String']>;
   lastImport?: InputMaybe<Scalars['Datetime']>;
   lastImportStartedAt?: InputMaybe<Scalars['Datetime']>;
   settings?: InputMaybe<Scalars['JSON']>;
@@ -9703,8 +9721,12 @@ export enum RepoImportsOrderBy {
   CreatedAtDesc = 'CREATED_AT_DESC',
   IdAsc = 'ID_ASC',
   IdDesc = 'ID_DESC',
+  ImportErrorAsc = 'IMPORT_ERROR_ASC',
+  ImportErrorDesc = 'IMPORT_ERROR_DESC',
   ImportIntervalAsc = 'IMPORT_INTERVAL_ASC',
   ImportIntervalDesc = 'IMPORT_INTERVAL_DESC',
+  ImportStatusAsc = 'IMPORT_STATUS_ASC',
+  ImportStatusDesc = 'IMPORT_STATUS_DESC',
   LastImportAsc = 'LAST_IMPORT_ASC',
   LastImportDesc = 'LAST_IMPORT_DESC',
   LastImportStartedAtAsc = 'LAST_IMPORT_STARTED_AT_ASC',
@@ -9762,6 +9784,8 @@ export type RepoPatch = {
 
 export type RepoSync = Node & {
   id: Scalars['UUID'];
+  /** Reads a single `RepoSyncQueue` that is related to this `RepoSync`. */
+  lastCompletedRepoSyncQueue?: Maybe<RepoSyncQueue>;
   lastCompletedRepoSyncQueueId?: Maybe<Scalars['BigInt']>;
   /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
   nodeId: Scalars['ID'];
@@ -10070,6 +10094,8 @@ export type RepoSyncQueue = Node & {
   repoSyncQueueStatusTypeByStatus?: Maybe<RepoSyncQueueStatusType>;
   /** Reads a single `RepoSyncTypeGroup` that is related to this `RepoSyncQueue`. */
   repoSyncTypeGroupByTypeGroup?: Maybe<RepoSyncTypeGroup>;
+  /** Reads and enables pagination through a set of `RepoSync`. */
+  repoSyncsByLastCompletedRepoSyncQueueId: RepoSyncsConnection;
   startedAt?: Maybe<Scalars['Datetime']>;
   status: Scalars['String'];
   typeGroup: Scalars['String'];
@@ -10085,6 +10111,18 @@ export type RepoSyncQueueRepoSyncLogsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<RepoSyncLogsOrderBy>>;
+};
+
+
+export type RepoSyncQueueRepoSyncsByLastCompletedRepoSyncQueueIdArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<RepoSyncCondition>;
+  filter?: InputMaybe<RepoSyncFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<RepoSyncsOrderBy>>;
 };
 
 /**
@@ -12670,6 +12708,8 @@ export type UpdateRepoSyncPayload = {
    * unchanged and unused. May be used by a client to track mutations.
    */
   clientMutationId?: Maybe<Scalars['String']>;
+  /** Reads a single `RepoSyncQueue` that is related to this `RepoSync`. */
+  lastCompletedRepoSyncQueue?: Maybe<RepoSyncQueue>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
   /** Reads a single `Repo` that is related to this `RepoSync`. */
@@ -13546,7 +13586,7 @@ export type GetReposQueryVariables = Exact<{
 }>;
 
 
-export type GetReposQuery = { serviceAuthCredentials?: { totalCount: number } | null, repoImports?: { totalCount: number } | null, repos?: { totalCount: number, nodes: Array<{ id: any, repo: string, createdAt: any, isGithub?: boolean | null, tags: any, repoImport?: { type: string, settings: any } | null, repoSyncs: { totalCount: number, nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, doneAt?: any | null, createdAt: any, hasError?: boolean | null }> } }> } }> } | null };
+export type GetReposQuery = { serviceAuthCredentials?: { totalCount: number } | null, repoImports?: { totalCount: number } | null, repos?: { totalCount: number, nodes: Array<{ id: any, repo: string, createdAt: any, isGithub?: boolean | null, tags: any, repoImport?: { type: string, settings: any } | null, repoSyncs: { totalCount: number, nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string } | null, lastCompletedRepoSyncQueue?: { id: any, status: string, doneAt?: any | null, createdAt: any, errors: { totalCount: number } } | null, repoSyncQueues: { nodes: Array<{ id: any, status: string, doneAt?: any | null, createdAt: any, hasError?: boolean | null }> } }> } }> } | null };
 
 export type GetSyncHistoryLogsQueryVariables = Exact<{
   repoId: Scalars['UUID'];

--- a/ui/src/api-logic/graphql/queries/get-repos.query.ts
+++ b/ui/src/api-logic/graphql/queries/get-repos.query.ts
@@ -55,13 +55,13 @@ const GET_REPOS = gql`
             repoSyncTypeBySyncType {
               shortName
             }
-            repoSyncQueues(first: 1, orderBy: CREATED_AT_DESC) {
-              nodes {
-                id
-                status
-                doneAt
-                createdAt
-                hasError
+            lastCompletedRepoSyncQueue {
+              id
+              status
+              doneAt
+              createdAt
+              errors: repoSyncLogs(condition: {logType: "ERROR"}) {
+                  totalCount
               }
             }
           }

--- a/ui/src/api-logic/graphql/queries/get-repos.query.ts
+++ b/ui/src/api-logic/graphql/queries/get-repos.query.ts
@@ -60,7 +60,7 @@ const GET_REPOS = gql`
               status
               doneAt
               createdAt
-              errors: repoSyncLogs(condition: {logType: "ERROR"}) {
+              repoSyncLogs(condition: {logType: "ERROR"}) {
                   totalCount
               }
             }

--- a/ui/src/api-logic/mappers/repos.ts
+++ b/ui/src/api-logic/mappers/repos.ts
@@ -61,7 +61,9 @@ const getSyncStatuses = (r: Repo, repoInfo: RepoDataPropsT): Array<RepoDataStatu
     // which is required by the `getStatus` function (used further below in this function). We should probably refactor this to be able to handle
     // the `hasError` field in a better way.
     const statusRepoSyncQueue = st.lastCompletedRepoSyncQueue as RepoSyncQueue
-    statusRepoSyncQueue.hasError = statusRepoSyncQueue?.repoSyncLogs?.totalCount > 0 || false
+    if (statusRepoSyncQueue !== null) {
+      statusRepoSyncQueue.hasError = statusRepoSyncQueue?.repoSyncLogs?.totalCount > 0 || false
+    }
 
     const syncObj: SyncTypeFlatten = {
       idType: st?.id,

--- a/ui/src/api-logic/mappers/repos.ts
+++ b/ui/src/api-logic/mappers/repos.ts
@@ -57,12 +57,18 @@ const mapToRepoData = (data: GetReposQuery | undefined): Array<RepoDataPropsT> =
 const getSyncStatuses = (r: Repo, repoInfo: RepoDataPropsT): Array<RepoDataStatusT> => {
   // 1. Syncs info is flatten in a simple object
   const syncTypes = r?.repoSyncs.nodes.map((st: RepoSync) => {
+    // TODO(patrickdevivo) this is a little bit clumsy, it's to populate the `hasError` field
+    // which is required by the `getStatus` function (used further below in this function). We should probably refactor this to be able to handle
+    // the `hasError` field in a better way.
+    const statusRepoSyncQueue = st.lastCompletedRepoSyncQueue as RepoSyncQueue
+    statusRepoSyncQueue.hasError = statusRepoSyncQueue.repoSyncLogs?.totalCount > 0 || false
+
     const syncObj: SyncTypeFlatten = {
       idType: st?.id,
       type: st?.repoSyncTypeBySyncType?.shortName || '',
       idLastSync: st?.lastCompletedRepoSyncQueue?.id || '',
       lastSync: st?.lastCompletedRepoSyncQueue?.doneAt || '',
-      status: getStatus(st?.lastCompletedRepoSyncQueue as RepoSyncQueue) || '',
+      status: getStatus(statusRepoSyncQueue) || '',
     }
 
     return syncObj

--- a/ui/src/api-logic/mappers/repos.ts
+++ b/ui/src/api-logic/mappers/repos.ts
@@ -60,16 +60,10 @@ const getSyncStatuses = (r: Repo, repoInfo: RepoDataPropsT): Array<RepoDataStatu
     const syncObj: SyncTypeFlatten = {
       idType: st?.id,
       type: st?.repoSyncTypeBySyncType?.shortName || '',
-      idLastSync: '',
-      status: 'empty',
-      lastSync: ''
+      idLastSync: st?.lastCompletedRepoSyncQueue?.id || '',
+      lastSync: st?.lastCompletedRepoSyncQueue?.doneAt || '',
+      status: getStatus(st?.lastCompletedRepoSyncQueue as RepoSyncQueue) || '',
     }
-
-    st?.repoSyncQueues.nodes.forEach((ls: RepoSyncQueue) => {
-      syncObj.idLastSync = ls?.id || ''
-      syncObj.lastSync = ls?.doneAt || ''
-      syncObj.status = getStatus(ls as RepoSyncQueue) || ''
-    })
 
     return syncObj
   })

--- a/ui/src/api-logic/mappers/repos.ts
+++ b/ui/src/api-logic/mappers/repos.ts
@@ -61,7 +61,7 @@ const getSyncStatuses = (r: Repo, repoInfo: RepoDataPropsT): Array<RepoDataStatu
     // which is required by the `getStatus` function (used further below in this function). We should probably refactor this to be able to handle
     // the `hasError` field in a better way.
     const statusRepoSyncQueue = st.lastCompletedRepoSyncQueue as RepoSyncQueue
-    statusRepoSyncQueue.hasError = statusRepoSyncQueue.repoSyncLogs?.totalCount > 0 || false
+    statusRepoSyncQueue.hasError = statusRepoSyncQueue?.repoSyncLogs?.totalCount > 0 || false
 
     const syncObj: SyncTypeFlatten = {
       idType: st?.id,


### PR DESCRIPTION
Make use of the `last_completed_repo_sync_queue_id` column we now have in the `mergestat.repo_syncs` table. This ends up being more performant. Also removes the `hasError` function call