### PR TITLE
feat: implement `Yelp/detect-secrets` as another *experimental* repo scan type

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,13 @@ RUN curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | 
 # install gitleaks binary from gitleaks image
 COPY --from=gitleaks /usr/bin/gitleaks /usr/local/bin/gitleaks
 
+# install python3 and yelp detect-secrets
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+RUN pip3 install detect-secrets
+
 # for pprof and prom metrics over http
 EXPOSE 8080
 

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -22,21 +22,22 @@ import (
 )
 
 const (
-	syncTypeGitCommits         = "GIT_COMMITS"
-	syncTypeGitCommitStats     = "GIT_COMMIT_STATS"
-	syncTypeGitRefs            = "GIT_REFS"
-	syncTypeGitFiles           = "GIT_FILES"
-	syncTypeGitBlame           = "GIT_BLAME"
-	syncTypeGitHubRepoMetadata = "GITHUB_REPO_METADATA"
-	syncTypeGitHubRepoPRs      = "GITHUB_REPO_PRS"
-	syncTypeGitHubRepoIssues   = "GITHUB_REPO_ISSUES"
-	syncTypeGitHubRepoStars    = "GITHUB_REPO_STARS"
-	syncTypeGitHubPRReviews    = "GITHUB_PR_REVIEWS"
-	syncTypeGitHubPRCommits    = "GITHUB_PR_COMMITS"
-	syncTypeTrivyRepoScan      = "TRIVY_REPO_SCAN"
-	syncTypeSyftRepoScan       = "SYFT_REPO_SCAN"
-	syncTypeGitHubActions      = "GITHUB_ACTIONS"
-	synTypeGitleaksRepoScan    = "GITLEAKS_REPO_SCAN"
+	syncTypeGitCommits                = "GIT_COMMITS"
+	syncTypeGitCommitStats            = "GIT_COMMIT_STATS"
+	syncTypeGitRefs                   = "GIT_REFS"
+	syncTypeGitFiles                  = "GIT_FILES"
+	syncTypeGitBlame                  = "GIT_BLAME"
+	syncTypeGitHubRepoMetadata        = "GITHUB_REPO_METADATA"
+	syncTypeGitHubRepoPRs             = "GITHUB_REPO_PRS"
+	syncTypeGitHubRepoIssues          = "GITHUB_REPO_ISSUES"
+	syncTypeGitHubRepoStars           = "GITHUB_REPO_STARS"
+	syncTypeGitHubPRReviews           = "GITHUB_PR_REVIEWS"
+	syncTypeGitHubPRCommits           = "GITHUB_PR_COMMITS"
+	syncTypeTrivyRepoScan             = "TRIVY_REPO_SCAN"
+	syncTypeSyftRepoScan              = "SYFT_REPO_SCAN"
+	syncTypeGitHubActions             = "GITHUB_ACTIONS"
+	syncTypeGitleaksRepoScan          = "GITLEAKS_REPO_SCAN"
+	syncTypeYelpDetectSecretsRepoScan = "YELP_DETECT_SECRETS_REPO_SCAN"
 )
 
 type worker struct {
@@ -177,8 +178,10 @@ func (w *worker) handle(ctx context.Context, j *db.DequeueSyncJobRow) error {
 		return w.handleSyftRepoScan(ctx, j)
 	case syncTypeGitHubActions:
 		return w.handleGithubActions(ctx, j)
-	case synTypeGitleaksRepoScan:
+	case syncTypeGitleaksRepoScan:
 		return w.handleGitleaksRepoScan(ctx, j)
+	case syncTypeYelpDetectSecretsRepoScan:
+		return w.handleYelpDetectSecretsRepoScan(ctx, j)
 	default:
 		return fmt.Errorf("unknown sync type: %s for job ID: %d", j.SyncType, j.ID)
 	}

--- a/internal/syncer/yelp_detect_secrets_repo_scan.go
+++ b/internal/syncer/yelp_detect_secrets_repo_scan.go
@@ -1,0 +1,108 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/mergestat/mergestat/internal/db"
+	"github.com/mergestat/mergestat/internal/helper"
+)
+
+// handleYelpDetectSecretsRepoScan executes `detect-secrets scan` on a repo
+// and inserts the output JSON into the DB
+func (w *worker) handleYelpDetectSecretsRepoScan(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	l := w.loggerForJob(j)
+
+	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	if err != nil {
+		return fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() {
+		if err := cleanup(); err != nil {
+			l.Err(err).Msgf("error cleaning up repo at: %s, %v", tmpPath, err)
+		}
+	}()
+
+	var ghToken string
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	if err = w.cloneRepo(ctx, ghToken, j.Repo, tmpPath, false, j); err != nil {
+		return fmt.Errorf("git clone: %w", err)
+	}
+
+	// indicate that we're starting a yelp detect-secrets scan
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, "detect-secrets", "scan")
+	cmd.Dir = tmpPath
+
+	var output []byte
+	if output, err = cmd.Output(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			w.logger.Warn().AnErr("error", exitErr).Str("stderr", string(exitErr.Stderr)).Msgf("error running yelp detect-secrets scan")
+		}
+		return fmt.Errorf("running yelp detect-secrets scan: %w", err)
+	}
+
+	var tx pgx.Tx
+	if tx, err = w.pool.BeginTx(ctx, pgx.TxOptions{}); err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			if !errors.Is(err, pgx.ErrTxClosed) {
+				w.logger.Err(err).Msgf("could not rollback transaction")
+			}
+		}
+	}()
+
+	r, err := tx.Exec(ctx, "DELETE FROM yelp_detect_secrets_repo_scans WHERE repo_id = $1;", j.RepoID.String())
+	if err != nil {
+		return fmt.Errorf("exec delete: %w", err)
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("removed %d row(s) from yelp_detect_secrets_repo_scans", r.RowsAffected()),
+	}}); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(ctx, "INSERT INTO yelp_detect_secrets_repo_scans (repo_id, results) VALUES ($1, $2)", j.RepoID, output); err != nil {
+		return fmt.Errorf("inserting yelp detect-secrets results: %w", err)
+	}
+
+	l.Info().Msg("inserted gitleaks scan results")
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         "inserted yelp detect-secrets scan results into yelp_detect_secrets_repo_scans",
+	}}); err != nil {
+		return err
+	}
+
+	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
+		return fmt.Errorf("update status done: %w", err)
+	}
+
+	// indicate that we're finishing query execution
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}

--- a/migrations/900000000000013_add_yelp_detect_secrets_sync.up.sql
+++ b/migrations/900000000000013_add_yelp_detect_secrets_sync.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+INSERT INTO mergestat.repo_sync_types (type, description, short_name, priority) VALUES ('YELP_DETECT_SECRETS_REPO_SCAN', 'Executes a Yelp detect-secrets scan on a git repository', 'Yelp Detect Secrets Repo Scan', 3) ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS yelp_detect_secrets_repo_scans (
+    repo_id uuid PRIMARY KEY,
+    results jsonb NOT NULL
+);
+
+CREATE OR REPLACE VIEW yelp_detect_secrets_repo_detections AS
+SELECT
+    yelp_detect_secrets_repo_scans.repo_id,
+    r.value[0]->> 'type' AS type,
+    r.value[0]->> 'filename' AS filename,
+    r.value[0]->> 'is_verified' AS is_verified,
+    r.value[0]->> 'line_number' AS line_number,
+    r.value[0]->> 'hashed_secret' AS hashed_secret,
+    results->> 'version' AS version,
+    results->> 'generated_at' AS generated_at,
+    results->> 'filters_used' AS filters_used,
+    results->> 'plugins_used' AS plugins_used
+FROM yelp_detect_secrets_repo_scans, jsonb_each(results-> 'results') AS r;
+
+COMMIT;


### PR DESCRIPTION
Similar to Gitleaks, but using this tool instead: https://github.com/Yelp/detect-secrets.

Closes #639

<img width="1788" alt="image" src="https://user-images.githubusercontent.com/57259/208264639-b3e10811-9cce-48f0-9e49-69fc0eb27d77.png">
