### PR TITLE
Fix broken migration for gosec_repo_scans

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,8 @@ services:
   worker:
     # NOTE: to opt out of basic image pull tracking, comment out the current image
     # and uncomment the next line (which will pull from Docker Hub directly).
-    # image: mergestat/worker:1.12.0-beta
-    image: images.mergestat.com/mergestat/worker:1.12.0-beta
+    # image: mergestat/worker:1.13.0-beta
+    image: images.mergestat.com/mergestat/worker:1.13.0-beta
     stop_grace_period: 10m
     restart: always
     depends_on:
@@ -50,8 +50,8 @@ services:
 
   graphql:
     # See NOTE above in worker service.
-    # image: mergestat/graphql:1.12.0-beta
-    image: images.mergestat.com/mergestat/graphql:1.12.0-beta
+    # image: mergestat/graphql:1.13.0-beta
+    image: images.mergestat.com/mergestat/graphql:1.13.0-beta
     restart: always
     depends_on:
       postgres:
@@ -94,8 +94,8 @@ services:
 
   ui:
     # See NOTE above in worker service.
-    # image: mergestat/console:1.12.0-beta
-    image: images.mergestat.com/mergestat/console:1.12.0-beta
+    # image: mergestat/console:1.13.0-beta
+    image: images.mergestat.com/mergestat/console:1.13.0-beta
     restart: always
     depends_on:
       - graphql

--- a/migrations/900000000000022_fix_gosec_table.up.sql
+++ b/migrations/900000000000022_fix_gosec_table.up.sql
@@ -6,6 +6,9 @@ ADD COLUMN IF NOT EXISTS _mergestat_synced_at timestamp with time zone DEFAULT n
 ALTER TABLE IF EXISTS public.gosec_repo_scans
 DROP CONSTRAINT IF EXISTS gosec_repo_scans_repo_id_fkey;
 
+--Delete any orphaned records
+DELETE FROM public.gosec_repo_scans WHERE repo_id NOT IN (SELECT id FROM public.repos);
+
 ALTER TABLE IF EXISTS public.gosec_repo_scans
 ADD CONSTRAINT gosec_repo_scans_repo_id_fkey
 FOREIGN KEY (repo_id) REFERENCES public.repos(id) ON UPDATE RESTRICT ON DELETE CASCADE;


### PR DESCRIPTION
This resolves #772 and bumps the version to 1.13.0-beta