### PR TITLE
chore: try add ing `"node": "^16"` to `engines` block of `package.json`

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": "16"
+    "node": "^16"
   },
   "scripts": {
     "dev": "next dev",

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,6 +2,9 @@
   "name": "mergestat-console",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "16"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
In an effort to get renovate to use `node` 16 when installing dependencies