### PR TITLE
feat: implement `GIT_REMOTES` repo syncer

### DIFF
--- a/internal/syncer/git_remotes.go
+++ b/internal/syncer/git_remotes.go
@@ -1,0 +1,102 @@
+package syncer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v4"
+	libgit2 "github.com/libgit2/git2go/v33"
+	"github.com/mergestat/mergestat/internal/db"
+)
+
+func (w *worker) handleGitRemotes(ctx context.Context, j *db.DequeueSyncJobRow) error {
+	var err error
+	l := w.loggerForJob(j)
+
+	// indicate that we're starting query execution
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatStartingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	var repo *libgit2.Repository
+	if repo, err = libgit2.OpenRepository(j.Repo); err != nil {
+		return fmt.Errorf("could not open repository: %w", err)
+	}
+	defer repo.Free()
+
+	var remotes []string
+	if remotes, err = repo.Remotes.List(); err != nil {
+		return fmt.Errorf("could not list remotes of repo: %w", err)
+	}
+
+	var tx pgx.Tx
+	if tx, err = w.pool.BeginTx(ctx, pgx.TxOptions{}); err != nil {
+		return err
+	}
+	defer func() {
+		if err := tx.Rollback(ctx); err != nil {
+			if !errors.Is(err, pgx.ErrTxClosed) {
+				w.logger.Err(err).Msgf("could not rollback transaction")
+			}
+		}
+	}()
+
+	r, err := tx.Exec(ctx, "DELETE FROM git_remotes WHERE repo_id = $1;", j.RepoID.String())
+	if err != nil {
+		return err
+	}
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("removed %d row(s) from git_remotes", r.RowsAffected()),
+	}}); err != nil {
+		return err
+	}
+
+	for _, rem := range remotes {
+		if err := func() error {
+			var r *libgit2.Remote
+			if r, err = repo.Remotes.Lookup(rem); err != nil {
+				return fmt.Errorf("could not lookup remote in repo: %w", err)
+			}
+			defer r.Free()
+
+			if _, err = tx.Exec(ctx, "INSERT INTO git_remotes (repo_id, name, url) VALUES ($1, $2, $3);", j.RepoID, r.Name(), r.Url()); err != nil {
+				return fmt.Errorf("could not insert remote into database: %w", err)
+			}
+
+			return nil
+		}(); err != nil {
+			return err
+		}
+	}
+
+	l.Info().Msgf("sent batch of %d remotes", len(remotes))
+
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{
+		Type:            SyncLogTypeInfo,
+		RepoSyncQueueID: j.ID,
+		Message:         fmt.Sprintf("inserted %d row(s) into git_remotes", len(remotes)),
+	}}); err != nil {
+		return err
+	}
+
+	if err := w.db.WithTx(tx).SetSyncJobStatus(ctx, db.SetSyncJobStatusParams{Status: "DONE", ID: j.ID}); err != nil {
+		return err
+	}
+
+	// indicate that we're finishing query execution
+	if err := w.sendBatchLogMessages(ctx, []*syncLog{{Type: SyncLogTypeInfo, RepoSyncQueueID: j.ID,
+		Message: fmt.Sprintf(LogFormatFinishingSync, j.SyncType, j.Repo),
+	}}); err != nil {
+		return fmt.Errorf("send batch log messages: %w", err)
+	}
+
+	err = tx.Commit(ctx)
+
+	return err
+}

--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -27,6 +27,7 @@ const (
 	syncTypeGitRefs                   = "GIT_REFS"
 	syncTypeGitFiles                  = "GIT_FILES"
 	syncTypeGitBlame                  = "GIT_BLAME"
+	syncTypeGitRemotes                = "GIT_REMOTES"
 	syncTypeGitHubRepoMetadata        = "GITHUB_REPO_METADATA"
 	syncTypeGitHubRepoPRs             = "GITHUB_REPO_PRS"
 	syncTypeGitHubRepoIssues          = "GITHUB_REPO_ISSUES"
@@ -165,6 +166,8 @@ func (w *worker) handle(ctx context.Context, j *db.DequeueSyncJobRow) error {
 		return w.handleGitRefs(ctx, j)
 	case syncTypeGitBlame:
 		return w.handleGitBlame(ctx, j)
+	case syncTypeGitRemotes:
+		return w.handleGitRemotes(ctx, j)
 	case syncTypeGitHubRepoMetadata:
 		return w.handleGitHubRepoMetadata(ctx, j)
 	case syncTypeGitHubRepoPRs:

--- a/migrations/900000000000024_git_remotes_syncer.up.sql
+++ b/migrations/900000000000024_git_remotes_syncer.up.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS git_remotes (
     repo_id uuid PRIMARY KEY,
     name text NOT NULL,
     url text NOT NULL,
-    _mergestat_synced_at timestamptz NOT NULL DEFAULT now()
+    _mergestat_synced_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 COMMENT ON TABLE git_remotes IS 'table of git repo remotes';

--- a/migrations/900000000000024_git_remotes_syncer.up.sql
+++ b/migrations/900000000000024_git_remotes_syncer.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+INSERT INTO mergestat.repo_sync_types (type, description, short_name) VALUES ('GIT_REMOTES', 'Retrieves the remotes of a git repo. Only relevant for local, on-disk repos.', 'Git Remotes') ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS git_remotes (
+    repo_id uuid PRIMARY KEY,
+    name text NOT NULL,
+    url text NOT NULL,
+    _mergestat_synced_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE git_remotes IS 'table of git repo remotes';
+COMMENT ON COLUMN git_remotes.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN git_remotes.name IS 'name of the remote';
+COMMENT ON COLUMN git_remotes.url IS 'url of the remote';
+COMMENT ON COLUMN git_remotes._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
+
+COMMIT;


### PR DESCRIPTION
Retrieves the remotes of a git repo. Only relevant for local, on-disk repos. Closes [#792](https://github.com/mergestat/mergestat/compare/feat/null/issues/792).

Errors on remote repos:
<img width="2048" alt="image" src="https://user-images.githubusercontent.com/57259/216505474-69522e2f-98bc-497d-bc8a-4333caab3fe1.png">

Works for local file path repos:
<img width="2048" alt="image" src="https://user-images.githubusercontent.com/57259/216505534-d64e1117-2c8f-4eca-a632-7bcb8e2c21b0.png">

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/57259/216505617-a2aed841-d310-4d7c-a1e3-cc28c3e1e80a.png">
