### PR TITLE
fix: bump up the default `jest` timeout in the UI tests

### DIFF
--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -2,6 +2,7 @@ const nextJest = require('next/jest')
 
 const createJestConfig = nextJest({
   dir: './',
+  testTimeout: 20000,
 })
 
 const customJestConfig = {


### PR DESCRIPTION
Hopefully this will give some breathing room to our current UI tests that are right on the cusp of the default 5000ms timeout. This won't catch all of our flaky tests, but hopefully will address the ones that are caused by timeouts. Closes #615

@german-mergestat what do you think?