### PR TITLE
fix: add a migration to run `GRANT mergestat_anonymous TO mergestat_admin;`

### DIFF
--- a/migrations/900000000000027_init_role_perms_fix.up.sql
+++ b/migrations/900000000000027_init_role_perms_fix.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+GRANT mergestat_anonymous TO mergestat_admin;
+
+COMMIT;


### PR DESCRIPTION
By default, we often use the `mergestat_admin` user. This migration fixes an issue where that user does not have sufficient permissions to take on the `mergestat_anonymous` role, which is what PostGraphile uses by default for unauthenticated users.