### PR TITLE
feat: implement an additional experimental syncer, the `ossf/scorecard` project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,10 @@ RUN python3 -m ensurepip
 RUN pip3 install --no-cache --upgrade pip setuptools
 RUN pip3 install detect-secrets
 
+# install the scorecard binary
+RUN curl -sfL https://github.com/ossf/scorecard/releases/download/v4.10.2/scorecard_4.10.2_linux_amd64.tar.gz | tar xvz scorecard-linux-amd64
+RUN chmod +x scorecard-linux-amd64 && cp scorecard-linux-amd64 /usr/local/bin/scorecard
+
 # for pprof and prom metrics over http
 EXPOSE 8080
 

--- a/internal/syncer/ossf_scorecard_scan.go
+++ b/internal/syncer/ossf_scorecard_scan.go
@@ -1,0 +1,96 @@
+package syncer
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/mergestat/mergestat/internal/db"
+)
+
+// handleOSSFScorecardScan executes `scorecard --repo {repo} --format json` for a repo
+// and inserts the output JSON into the DB
+func (w *worker) handleOSSFScorecardScan(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	l := w.loggerForJob(j)
+
+	var ghToken string
+	var err error
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	// indicate that we're starting a scorecard scan
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, "scorecard", "--repo", j.Repo, "--format", "json")
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GITHUB_AUTH_TOKEN=%s", ghToken))
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err = cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			w.logger.Warn().AnErr("error", exitErr).Str("stderr", stderr.String()).Msgf("error running scorecard scan")
+		}
+		return fmt.Errorf("running scorecard scan: %w", err)
+	}
+
+	var tx pgx.Tx
+	if tx, err = w.pool.BeginTx(ctx, pgx.TxOptions{}); err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			if !errors.Is(err, pgx.ErrTxClosed) {
+				w.logger.Err(err).Msgf("could not rollback transaction")
+			}
+		}
+	}()
+
+	r, err := tx.Exec(ctx, "DELETE FROM public.ossf_scorecard_repo_scans WHERE repo_id = $1;", j.RepoID.String())
+	if err != nil {
+		return fmt.Errorf("exec delete: %w", err)
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("removed %d row(s) from ossf_scorecard_repo_scans", r.RowsAffected()),
+	}}); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(ctx, "INSERT INTO public.ossf_scorecard_repo_scans (repo_id, results) VALUES ($1, $2)", j.RepoID, stdout.Bytes()); err != nil {
+		return fmt.Errorf("inserting scorecard results: %w", err)
+	}
+
+	l.Info().Msg("inserted scorecard scan results")
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         "inserted scorecard scan results into ossf_scorecard_repo_scans",
+	}}); err != nil {
+		return err
+	}
+
+	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
+		return fmt.Errorf("update status done: %w", err)
+	}
+
+	// indicate that we're finishing query execution
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -39,6 +39,7 @@ const (
 	syncTypeGitleaksRepoScan          = "GITLEAKS_REPO_SCAN"
 	syncTypeYelpDetectSecretsRepoScan = "YELP_DETECT_SECRETS_REPO_SCAN"
 	syncTypeGosecRepoScan             = "GOSEC_REPO_SCAN"
+	syncTypeOSSFScorecardRepoScan     = "OSSF_SCORECARD_REPO_SCAN"
 )
 
 type worker struct {
@@ -185,6 +186,8 @@ func (w *worker) handle(ctx context.Context, j *db.DequeueSyncJobRow) error {
 		return w.handleYelpDetectSecretsRepoScan(ctx, j)
 	case syncTypeGosecRepoScan:
 		return w.handleGosecRepoScan(ctx, j)
+	case syncTypeOSSFScorecardRepoScan:
+		return w.handleOSSFScorecardScan(ctx, j)
 	default:
 		return fmt.Errorf("unknown sync type: %s for job ID: %d", j.SyncType, j.ID)
 	}

--- a/migrations/900000000000021_ossf_scorecard.up.sql
+++ b/migrations/900000000000021_ossf_scorecard.up.sql
@@ -33,7 +33,7 @@ SELECT
     c.value -> 'documentation' ->> 'url' AS documentation_url,
     c.value -> 'documentation' ->> 'short' AS documentation_short,
     c.value AS value
-FROM ossf_scorecard_repo_scans, jsonb_array_elements(results -> 'checks'); c -- noqa: L011
+FROM ossf_scorecard_repo_scans, jsonb_array_elements(results -> 'checks') c; -- noqa: L011
 
 COMMENT ON VIEW ossf_scorecard_repo_check_results IS 'view of OSSF scorecard scan check results';
 COMMENT ON COLUMN ossf_scorecard_repo_check_results.repo_id IS 'foreign key for public.repos.id';

--- a/migrations/900000000000021_ossf_scorecard.up.sql
+++ b/migrations/900000000000021_ossf_scorecard.up.sql
@@ -1,0 +1,48 @@
+BEGIN;
+
+INSERT INTO mergestat.repo_sync_types (type, description, short_name, priority, type_group)
+VALUES ('OSSF_SCORECARD_REPO_SCAN', 'Executes an OSSF scorecard scan on a git repository', 'OSSF Scorecard Repo Scan', 3, 'GITHUB') ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS ossf_scorecard_repo_scans (repo_id uuid PRIMARY KEY, results jsonb NOT NULL);
+
+CREATE OR REPLACE VIEW ossf_scorecard_repo_scores AS
+SELECT
+    ossf_scorecard_repo_scans.repo_id,
+    ossf_scorecard_repo_scans.results -> 'repo' ->> 'name' AS repo,
+    ossf_scorecard_repo_scans.results -> 'repo' ->> 'commit' AS commit,
+    ossf_scorecard_repo_scans.results ->> 'date' AS date,
+    ossf_scorecard_repo_scans.results ->> 'score' AS score,
+    ossf_scorecard_repo_scans.results -> 'scorecard' -> 'version' AS scorecard_version
+FROM ossf_scorecard_repo_scans;
+
+COMMENT ON VIEW ossf_scorecard_repo_scores IS 'view of OSSF scorecard scan result scores';
+COMMENT ON COLUMN ossf_scorecard_repo_scores.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN ossf_scorecard_repo_scores.repo IS 'URL to repo scan was run on';
+COMMENT ON COLUMN ossf_scorecard_repo_scores.commit IS 'commit of repo that the scan was run on';
+COMMENT ON COLUMN ossf_scorecard_repo_scores.date IS 'date of the scan';
+COMMENT ON COLUMN ossf_scorecard_repo_scores.score IS 'resulting total score of the scan';
+COMMENT ON COLUMN ossf_scorecard_repo_scores.scorecard_version IS 'scorecard version used to run the scan';
+
+CREATE OR REPLACE VIEW ossf_scorecard_repo_check_results AS
+SELECT
+    ossf_scorecard_repo_scans.repo_id,
+    c.value ->> 'name' AS name,
+    c.value ->> 'score' AS score,
+    c.value ->> 'reason' AS reason,
+    c.value ->> 'details' AS details,
+    c.value -> 'documentation' ->> 'url' AS documentation_url,
+    c.value -> 'documentation' ->> 'short' AS documentation_short,
+    c.value AS value
+FROM ossf_scorecard_repo_scans, jsonb_array_elements(results -> 'checks'); c -- noqa: L011
+
+COMMENT ON VIEW ossf_scorecard_repo_check_results IS 'view of OSSF scorecard scan check results';
+COMMENT ON COLUMN ossf_scorecard_repo_check_results.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN ossf_scorecard_repo_check_results.name IS 'name of the check in the scan run';
+COMMENT ON COLUMN ossf_scorecard_repo_check_results.score IS 'score of the check in the scan run';
+COMMENT ON COLUMN ossf_scorecard_repo_check_results.reason IS 'reason for the score of the check in the scan run';
+COMMENT ON COLUMN ossf_scorecard_repo_check_results.details IS 'details of the check in the scan run';
+COMMENT ON COLUMN ossf_scorecard_repo_check_results.documentation_url IS 'URL to the documentation of the check in the scan run';
+COMMENT ON COLUMN ossf_scorecard_repo_check_results.documentation_short IS 'description of the check in the scan run';
+COMMENT ON COLUMN ossf_scorecard_repo_check_results.value IS 'JSON of the check results in the scan run';
+
+COMMIT;

--- a/migrations/900000000000021_ossf_scorecard.up.sql
+++ b/migrations/900000000000021_ossf_scorecard.up.sql
@@ -3,7 +3,16 @@ BEGIN;
 INSERT INTO mergestat.repo_sync_types (type, description, short_name, priority, type_group)
 VALUES ('OSSF_SCORECARD_REPO_SCAN', 'Executes an OSSF scorecard scan on a git repository', 'OSSF Scorecard Repo Scan', 3, 'GITHUB') ON CONFLICT DO NOTHING;
 
-CREATE TABLE IF NOT EXISTS ossf_scorecard_repo_scans (repo_id uuid PRIMARY KEY, results jsonb NOT NULL);
+CREATE TABLE IF NOT EXISTS ossf_scorecard_repo_scans (
+    repo_id uuid PRIMARY KEY REFERENCES repos(id) ON DELETE CASCADE ON UPDATE RESTRICT,
+    results jsonb NOT NULL,
+    _mergestat_synced_at timestamp with time zone NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.ossf_scorecard_repo_scans IS 'Output of OSSF scorecard scans on a git repository';
+COMMENT ON COLUMN ossf_scorecard_repo_scores.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN ossf_scorecard_repo_scores.results IS 'JSON results of the scan';
+COMMENT ON COLUMN ossf_scorecard_repo_scores._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
 
 CREATE OR REPLACE VIEW ossf_scorecard_repo_scores AS
 SELECT

--- a/migrations/900000000000021_ossf_scorecard.up.sql
+++ b/migrations/900000000000021_ossf_scorecard.up.sql
@@ -10,9 +10,9 @@ CREATE TABLE IF NOT EXISTS ossf_scorecard_repo_scans (
 );
 
 COMMENT ON TABLE public.ossf_scorecard_repo_scans IS 'Output of OSSF scorecard scans on a git repository';
-COMMENT ON COLUMN ossf_scorecard_repo_scores.repo_id IS 'foreign key for public.repos.id';
-COMMENT ON COLUMN ossf_scorecard_repo_scores.results IS 'JSON results of the scan';
-COMMENT ON COLUMN ossf_scorecard_repo_scores._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
+COMMENT ON COLUMN ossf_scorecard_repo_scans.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN ossf_scorecard_repo_scans.results IS 'JSON results of the scan';
+COMMENT ON COLUMN ossf_scorecard_repo_scans._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
 
 CREATE OR REPLACE VIEW ossf_scorecard_repo_scores AS
 SELECT


### PR DESCRIPTION
more context can be found here: https://github.com/ossf/scorecard. Produces a score for a repo, stores the results as JSON in the DB, and creates some views for easier consumption of the data.