### PR TITLE
fix: typo (extra `;`) in latest migration

### DIFF
--- a/migrations/900000000000016_update_users_view_only_mergestat_roles.up.sql
+++ b/migrations/900000000000016_update_users_view_only_mergestat_roles.up.sql
@@ -32,7 +32,7 @@ CREATE OR REPLACE VIEW mergestat.user_mgmt_pg_users AS (
     -- but this works for now.
     SELECT * FROM users
     WHERE (memberof && ARRAY['mergestat_role_admin', 'mergestat_role_user', 'mergestat_role_readonly']::name[])
-        AND users.rolname != 'mergestat_admin';
+        AND users.rolname != 'mergestat_admin'
 );
 -- noqa: enable=L011,L031,L051
 


### PR DESCRIPTION
Addresses an issue in the latest migration:
<img width="1257" alt="image" src="https://user-images.githubusercontent.com/57259/208767902-e4ad64c3-38ae-483a-9c9f-51b104b2d529.png">

Validated the fix locally