### PR TITLE
feat: implement support for `INSECURE_SESSION_COOKIE` env var in the UI

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -105,6 +105,7 @@ services:
       POSTGRAPHILE_API: http://graphql:5433/graphql
       POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres?sslmode=disable
       JWT_SECRET: secret # should match - "--jwt-secret=secret" flag in graphql service
+      INSECURE_SESSION_COOKIE: 1
     labels:
       shipyard.route: '/'
 


### PR DESCRIPTION
This allows an operator to use non ssl-only cookies for user sessions of the web app. This can be useful in situations where MergeStat is run internally on a private IP. Otherwise, the UI requires an HTTPS connection to function.

Closes #673

Validated on an Equinix Metal server