### PR TITLE
feat: implement a `gitleaks` syncer for detecting secrets in a repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ COPY . .
 RUN --mount=type=cache,target=/root/.cache/go-build \
 PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/share/pkgconfig/libgit2/lib/pkgconfig/ make
 
+FROM zricethezav/gitleaks:v8.15.2 AS gitleaks
+
 FROM alpine:3.16
 RUN set -x && apk add --no-cache curl postgresql-client ca-certificates git
 
@@ -26,6 +28,9 @@ RUN curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/
 
 # install syft binary
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin v0.58.0
+
+# install gitleaks binary from gitleaks image
+COPY --from=gitleaks /usr/bin/gitleaks /usr/local/bin/gitleaks
 
 # for pprof and prom metrics over http
 EXPOSE 8080

--- a/internal/syncer/gitleaks_repo_scan.go
+++ b/internal/syncer/gitleaks_repo_scan.go
@@ -1,0 +1,111 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/mergestat/mergestat/internal/db"
+	"github.com/mergestat/mergestat/internal/helper"
+)
+
+// handleGitleaksRepoScan executes `gitleaks detect {git-repo} -f json` for a repo
+// and inserts the output JSON into the DB
+func (w *worker) handleGitleaksRepoScan(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	l := w.loggerForJob(j)
+
+	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			l.Err(err).Msgf("error cleaning up repo at: %s, %v", tmpPath, err)
+		}
+	}()
+
+	var ghToken string
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	if err = w.cloneRepo(ctx, ghToken, j.Repo, tmpPath, false, j); err != nil {
+		return fmt.Errorf("git clone: %w", err)
+	}
+
+	// indicate that we're starting a gitleaks scan
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "gitleaks", "detect", "-s", tmpPath, "-f", "json", "-r", "_mergestat_gitleaks_scan_results.json", "--exit-code", "0")
+
+	if err = cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			w.logger.Warn().AnErr("error", exitErr).Str("stderr", string(exitErr.Stderr)).Msgf("error running gitleaks scan")
+		}
+		return fmt.Errorf("running gitleaks scan: %w", err)
+	}
+
+	var output []byte
+	if output, err = os.ReadFile("_mergestat_gitleaks_scan_results.json"); err != nil {
+		return fmt.Errorf("reading gitleaks scan results: %w", err)
+	}
+
+	var tx pgx.Tx
+	if tx, err = w.pool.BeginTx(ctx, pgx.TxOptions{}); err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			if !errors.Is(err, pgx.ErrTxClosed) {
+				w.logger.Err(err).Msgf("could not rollback transaction")
+			}
+		}
+	}()
+
+	r, err := tx.Exec(ctx, "DELETE FROM gitleaks_repo_scans WHERE repo_id = $1;", j.RepoID.String())
+	if err != nil {
+		return fmt.Errorf("exec delete: %w", err)
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("removed %d row(s) from gitleaks_repo_scans", r.RowsAffected()),
+	}}); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(ctx, "INSERT INTO gitleaks_repo_scans (repo_id, results) VALUES ($1, $2)", j.RepoID, output); err != nil {
+		return fmt.Errorf("inserting gitleaks results: %w", err)
+	}
+
+	l.Info().Msg("inserted gitleaks scan results")
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         "inserted gitleaks scan results into gitleaks_repo_scans",
+	}}); err != nil {
+		return err
+	}
+
+	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
+		return fmt.Errorf("update status done: %w", err)
+	}
+
+	// indicate that we're finishing query execution
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -33,10 +33,10 @@ const (
 	syncTypeGitHubRepoStars    = "GITHUB_REPO_STARS"
 	syncTypeGitHubPRReviews    = "GITHUB_PR_REVIEWS"
 	syncTypeGitHubPRCommits    = "GITHUB_PR_COMMITS"
-
-	syncTypeTrivyRepoScan = "TRIVY_REPO_SCAN"
-	syncTypeSyftRepoScan  = "SYFT_REPO_SCAN"
-	syncTypeGitHubActions = "GITHUB_ACTIONS"
+	syncTypeTrivyRepoScan      = "TRIVY_REPO_SCAN"
+	syncTypeSyftRepoScan       = "SYFT_REPO_SCAN"
+	syncTypeGitHubActions      = "GITHUB_ACTIONS"
+	synTypeGitleaksRepoScan    = "GITLEAKS_REPO_SCAN"
 )
 
 type worker struct {
@@ -177,6 +177,8 @@ func (w *worker) handle(ctx context.Context, j *db.DequeueSyncJobRow) error {
 		return w.handleSyftRepoScan(ctx, j)
 	case syncTypeGitHubActions:
 		return w.handleGithubActions(ctx, j)
+	case synTypeGitleaksRepoScan:
+		return w.handleGitleaksRepoScan(ctx, j)
 	default:
 		return fmt.Errorf("unknown sync type: %s for job ID: %d", j.SyncType, j.ID)
 	}

--- a/migrations/900000000000012_add_gitleaks_sync.up.sql
+++ b/migrations/900000000000012_add_gitleaks_sync.up.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+INSERT INTO mergestat.repo_sync_types (type, description, short_name) VALUES ('GITLEAKS_REPO_SCAN', 'Executes a gitleaks scan on a git repository', 'Gitleaks Repo Scan') ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS gitleaks_repo_scans (
+    repo_id uuid PRIMARY KEY,
+    results jsonb NOT NULL
+);
+
+CREATE OR REPLACE VIEW gitleaks_repo_detections AS
+SELECT
+    gitleaks_repo_scans.repo_id,
+    r.value->> 'Description' AS description,
+    r.value->> 'StartLine' AS start_line,
+    r.value->> 'EndLine' AS end_line,
+    r.value->> 'StartColumn' AS start_column,
+    r.value->> 'EndColumn' AS end_column,
+    r.value->> 'Match' AS match,
+    r.value->> 'Secret' AS secret,
+    r.value->> 'File' AS file,
+    r.value->> 'SymlinkFile' AS symlink_file,
+    r.value->> 'Commit' AS commit,
+    r.value->> 'Entropy' AS entropy,
+    r.value->> 'Author' AS author,
+    r.value->> 'Email' AS email,
+    r.value->> 'Date' AS date,
+    r.value->> 'Message' AS message,
+    r.value->> 'Tags' AS tags,
+    r.value->> 'RuleID' AS rule_id,
+    r.value->> 'Fingerprint' AS fingerprint
+FROM gitleaks_repo_scans, jsonb_array_elements(results) AS r;
+
+COMMIT;

--- a/migrations/900000000000012_add_gitleaks_sync.up.sql
+++ b/migrations/900000000000012_add_gitleaks_sync.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-INSERT INTO mergestat.repo_sync_types (type, description, short_name) VALUES ('GITLEAKS_REPO_SCAN', 'Executes a gitleaks scan on a git repository', 'Gitleaks Repo Scan') ON CONFLICT DO NOTHING;
+INSERT INTO mergestat.repo_sync_types (type, description, short_name, priority) VALUES ('GITLEAKS_REPO_SCAN', 'Executes a gitleaks scan on a git repository', 'Gitleaks Repo Scan', 3) ON CONFLICT DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS gitleaks_repo_scans (
     repo_id uuid PRIMARY KEY,


### PR DESCRIPTION
Another POC syncer that brings in this tool: https://gitleaks.io/ as a sync type. Runs a scan on a repo and then stores the JSON output in the DB. Also sets up a view to make the JSON data a bit easier to consume.

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/57259/207175911-63ea59f5-34e3-4e02-b72c-ab445aa7a5e0.png">
