### PR TITLE
feat: use `Intl.NumberFormat()` in our `/repos` metrics number

### DIFF
--- a/ui/src/views/repositories/index.tsx
+++ b/ui/src/views/repositories/index.tsx
@@ -21,7 +21,7 @@ interface MetricNumberProp {
 const MetricNumber: React.FC<MetricNumberProp> = ({ loading, metric }: MetricNumberProp) => {
   return (
     <div>
-      {loading ? <Spinner size="sm" /> : metric}
+      {loading ? <Spinner size="sm" /> : new Intl.NumberFormat().format(metric)}
     </div>
   )
 }


### PR DESCRIPTION
Adds comma formatting to the metric numbers

<img width="1911" alt="image" src="https://user-images.githubusercontent.com/57259/206590644-c81e294f-93c2-42eb-9686-c8c3dd68309a.png">
