### PR TITLE
fix(syncer): do not append token to local URLs

### DIFF
--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -259,6 +259,11 @@ func (w *worker) addGithubTokenToUrl(urlString, ghToken string) (string, error) 
 		return "", err
 	}
 
+	// for URLs with file:// or no scheme, do not append GitHub token.
+	if parsedUrl.Scheme == "" || parsedUrl.Scheme == "file" {
+		return urlString, nil
+	}
+
 	parsedUrl.User = url.UserPassword(parsedUrl.Path, ghToken)
 	return parsedUrl.String(), nil
 }


### PR DESCRIPTION
When testing out support for local or `file://` URLs (see #635), I ran into this issue where the GitHub token was being appended (and the path was being escaped / encoded), even for local filesystem paths.