### PR TITLE
fix: fix page titles

### DIFF
--- a/ui/src/pages/connect/index.tsx
+++ b/ui/src/pages/connect/index.tsx
@@ -15,7 +15,7 @@ const Connect: NextPage = () => {
   return (
     <Fragment>
       <Head>
-        <title>MergeStat</title>
+        <title>Connect - MergeStat</title>
       </Head>
       <main className="w-full flex flex-col h-full bg-gray-50 overflow-hidden">
         <div className="bg-white h-16 w-full border-b px-8">

--- a/ui/src/pages/login/index.tsx
+++ b/ui/src/pages/login/index.tsx
@@ -4,8 +4,10 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { ChangeEvent, Fragment, useState } from 'react'
 import { auth } from 'src/api-logic/axios/api'
+import { MERGESTAT_TITLE } from 'src/utils/constants'
 
 const LoginPage = () => {
+  const title = `Login  ${MERGESTAT_TITLE}`
   const router = useRouter()
   const { lostSession } = router.query
 
@@ -22,7 +24,7 @@ const LoginPage = () => {
   return (
     <Fragment>
       <Head>
-        <title>MergeStat</title>
+        <title>{title}</title>
       </Head>
       <main className="w-full min-h-screen h-full flex flex-col items-center justify-center bg-gray-800">
         <Panel className="w-full max-w-lg">

--- a/ui/src/pages/queries/index.tsx
+++ b/ui/src/pages/queries/index.tsx
@@ -8,7 +8,7 @@ const QueryEditorPage: NextPage = () => {
   return (
     <Fragment>
       <Head>
-        <title>MergeStat</title>
+        <title>Queries - MergeStat</title>
       </Head>
       <QueryProvider>
         <QueryEditor />

--- a/ui/src/pages/repos/[repository]/[syncTypeId]/[logID].tsx
+++ b/ui/src/pages/repos/[repository]/[syncTypeId]/[logID].tsx
@@ -20,7 +20,7 @@ const LogsDetailsPage = () => {
   })
 
   const repoData: SyncTypeData = mapToSyncLogsData(data)
-  const title = `${MERGESTAT_TITLE} ${repoData.repo.name}`
+  const title = `${repoData.logs?.[0].syncStartText} - ${repoData.sync?.title} - ${repoData.repo.name} - Repos ${MERGESTAT_TITLE}`
 
   return (
     <Fragment>

--- a/ui/src/pages/repos/index.tsx
+++ b/ui/src/pages/repos/index.tsx
@@ -6,7 +6,7 @@ import { MERGESTAT_TITLE } from 'src/utils/constants'
 import RepositoriesView from 'src/views/repositories'
 
 const ReposPage: NextPage = () => {
-  const title = `${MERGESTAT_TITLE} Repos`
+  const title = `Repos ${MERGESTAT_TITLE}`
 
   return (
     <Fragment>

--- a/ui/src/pages/settings/index.tsx
+++ b/ui/src/pages/settings/index.tsx
@@ -4,12 +4,14 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 import Link from 'next/link'
 import { Fragment } from 'react'
-import { LINKS_TO, TEST_IDS } from 'src/utils/constants'
+import { LINKS_TO, TEST_IDS, MERGESTAT_TITLE } from 'src/utils/constants'
 import useSetPat from 'src/views/hooks/useSetPat'
 
 import SettingsView from 'src/views/settings'
 
 const Settings: NextPage = () => {
+  const title = `GitHub Authentication - Settings ${MERGESTAT_TITLE}`
+
   const {
     pat,
     showValidation,
@@ -24,7 +26,7 @@ const Settings: NextPage = () => {
   return (
     <Fragment>
       <Head>
-        <title>MergeStat</title>
+        <title>{title}</title>
       </Head>
       <SettingsView>
         {/* Main content */}

--- a/ui/src/pages/settings/repo-auto-imports/[importId].tsx
+++ b/ui/src/pages/settings/repo-auto-imports/[importId].tsx
@@ -11,7 +11,7 @@ import { GET_REPO_IMPORT } from 'src/api-logic/graphql/queries/get-repo-imports'
 import Loading from 'src/components/Loading'
 import RepoImage from 'src/components/RepoImage'
 import { showSuccessAlert } from 'src/utils/alerts'
-import { SYNC_REPO_METHOD } from 'src/utils/constants'
+import { SYNC_REPO_METHOD, MERGESTAT_TITLE } from 'src/utils/constants'
 
 import SettingsView from 'src/views/settings'
 
@@ -26,6 +26,8 @@ const AutoImportsDetail: NextPage = () => {
     variables: { id: importId },
     fetchPolicy: 'no-cache',
   })
+
+  const title = `${name} - Auto Import ${MERGESTAT_TITLE}`
 
   const [updateAutoImport] = useMutation(UPDATE_AUTO_IMPORT_REPOS, {
     onCompleted: () => {
@@ -81,7 +83,7 @@ const AutoImportsDetail: NextPage = () => {
     <>
       <Fragment>
         <Head>
-          <title>MergeStat</title>
+          <title>{title}</title>
         </Head>
         <SettingsView>
           {/* Main content */}

--- a/ui/src/pages/settings/repo-auto-imports/index.tsx
+++ b/ui/src/pages/settings/repo-auto-imports/index.tsx
@@ -7,7 +7,7 @@ import { RepositoriesProvider } from 'src/state/contexts'
 import AutoImports from 'src/views/settings/repo-auto-imports'
 
 const AutoImportPage: NextPage = () => {
-  const title = `${MERGESTAT_TITLE} Imports`
+  const title = `Repo Auto Imports - Settings  ${MERGESTAT_TITLE}`
 
   return (
     <Fragment>

--- a/ui/src/pages/settings/user-management/index.tsx
+++ b/ui/src/pages/settings/user-management/index.tsx
@@ -7,7 +7,7 @@ import { UserSettingsProvider } from 'src/state/contexts'
 import UserManagement from 'src/views/settings/user-management'
 
 const UserManagementPage: NextPage = () => {
-  const title = `${MERGESTAT_TITLE} Imports`
+  const title = `User Management - Settings ${MERGESTAT_TITLE}`
 
   return (
     <Fragment>

--- a/ui/src/pages/settings/user-settings/index.tsx
+++ b/ui/src/pages/settings/user-settings/index.tsx
@@ -7,7 +7,7 @@ import { UserSettingsProvider } from 'src/state/contexts'
 import UserSettings from 'src/views/settings/user-settings'
 
 const UserSettingsPage: NextPage = () => {
-  const title = `${MERGESTAT_TITLE} Imports`
+  const title = `User Settings - Settings ${MERGESTAT_TITLE}`
 
   return (
     <Fragment>

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -9,7 +9,7 @@ export const API = {
 
 export const GITHUB_URL = 'https://github.com/'
 
-export const MERGESTAT_TITLE = 'MergeStat |'
+export const MERGESTAT_TITLE = '- MergeStat'
 
 export enum TEST_IDS {
   emptyRepository = 'empty-repository',

--- a/ui/src/views/hooks/useSyncs.ts
+++ b/ui/src/views/hooks/useSyncs.ts
@@ -16,7 +16,7 @@ const useSyncs = () => {
   })
 
   const repo = mapToSyncsData(data)
-  const title = `${MERGESTAT_TITLE} ${repo?.name}`
+  const title = `${repo?.name} - Repos ${MERGESTAT_TITLE}`
 
   return { loading, repo, title }
 }

--- a/ui/src/views/hooks/useSyncsLogs.ts
+++ b/ui/src/views/hooks/useSyncsLogs.ts
@@ -19,7 +19,7 @@ const useSyncsLogs = (poll = false) => {
   const { updateSchedule, syncNow } = useSyncNow('getSyncHistoryLogs')
 
   const repoData: SyncTypeData = mapToSyncLogsData(data)
-  const title = `${MERGESTAT_TITLE} ${repoData.repo.name}`
+  const title = `${repoData.sync?.title} - ${repoData.repo.name} - Repos  ${MERGESTAT_TITLE}`
 
   return { loading, repoData, title, syncTypeId, updateSchedule, syncNow }
 }

--- a/ui/src/views/settings/repo-auto-imports/index.tsx
+++ b/ui/src/views/settings/repo-auto-imports/index.tsx
@@ -1,7 +1,6 @@
 import { Alert, Button, ColoredBox, Panel, Toolbar } from '@mergestat/blocks'
 import { CircleCheckFilledIcon, CircleErrorFilledIcon, ClockIcon, TrashIcon } from '@mergestat/icons'
 import type { NextPage } from 'next'
-import Head from 'next/head'
 import Link from 'next/link'
 import { Fragment } from 'react'
 import { RelativeTimeField } from 'src/components/Fields/relative-time-field'
@@ -18,9 +17,6 @@ const AutoImports: NextPage = () => {
   return (
     <>
       <Fragment>
-        <Head>
-          <title>MergeStat</title>
-        </Head>
         <SettingsView>
           {/* Main content */}
           <div className='flex flex-col flex-1 overflow-hidden'>

--- a/ui/src/views/settings/user-management/index.tsx
+++ b/ui/src/views/settings/user-management/index.tsx
@@ -3,7 +3,6 @@ import { Avatar, Button, Input, Panel, Toolbar } from '@mergestat/blocks'
 import { PencilIcon, PlusIcon, SearchIcon, TrashIcon, UserIcon } from '@mergestat/icons'
 import { debounce } from 'lodash'
 import type { NextPage } from 'next'
-import Head from 'next/head'
 import { Fragment, useEffect, useState } from 'react'
 import { UserData, UserTypeUI } from 'src/@types'
 import { CurrentUserQuery, GetUsersQuery } from 'src/api-logic/graphql/generated/schema'
@@ -56,9 +55,6 @@ const UserManagement: NextPage = () => {
   return (
     <>
       <Fragment>
-        <Head>
-          <title>MergeStat</title>
-        </Head>
         <SettingsView>
           {/* Main content */}
           <div className='flex flex-col flex-1 overflow-hidden'>

--- a/ui/src/views/settings/user-settings/index.tsx
+++ b/ui/src/views/settings/user-settings/index.tsx
@@ -2,7 +2,6 @@ import { useQuery } from '@apollo/client'
 import { Avatar, Button, Label, Panel, Toolbar } from '@mergestat/blocks'
 import { UserIcon } from '@mergestat/icons'
 import type { NextPage } from 'next'
-import Head from 'next/head'
 import { Fragment } from 'react'
 import { CurrentUserQuery } from 'src/api-logic/graphql/generated/schema'
 import { CURRENT_USER } from 'src/api-logic/graphql/queries/auth'
@@ -20,9 +19,6 @@ const UserSettings: NextPage = () => {
   return (
     <>
       <Fragment>
-        <Head>
-          <title>MergeStat</title>
-        </Head>
         <SettingsView>
           {/* Main content */}
           <div className='flex flex-col flex-1 overflow-hidden'>


### PR DESCRIPTION
- I went for `-` as a separator instead of `|` as it seems more widely used and feels a bit more readable
- Ordered titles from detail to top level, for example `Sync 22 Dec 2022 - 17:38 - Git Blame - mergestat/workspace - Repos - MergeStat` 

Resolves #606 