### PR TITLE
fix(syncer): Failing syncs when pat is not present

### DIFF
--- a/internal/syncer/github_actions.go
+++ b/internal/syncer/github_actions.go
@@ -27,6 +27,10 @@ func (w *worker) handleGithubActions(ctx context.Context, j *db.DequeueSyncJobRo
 		return err
 	}
 
+	if len(ghToken) <= 0 {
+		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+	}
+
 	if err := warehouse.New(ctx, w.db, w.pool, l, ghToken).GitHubActions(ctx, j); err != nil {
 		return err
 	}

--- a/internal/syncer/github_actions.go
+++ b/internal/syncer/github_actions.go
@@ -28,7 +28,7 @@ func (w *worker) handleGithubActions(ctx context.Context, j *db.DequeueSyncJobRo
 	}
 
 	if len(ghToken) <= 0 {
-		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+		return ErrGitHubTokenRequired
 	}
 
 	if err := warehouse.New(ctx, w.db, w.pool, l, ghToken).GitHubActions(ctx, j); err != nil {

--- a/internal/syncer/github_actions.go
+++ b/internal/syncer/github_actions.go
@@ -28,7 +28,7 @@ func (w *worker) handleGithubActions(ctx context.Context, j *db.DequeueSyncJobRo
 	}
 
 	if len(ghToken) <= 0 {
-		return ErrGitHubTokenRequired
+		return errGitHubTokenRequired
 	}
 
 	if err := warehouse.New(ctx, w.db, w.pool, l, ghToken).GitHubActions(ctx, j); err != nil {

--- a/internal/syncer/github_pr_commits.go
+++ b/internal/syncer/github_pr_commits.go
@@ -94,7 +94,7 @@ func (w *worker) handleGitHubPRCommits(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	if len(ghToken) <= 0 {
-		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+		return ErrGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_pr_commits.go
+++ b/internal/syncer/github_pr_commits.go
@@ -94,7 +94,7 @@ func (w *worker) handleGitHubPRCommits(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	if len(ghToken) <= 0 {
-		return ErrGitHubTokenRequired
+		return errGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_pr_reviews.go
+++ b/internal/syncer/github_pr_reviews.go
@@ -105,7 +105,7 @@ func (w *worker) handleGitHubPRReviews(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	if len(ghToken) <= 0 {
-		return ErrGitHubTokenRequired
+		return errGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_pr_reviews.go
+++ b/internal/syncer/github_pr_reviews.go
@@ -105,7 +105,7 @@ func (w *worker) handleGitHubPRReviews(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	if len(ghToken) <= 0 {
-		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+		return ErrGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_pr_reviews.go
+++ b/internal/syncer/github_pr_reviews.go
@@ -89,6 +89,8 @@ func (w *worker) sendBatchGitHubPRReviews(ctx context.Context, tx pgx.Tx, repo u
 }
 
 func (w *worker) handleGitHubPRReviews(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	var ghToken string
+	var err error
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
@@ -96,6 +98,14 @@ func (w *worker) handleGitHubPRReviews(ctx context.Context, j *db.DequeueSyncJob
 		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
 	}}); err != nil {
 		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	if len(ghToken) <= 0 {
+		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_issues.go
+++ b/internal/syncer/github_repo_issues.go
@@ -116,6 +116,8 @@ func (w *worker) sendBatchGitHubRepoIssues(ctx context.Context, tx pgx.Tx, repo 
 }
 
 func (w *worker) handleGitHubRepoIssues(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	var ghToken string
+	var err error
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
@@ -123,6 +125,14 @@ func (w *worker) handleGitHubRepoIssues(ctx context.Context, j *db.DequeueSyncJo
 		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
 	}}); err != nil {
 		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	if len(ghToken) <= 0 {
+		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_issues.go
+++ b/internal/syncer/github_repo_issues.go
@@ -132,7 +132,7 @@ func (w *worker) handleGitHubRepoIssues(ctx context.Context, j *db.DequeueSyncJo
 	}
 
 	if len(ghToken) <= 0 {
-		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+		return ErrGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_issues.go
+++ b/internal/syncer/github_repo_issues.go
@@ -132,7 +132,7 @@ func (w *worker) handleGitHubRepoIssues(ctx context.Context, j *db.DequeueSyncJo
 	}
 
 	if len(ghToken) <= 0 {
-		return ErrGitHubTokenRequired
+		return errGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_metadata.go
+++ b/internal/syncer/github_repo_metadata.go
@@ -66,7 +66,7 @@ func (w *worker) handleGitHubRepoMetadata(ctx context.Context, j *db.DequeueSync
 	}
 
 	if len(ghToken) <= 0 {
-		return ErrGitHubTokenRequired
+		return errGitHubTokenRequired
 	}
 
 	var u *url.URL

--- a/internal/syncer/github_repo_metadata.go
+++ b/internal/syncer/github_repo_metadata.go
@@ -66,7 +66,7 @@ func (w *worker) handleGitHubRepoMetadata(ctx context.Context, j *db.DequeueSync
 	}
 
 	if len(ghToken) <= 0 {
-		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+		return ErrGitHubTokenRequired
 	}
 
 	var u *url.URL

--- a/internal/syncer/github_repo_prs.go
+++ b/internal/syncer/github_repo_prs.go
@@ -183,7 +183,7 @@ func (w *worker) handleGitHubRepoPRs(ctx context.Context, j *db.DequeueSyncJobRo
 	}
 
 	if len(ghToken) <= 0 {
-		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+		return ErrGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_prs.go
+++ b/internal/syncer/github_repo_prs.go
@@ -183,7 +183,7 @@ func (w *worker) handleGitHubRepoPRs(ctx context.Context, j *db.DequeueSyncJobRo
 	}
 
 	if len(ghToken) <= 0 {
-		return ErrGitHubTokenRequired
+		return errGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_prs.go
+++ b/internal/syncer/github_repo_prs.go
@@ -167,6 +167,8 @@ func (w *worker) sendBatchGitHubRepoPRs(ctx context.Context, tx pgx.Tx, repo uui
 }
 
 func (w *worker) handleGitHubRepoPRs(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	var ghToken string
+	var err error
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
@@ -174,6 +176,14 @@ func (w *worker) handleGitHubRepoPRs(ctx context.Context, j *db.DequeueSyncJobRo
 		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
 	}}); err != nil {
 		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	if len(ghToken) <= 0 {
+		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_stars.go
+++ b/internal/syncer/github_repo_stars.go
@@ -75,6 +75,8 @@ func (w *worker) sendBatchGitHubRepoStars(ctx context.Context, tx pgx.Tx, repo u
 }
 
 func (w *worker) handleGitHubRepoStars(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	var ghToken string
+	var err error
 	l := w.loggerForJob(j)
 
 	// indicate that we're starting query execution
@@ -82,6 +84,14 @@ func (w *worker) handleGitHubRepoStars(ctx context.Context, j *db.DequeueSyncJob
 		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
 	}}); err != nil {
 		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	if ghToken, err = w.fetchGitHubTokenFromDB(ctx); err != nil {
+		return err
+	}
+
+	if len(ghToken) <= 0 {
+		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_stars.go
+++ b/internal/syncer/github_repo_stars.go
@@ -91,7 +91,7 @@ func (w *worker) handleGitHubRepoStars(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	if len(ghToken) <= 0 {
-		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+		return ErrGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/github_repo_stars.go
+++ b/internal/syncer/github_repo_stars.go
@@ -91,7 +91,7 @@ func (w *worker) handleGitHubRepoStars(ctx context.Context, j *db.DequeueSyncJob
 	}
 
 	if len(ghToken) <= 0 {
-		return ErrGitHubTokenRequired
+		return errGitHubTokenRequired
 	}
 
 	id, err := uuid.FromString(j.RepoID.String())

--- a/internal/syncer/ossf_scorecard_scan.go
+++ b/internal/syncer/ossf_scorecard_scan.go
@@ -23,7 +23,7 @@ func (w *worker) handleOSSFScorecardScan(ctx context.Context, j *db.DequeueSyncJ
 	}
 
 	if len(ghToken) <= 0 {
-		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+		return ErrGitHubTokenRequired
 	}
 	// indicate that we're starting a scorecard scan
 	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,

--- a/internal/syncer/ossf_scorecard_scan.go
+++ b/internal/syncer/ossf_scorecard_scan.go
@@ -23,7 +23,7 @@ func (w *worker) handleOSSFScorecardScan(ctx context.Context, j *db.DequeueSyncJ
 	}
 
 	if len(ghToken) <= 0 {
-		return ErrGitHubTokenRequired
+		return errGitHubTokenRequired
 	}
 	// indicate that we're starting a scorecard scan
 	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,

--- a/internal/syncer/ossf_scorecard_scan.go
+++ b/internal/syncer/ossf_scorecard_scan.go
@@ -22,6 +22,9 @@ func (w *worker) handleOSSFScorecardScan(ctx context.Context, j *db.DequeueSyncJ
 		return err
 	}
 
+	if len(ghToken) <= 0 {
+		return fmt.Errorf("in order to run this syncer, a GitHub authentication token must be present")
+	}
 	// indicate that we're starting a scorecard scan
 	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
 		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -42,7 +42,7 @@ const (
 	syncTypeOSSFScorecardRepoScan     = "OSSF_SCORECARD_REPO_SCAN"
 )
 
-var noGitHubTokenError = errors.New("in order to run this syncer, a GitHub authentication token must be present")
+var errGitHubTokenRequired = errors.New("in order to run this syncer, a GitHub authentication token must be present")
 
 type worker struct {
 	logger       *zerolog.Logger

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -42,6 +42,8 @@ const (
 	syncTypeOSSFScorecardRepoScan     = "OSSF_SCORECARD_REPO_SCAN"
 )
 
+var noGitHubTokenError = errors.New("in order to run this syncer, a GitHub authentication token must be present")
+
 type worker struct {
 	logger       *zerolog.Logger
 	pool         *pgxpool.Pool


### PR DESCRIPTION
This resolves the issue of this syncs running indefinitely without returning any error to the user 
Syncs affected are GITHUB_ACTIONS and OSSF_SCORECARD_REPO_SCAN
Closes #776 