### PR TITLE
feat: add a view `mergestat.schema_introspection`

### DIFF
--- a/migrations/900000000000014_add_schema_introspection_view.up.sql
+++ b/migrations/900000000000014_add_schema_introspection_view.up.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+-- Creates a view that can be used to introspect the schema of the database
+-- i.e. returns a list of tables, columns and their respective types (and other metadata).
+-- This is useful for the schema introspection feature in the UI.
+CREATE OR REPLACE VIEW mergestat.schema_introspection AS (
+    SELECT
+        information_schema.tables.table_schema AS schema,
+        information_schema.tables.table_name,
+        information_schema.tables.table_type,
+        information_schema.columns.column_name,
+        information_schema.columns.ordinal_position,
+        information_schema.columns.is_nullable,
+        information_schema.columns.data_type,
+        information_schema.columns.udt_name
+    FROM information_schema.tables
+    INNER JOIN information_schema.columns ON (information_schema.tables.table_name = information_schema.columns.table_name AND information_schema.tables.table_schema = information_schema.columns.table_schema)
+    WHERE information_schema.tables.table_schema IN ('public', 'mergestat')
+);
+
+COMMIT;


### PR DESCRIPTION
to enable the UI to query for tables, columns and column types (and other metadata) for display in the `Queries` area. Dynamically retrieves from the `public` and `mergestat` schemas.

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/57259/208312532-60d2efc9-1552-42e0-a69d-ae58bca9d6b2.png">
