### PR TITLE
chore(migrations): Adding synced_at and comments on grype table

### DIFF
--- a/migrations/900000000000025_grype_synced_at.up.sql
+++ b/migrations/900000000000025_grype_synced_at.up.sql
@@ -6,6 +6,6 @@ ADD COLUMN _mergestat_synced_at timestamp with time zone DEFAULT now() NOT NULL;
 COMMENT ON TABLE public.grype_repo_scans IS 'Table for Grype repo scan results';
 COMMENT ON COLUMN grype_repo_scans.repo_id IS 'foreign key for public.repos.id';
 COMMENT ON COLUMN grype_repo_scans.results IS 'JSON results of Grype repo scanner';
-COMMENT ON COLUMN grype_repo_scans._mergestat_synced_at IS 'timestamp when record was synced into the Mergestat database';
+COMMENT ON COLUMN grype_repo_scans._mergestat_synced_at IS 'timestamp when record was synced into the MergeStat database';
 
 COMMIT;

--- a/migrations/900000000000025_grype_synced_at.up.sql
+++ b/migrations/900000000000025_grype_synced_at.up.sql
@@ -4,8 +4,8 @@ ALTER TABLE public.grype_repo_scans
 ADD COLUMN _mergestat_synced_at timestamp with time zone DEFAULT now() NOT NULL;
 
 COMMENT ON TABLE public.grype_repo_scans IS 'Table for Grype repo scan results';
-COMMENT ON COLUMN grype_repo_scans.repo_id IS 'ID of repository which grype was executed';
-COMMENT ON COLUMN grype_repo_scans.results IS 'Json result of Grype repo scanner';
-COMMENT ON COLUMN grype_repo_scans._mergestat_synced_at IS 'Time when syncer completed its execution';
+COMMENT ON COLUMN grype_repo_scans.repo_id IS 'foreign key for public.repos.id';
+COMMENT ON COLUMN grype_repo_scans.results IS 'JSON results of Grype repo scanner';
+COMMENT ON COLUMN grype_repo_scans._mergestat_synced_at IS 'timestamp when record was synced into the Mergestat database';
 
 COMMIT;

--- a/migrations/900000000000025_grype_synced_at.up.sql
+++ b/migrations/900000000000025_grype_synced_at.up.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+ALTER TABLE public.grype_repo_scans
+ADD COLUMN _mergestat_synced_at timestamp with time zone DEFAULT now() NOT NULL;
+
+COMMENT ON TABLE public.grype_repo_scans IS 'Table for Grype repo scan results';
+COMMENT ON COLUMN grype_repo_scans.repo_id IS 'ID of repository which grype was executed';
+COMMENT ON COLUMN grype_repo_scans.results IS 'Json result of Grype repo scanner';
+COMMENT ON COLUMN grype_repo_scans._mergestat_synced_at IS 'Time when syncer completed its execution';
+
+COMMIT;


### PR DESCRIPTION
Improvement with the new column synced_at and also comments on the columns and table 
Closes #793 