### PR TITLE
feat: implement first pass at backend for query history functionality

### DIFF
--- a/graphql/exec-sql/index.js
+++ b/graphql/exec-sql/index.js
@@ -23,6 +23,7 @@ module.exports = (0, graphile_utils_1.makeExtendSchemaPlugin)({
       variables: [String!]
       rowLimit: Int
       disableReadOnly: Boolean
+      trackHistory: Boolean
     }
 
     type ExecSQLResult {
@@ -40,6 +41,10 @@ module.exports = (0, graphile_utils_1.makeExtendSchemaPlugin)({
             execSQL(_parent, args, context, _info) {
                 return __awaiter(this, void 0, void 0, function* () {
                     const { input } = args;
+                    if (input.trackHistory) {
+                        // if trackHistory is true, then we need to track the query in the query history table
+                        yield context.pgClient.query("INSERT INTO mergestat.query_history (run_by, query) VALUES ((SELECT current_user), $1);", [input.query]);
+                    }
                     // first set the pg session to be read only, if disableReadOnly is false
                     if (!input.disableReadOnly) {
                         yield context.pgClient.query("SET TRANSACTION READ ONLY;");

--- a/migrations/900000000000019_query_history.up.sql
+++ b/migrations/900000000000019_query_history.up.sql
@@ -10,6 +10,11 @@ CREATE TABLE mergestat.query_history (
 ALTER TABLE mergestat.query_history ENABLE ROW LEVEL SECURITY;
 
 -- creates an RLS policy that only allows users to see their own queries
-CREATE POLICY query_history_access ON mergestat.query_history USING (run_by = current_user);
+CREATE POLICY query_history_access ON mergestat.query_history FOR ALL USING (run_by = current_user);
+
+-- the mergestat_role_readonly needs to be permitted to INSERT into the query_history table
+-- the policy above will still prevent the mergestat_role_readonly (any or user) from inserting a row
+-- with a run_by value that is *not* the current_user
+GRANT INSERT ON TABLE mergestat.query_history TO mergestat_role_readonly;
 
 COMMIT;

--- a/migrations/900000000000019_query_history.up.sql
+++ b/migrations/900000000000019_query_history.up.sql
@@ -7,4 +7,9 @@ CREATE TABLE mergestat.query_history (
     query text NOT NULL
 );
 
+ALTER TABLE mergestat.query_history ENABLE ROW LEVEL SECURITY;
+
+-- creates an RLS policy that only allows users to see their own queries
+CREATE POLICY query_history_access ON mergestat.query_history USING (run_by = current_user);
+
 COMMIT;

--- a/migrations/900000000000019_query_history.up.sql
+++ b/migrations/900000000000019_query_history.up.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+CREATE TABLE mergestat.query_history (
+    id uuid DEFAULT public.gen_random_uuid() PRIMARY KEY,
+    run_at timestamp with time zone DEFAULT now(),
+    run_by text NOT NULL,
+    query text NOT NULL
+);
+
+COMMIT;


### PR DESCRIPTION
Adds a table to track the history of queries run in the UI, by user.

See here: https://www.postgresql.org/docs/current/ddl-rowsecurity.html for some additional context on the RLS.

Closes #722 