### PR TITLE
fix: add a link to `/settings/repo-auto-imports` in the auto import error message

### DIFF
--- a/ui/src/views/repositories/index.tsx
+++ b/ui/src/views/repositories/index.tsx
@@ -1,4 +1,5 @@
 import { useRepositoriesContext } from 'src/state/contexts/repositories.context'
+import Link from 'next/link'
 import { EmptyRepositoryTable, FilterHeader, PageHeader, RepositoriesTable } from './components'
 import { AddRepositoryModal } from './modals/add-repository-modal'
 
@@ -51,7 +52,7 @@ const RepositoriesView: React.FC = () => {
           >
             <span className='flex flex-col'>
               {failedImports.map((imp, index) => (
-                <li key={`failed-imports-${index}`}><b>{`${imp.name} `}</b>{`(${imp.type}): ${imp.error}`}</li>
+                <li key={`failed-imports-${index}`}><Link href={'/settings/repo-auto-imports'}><a className='font-bold hover:underline'>{`${imp.name} `}</a></Link>{`(${imp.type}): ${imp.error}`}</li>
               ))}
             </span>
           </Alert>}


### PR DESCRIPTION
it's not super clear at the moment that it's clickable, maybe needs to be tweaked. Closes #687 

<img width="2047" alt="image" src="https://user-images.githubusercontent.com/57259/210814514-0943a9cc-4479-4cf1-b276-df26d19c41d2.png">
