### PR TITLE
fix: run `sqlc generate` as a part of CI for the worker

### DIFF
--- a/.github/workflows/ci-worker.yaml
+++ b/.github/workflows/ci-worker.yaml
@@ -26,6 +26,12 @@ jobs:
       - name: Test
         run: make test
 
+      - name: Run sqlc
+        # TODO(patrickdevivo) we should probably pin the sqlc version elsewhere (https://marcofranssen.nl/manage-go-tools-via-go-modules)
+        run: |
+          go install github.com/kyleconroy/sqlc/cmd/sqlc@v1.16.0
+          sqlc generate
+
       - name: Lint
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.47.3

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -11,7 +11,7 @@ templater = raw
 # Comma separated list of rules to check, default to all
 rules = all
 # Comma separated list of rules to exclude, or None
-exclude_rules = L016,L044,L006,L028,L014,L025,L010,L029,L027,L030,L022,L034,L026
+exclude_rules = L016,L044,L006,L028,L014,L025,L010,L029,L027,L030,L022,L034,L026,L031
 # The depth to recursively parse to (0 for unlimited)
 recurse = 0
 # Below controls SQLFluff output, see max_line_length for SQL output

--- a/migrations/900000000000014_add_schema_introspection_view.up.sql
+++ b/migrations/900000000000014_add_schema_introspection_view.up.sql
@@ -5,18 +5,18 @@ BEGIN;
 -- This is useful for the schema introspection feature in the UI.
 CREATE OR REPLACE VIEW mergestat.schema_introspection AS (
     SELECT
-        information_schema.tables.table_schema AS schema,
-        information_schema.tables.table_name,
-        information_schema.tables.table_type,
-        information_schema.columns.column_name,
-        information_schema.columns.ordinal_position,
-        information_schema.columns.is_nullable,
-        information_schema.columns.data_type,
-        information_schema.columns.udt_name,
-        pg_catalog.col_description(format('%s.%s', information_schema.columns.table_schema, information_schema.columns.table_name)::regclass::oid, information_schema.columns.ordinal_position) as column_description
-    FROM information_schema.tables
-    INNER JOIN information_schema.columns ON (information_schema.tables.table_name = information_schema.columns.table_name AND information_schema.tables.table_schema = information_schema.columns.table_schema)
-    WHERE information_schema.tables.table_schema IN ('public', 'mergestat')
+        t.table_schema AS schema,
+        t.table_name,
+        t.table_type,
+        c.column_name,
+        c.ordinal_position,
+        c.is_nullable,
+        c.data_type,
+        c.udt_name,
+        pg_catalog.col_description(format('%s.%s', c.table_schema, c.table_name)::regclass::oid, c.ordinal_position) as column_description
+    FROM information_schema.tables as t
+    INNER JOIN information_schema.columns AS c ON (t.table_name = c.table_name AND t.table_schema = c.table_schema)
+    WHERE t.table_schema IN ('public', 'mergestat')
 );
 
 COMMIT;

--- a/migrations/900000000000021_ossf_scorecard.up.sql
+++ b/migrations/900000000000021_ossf_scorecard.up.sql
@@ -41,7 +41,7 @@ SELECT
     c.value ->> 'details' AS details,
     c.value -> 'documentation' ->> 'url' AS documentation_url,
     c.value -> 'documentation' ->> 'short' AS documentation_short,
-    c.value AS value
+    c.value::jsonb AS value
 FROM ossf_scorecard_repo_scans, jsonb_array_elements(results -> 'checks') c; -- noqa: L011
 
 COMMENT ON VIEW ossf_scorecard_repo_check_results IS 'view of OSSF scorecard scan check results';


### PR DESCRIPTION
the intent is to catch migrations that break `sqlc` early on. Closes #758 