### PR TITLE
fix: migration 11

### DIFF
--- a/migrations/900000000000011_last_repo_sync_queue_fk_null.up.sql
+++ b/migrations/900000000000011_last_repo_sync_queue_fk_null.up.sql
@@ -13,4 +13,19 @@ ADD CONSTRAINT last_completed_repo_sync_queue_id_fk
 FOREIGN KEY (last_completed_repo_sync_queue_id)
 REFERENCES mergestat.repo_sync_queue(id) ON DELETE SET NULL;
 
+-- update trigger to reset migration to not dirty to allow re-run of migration without intervention
+CREATE OR REPLACE FUNCTION track_applied_migration()
+RETURNS trigger AS $$
+DECLARE _current_version BIGINT;
+BEGIN
+    SELECT COALESCE(MAX(version),0) FROM public.schema_migrations_history INTO _current_version;
+    IF new.dirty = false AND new.version > _current_version THEN
+        INSERT INTO public.schema_migrations_history(version) VALUES (new.version);
+    ELSE
+        UPDATE public.schema_migrations SET version = (SELECT MAX(version) FROM public.schema_migrations_history), dirty = false;
+    END IF;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
 COMMIT;

--- a/migrations/900000000000011_last_repo_sync_queue_fk_null.up.sql
+++ b/migrations/900000000000011_last_repo_sync_queue_fk_null.up.sql
@@ -1,8 +1,16 @@
 BEGIN;
 
-ALTER TABLE "mergestat"."repo_syncs"
-ADD CONSTRAINT "last_completed_repo_sync_queue_id_fk"
-FOREIGN KEY ("last_completed_repo_sync_queue_id")
-REFERENCES "mergestat"."repo_sync_queue"("id");
+--Cleanup any orphaned id's
+UPDATE mergestat.repo_syncs
+SET last_completed_repo_sync_queue_id = NULL
+WHERE last_completed_repo_sync_queue_id NOT IN (SELECT id FROM mergestat.repo_sync_queue);
+
+ALTER TABLE mergestat.repo_syncs
+DROP CONSTRAINT IF EXISTS last_completed_repo_sync_queue_id_fk;
+
+ALTER TABLE mergestat.repo_syncs
+ADD CONSTRAINT last_completed_repo_sync_queue_id_fk
+FOREIGN KEY (last_completed_repo_sync_queue_id)
+REFERENCES mergestat.repo_sync_queue(id) ON DELETE SET NULL;
 
 COMMIT;


### PR DESCRIPTION
This fixes the issue with migration 11 where the constraint fails to be added when there are orphaned id's in the new FK constraint. To address this we have added a query to clean these records up before adding the constraint and additionally have added the command to set the id's to null when the parent record is deleted. Also added support for resetting dirty migrations automatically so we can recover broken migrations without manual intervention.

resolves #628 