### PR TITLE
feat(saved-queries): Starting implementation for Saved Queries

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.7.0",
         "@apollo/react-testing": "^4.0.0",
-        "@mergestat/blocks": "^1.5.42",
+        "@mergestat/blocks": "^1.5.43",
         "@mergestat/icons": "1.2.12",
         "@monaco-editor/react": "^4.4.6",
         "@next/bundle-analyzer": "^12.1.4",
@@ -3210,9 +3210,9 @@
       }
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.5.42",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.42.tgz",
-      "integrity": "sha512-riMpjafx594tT5hWk5tDmqJvW+gfpwa+dcblVZuixAMjWQ0q7wX3nlDQjeyYThSCvt0iKMJbRfcABg+/yF2ktw==",
+      "version": "1.5.43",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.43.tgz",
+      "integrity": "sha512-cCsB3vtDNitFwtHF/1DivdXU5Xi+EuKsg5EX5Nf6krG55lovBe0/43VvTX84e0hSNEjzAkITneTtbO4hD3Ax6w==",
       "dependencies": {
         "@floating-ui/react": "0.18.0",
         "@headlessui/react": "1.7.10",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.7.0",
         "@apollo/react-testing": "^4.0.0",
-        "@mergestat/blocks": "^1.5.39",
+        "@mergestat/blocks": "^1.5.41",
         "@mergestat/icons": "1.2.12",
         "@monaco-editor/react": "^4.4.6",
         "@next/bundle-analyzer": "^12.1.4",
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.7.tgz",
-      "integrity": "sha512-BqDOd/tB9u2tA0T3Z0fn18ktw+KbVwMnkxxsGPIH2hzssrQhKB5n/6StZOyvLYP/FsYtvuXfi9I0YowKPv2c1w==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.10.tgz",
+      "integrity": "sha512-1m66h/5eayTEZVT2PI13/2PG3EVC7a9XalmUtVSC8X76pcyKYMuyX1XAL2RUtCr8WhoMa/KrDEyoeU5v+kSQOw==",
       "dependencies": {
         "client-only": "^0.0.1"
       },
@@ -3210,12 +3210,12 @@
       }
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.5.39",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.39.tgz",
-      "integrity": "sha512-4qbNRhA03+UbG4CQSfBYJHLxFUT55QEMJDBOmcU1yD49GmEOj1XCQiSWrV85EA5h/epwUmgGKEBFZxRY3gBh8Q==",
+      "version": "1.5.41",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.41.tgz",
+      "integrity": "sha512-JtBgxsYFM3mIyga43uCwdkt3yo2TMzUlqdv3Y7W+V0/1ZpRsxapqVZ2yYUg3JcD/qUyK0367ClUxO2H6gvo1NA==",
       "dependencies": {
         "@floating-ui/react": "0.18.0",
-        "@headlessui/react": "1.7.7",
+        "@headlessui/react": "1.7.10",
         "@mergestat/icons": "1.2.12",
         "classnames": "2.3.2",
         "rc-notification": "4.6.1",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.7.0",
         "@apollo/react-testing": "^4.0.0",
-        "@mergestat/blocks": "^1.5.41",
+        "@mergestat/blocks": "^1.5.42",
         "@mergestat/icons": "1.2.12",
         "@monaco-editor/react": "^4.4.6",
         "@next/bundle-analyzer": "^12.1.4",
@@ -3210,9 +3210,9 @@
       }
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.5.41",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.41.tgz",
-      "integrity": "sha512-JtBgxsYFM3mIyga43uCwdkt3yo2TMzUlqdv3Y7W+V0/1ZpRsxapqVZ2yYUg3JcD/qUyK0367ClUxO2H6gvo1NA==",
+      "version": "1.5.42",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.42.tgz",
+      "integrity": "sha512-riMpjafx594tT5hWk5tDmqJvW+gfpwa+dcblVZuixAMjWQ0q7wX3nlDQjeyYThSCvt0iKMJbRfcABg+/yF2ktw==",
       "dependencies": {
         "@floating-ui/react": "0.18.0",
         "@headlessui/react": "1.7.10",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@apollo/client": "^3.7.0",
         "@apollo/react-testing": "^4.0.0",
-        "@mergestat/blocks": "^1.5.35",
-        "@mergestat/icons": "1.2.9",
+        "@mergestat/blocks": "^1.5.39",
+        "@mergestat/icons": "1.2.12",
         "@monaco-editor/react": "^4.4.6",
         "@next/bundle-analyzer": "^12.1.4",
         "@tailwindcss/line-clamp": "^0.4.2",
@@ -3210,13 +3210,13 @@
       }
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.5.35",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.35.tgz",
-      "integrity": "sha512-Qq3GfPy4x0Uv2R4rLLmrRzOf5oPwkTwx146oPreVpSToSzbQ+R+Ol84wIhD2W/BBTpOqb9LY3/9nmI2d3jclRA==",
+      "version": "1.5.39",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.39.tgz",
+      "integrity": "sha512-4qbNRhA03+UbG4CQSfBYJHLxFUT55QEMJDBOmcU1yD49GmEOj1XCQiSWrV85EA5h/epwUmgGKEBFZxRY3gBh8Q==",
       "dependencies": {
         "@floating-ui/react": "0.18.0",
         "@headlessui/react": "1.7.7",
-        "@mergestat/icons": "1.2.9",
+        "@mergestat/icons": "1.2.12",
         "classnames": "2.3.2",
         "rc-notification": "4.6.1",
         "react": "18.2.0",
@@ -3224,9 +3224,9 @@
       }
     },
     "node_modules/@mergestat/icons": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@mergestat/icons/-/icons-1.2.9.tgz",
-      "integrity": "sha512-VBX3J3LZu/TI2mx2m+VlN8Z7wHvcyU5y91CrRikJtNEg+nlxduZ27IWbmj3qQbwlCMSGgp6Sjq3VPPE1VXhcsw==",
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@mergestat/icons/-/icons-1.2.12.tgz",
+      "integrity": "sha512-MKTd7wT4VNqLT8cuNj7sMBksp8RBIM7On4sACYLtOyxV7yi8x7ppyieLXDzZ2dkezGSs46vWSAoyuhRPJw0dew==",
       "peerDependencies": {
         "classnames": "2.3.2",
         "react": "18.2.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@apollo/client": "^3.7.0",
     "@apollo/react-testing": "^4.0.0",
-    "@mergestat/blocks": "^1.5.35",
-    "@mergestat/icons": "1.2.9",
+    "@mergestat/blocks": "^1.5.39",
+    "@mergestat/icons": "1.2.12",
     "@monaco-editor/react": "^4.4.6",
     "@next/bundle-analyzer": "^12.1.4",
     "@tailwindcss/line-clamp": "^0.4.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.0",
     "@apollo/react-testing": "^4.0.0",
-    "@mergestat/blocks": "^1.5.39",
+    "@mergestat/blocks": "^1.5.41",
     "@mergestat/icons": "1.2.12",
     "@monaco-editor/react": "^4.4.6",
     "@next/bundle-analyzer": "^12.1.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.0",
     "@apollo/react-testing": "^4.0.0",
-    "@mergestat/blocks": "^1.5.41",
+    "@mergestat/blocks": "^1.5.42",
     "@mergestat/icons": "1.2.12",
     "@monaco-editor/react": "^4.4.6",
     "@next/bundle-analyzer": "^12.1.4",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.0",
     "@apollo/react-testing": "^4.0.0",
-    "@mergestat/blocks": "^1.5.42",
+    "@mergestat/blocks": "^1.5.43",
     "@mergestat/icons": "1.2.12",
     "@monaco-editor/react": "^4.4.6",
     "@next/bundle-analyzer": "^12.1.4",

--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -240,3 +240,13 @@ export interface ColumnInfo {
   name: string,
   format: string
 }
+
+/** Saved Queries */
+
+export type SavedQueryData = {
+  id: string;
+  createdAt?: string;
+  createdBy?: string | null | undefined;
+  name?: string | null | undefined;
+  description?: string | null | undefined;
+}

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -18008,6 +18008,28 @@ export type UpdateTagsMutationVariables = Exact<{
 
 export type UpdateTagsMutation = { updateRepo?: { repo?: { id: any, tags: any } | null } | null };
 
+export type AddSavedQueryMutationVariables = Exact<{
+  createdBy: Scalars['String'];
+  createdAt: Scalars['Datetime'];
+  name: Scalars['String'];
+  description: Scalars['String'];
+  sql: Scalars['String'];
+  metadata?: InputMaybe<Scalars['JSON']>;
+}>;
+
+
+export type AddSavedQueryMutation = { createSavedQuery?: { savedQuery?: { id: any, name?: string | null } | null } | null };
+
+export type UpdateSavedQueryMutationVariables = Exact<{
+  id: Scalars['UUID'];
+  name?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  sql?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type UpdateSavedQueryMutation = { updateSavedQuery?: { savedQuery?: { id: any, name?: string | null, description?: string | null, sql?: string | null } | null } | null };
+
 export type SetGithubPatMutationVariables = Exact<{
   pat: Scalars['String'];
 }>;
@@ -18102,6 +18124,13 @@ export type GetReposQueryVariables = Exact<{
 
 
 export type GetReposQuery = { serviceAuthCredentials?: { totalCount: number } | null, repoImports?: { totalCount: number, nodes: Array<{ id: any, type: string, settings: any, importError?: string | null }> } | null, repos?: { totalCount: number, nodes: Array<{ id: any, repo: string, createdAt: any, isGithub?: boolean | null, tags: any, repoImport?: { type: string, settings: any } | null, repoSyncs: { totalCount: number, nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string } | null, lastCompletedRepoSyncQueue?: { id: any, status: string, doneAt?: any | null, createdAt: any, hasError?: boolean | null, warnings: { totalCount: number } } | null }> } }> } | null };
+
+export type GetSavedQueryQueryVariables = Exact<{
+  id: Scalars['UUID'];
+}>;
+
+
+export type GetSavedQueryQuery = { savedQuery?: { createdAt?: any | null, createdBy?: string | null, name?: string | null, description?: string | null, sql?: string | null, metadata?: any | null } | null };
 
 export type GetSyncHistoryLogsQueryVariables = Exact<{
   repoId: Scalars['UUID'];

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -18030,6 +18030,13 @@ export type UpdateSavedQueryMutationVariables = Exact<{
 
 export type UpdateSavedQueryMutation = { updateSavedQuery?: { savedQuery?: { id: any, name?: string | null, description?: string | null, sql?: string | null } | null } | null };
 
+export type RemoveSavedQueryMutationVariables = Exact<{
+  id: Scalars['UUID'];
+}>;
+
+
+export type RemoveSavedQueryMutation = { deleteSavedQuery?: { deletedSavedQueryNodeId?: string | null } | null };
+
 export type SetGithubPatMutationVariables = Exact<{
   pat: Scalars['String'];
 }>;

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -18125,6 +18125,15 @@ export type GetReposQueryVariables = Exact<{
 
 export type GetReposQuery = { serviceAuthCredentials?: { totalCount: number } | null, repoImports?: { totalCount: number, nodes: Array<{ id: any, type: string, settings: any, importError?: string | null }> } | null, repos?: { totalCount: number, nodes: Array<{ id: any, repo: string, createdAt: any, isGithub?: boolean | null, tags: any, repoImport?: { type: string, settings: any } | null, repoSyncs: { totalCount: number, nodes: Array<{ id: any, syncType: string, repoSyncTypeBySyncType?: { shortName: string } | null, lastCompletedRepoSyncQueue?: { id: any, status: string, doneAt?: any | null, createdAt: any, hasError?: boolean | null, warnings: { totalCount: number } } | null }> } }> } | null };
 
+export type GetSavedQueryListQueryVariables = Exact<{
+  search: Scalars['String'];
+  first?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+}>;
+
+
+export type GetSavedQueryListQuery = { all?: { totalCount: number } | null, savedQueries?: { totalCount: number, nodes: Array<{ id: any, createdAt?: any | null, createdBy?: string | null, name?: string | null, description?: string | null }> } | null };
+
 export type GetSavedQueryQueryVariables = Exact<{
   id: Scalars['UUID'];
 }>;

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -413,6 +413,38 @@ export type CreateGitRefPayloadGitRefEdgeArgs = {
   orderBy?: InputMaybe<Array<GitRefsOrderBy>>;
 };
 
+/** All input for the create `GitRemote` mutation. */
+export type CreateGitRemoteInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The `GitRemote` to be created by this mutation. */
+  gitRemote: GitRemoteInput;
+};
+
+/** The output of our create `GitRemote` mutation. */
+export type CreateGitRemotePayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `GitRemote` that was created by this mutation. */
+  gitRemote?: Maybe<GitRemote>;
+  /** An edge for our `GitRemote`. May be used by Relay 1. */
+  gitRemoteEdge?: Maybe<GitRemotesEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our create `GitRemote` mutation. */
+export type CreateGitRemotePayloadGitRemoteEdgeArgs = {
+  orderBy?: InputMaybe<Array<GitRemotesOrderBy>>;
+};
+
 /** All input for the create `GitTag` mutation. */
 export type CreateGitTagInput = {
   /**
@@ -815,6 +847,38 @@ export type CreateGosecRepoScanPayload = {
 /** The output of our create `GosecRepoScan` mutation. */
 export type CreateGosecRepoScanPayloadGosecRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GosecRepoScansOrderBy>>;
+};
+
+/** All input for the create `GrypeRepoScan` mutation. */
+export type CreateGrypeRepoScanInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The `GrypeRepoScan` to be created by this mutation. */
+  grypeRepoScan: GrypeRepoScanInput;
+};
+
+/** The output of our create `GrypeRepoScan` mutation. */
+export type CreateGrypeRepoScanPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `GrypeRepoScan` that was created by this mutation. */
+  grypeRepoScan?: Maybe<GrypeRepoScan>;
+  /** An edge for our `GrypeRepoScan`. May be used by Relay 1. */
+  grypeRepoScanEdge?: Maybe<GrypeRepoScansEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our create `GrypeRepoScan` mutation. */
+export type CreateGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
+  orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
 /** All input for the create `LabelAssociation` mutation. */
@@ -1323,6 +1387,38 @@ export type CreateRepoSyncTypePayload = {
 /** The output of our create `RepoSyncType` mutation. */
 export type CreateRepoSyncTypePayloadRepoSyncTypeEdgeArgs = {
   orderBy?: InputMaybe<Array<RepoSyncTypesOrderBy>>;
+};
+
+/** All input for the create `SavedQuery` mutation. */
+export type CreateSavedQueryInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The `SavedQuery` to be created by this mutation. */
+  savedQuery: SavedQueryInput;
+};
+
+/** The output of our create `SavedQuery` mutation. */
+export type CreateSavedQueryPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** The `SavedQuery` that was created by this mutation. */
+  savedQuery?: Maybe<SavedQuery>;
+  /** An edge for our `SavedQuery`. May be used by Relay 1. */
+  savedQueryEdge?: Maybe<SavedQueriesEdge>;
+};
+
+
+/** The output of our create `SavedQuery` mutation. */
+export type CreateSavedQueryPayloadSavedQueryEdgeArgs = {
+  orderBy?: InputMaybe<Array<SavedQueriesOrderBy>>;
 };
 
 /** All input for the create `SchemaMigration` mutation. */
@@ -1854,6 +1950,50 @@ export type DeleteGitRefPayload = {
 /** The output of our delete `GitRef` mutation. */
 export type DeleteGitRefPayloadGitRefEdgeArgs = {
   orderBy?: InputMaybe<Array<GitRefsOrderBy>>;
+};
+
+/** All input for the `deleteGitRemoteByNodeId` mutation. */
+export type DeleteGitRemoteByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `GitRemote` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** All input for the `deleteGitRemote` mutation. */
+export type DeleteGitRemoteInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+};
+
+/** The output of our delete `GitRemote` mutation. */
+export type DeleteGitRemotePayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  deletedGitRemoteNodeId?: Maybe<Scalars['ID']>;
+  /** The `GitRemote` that was deleted by this mutation. */
+  gitRemote?: Maybe<GitRemote>;
+  /** An edge for our `GitRemote`. May be used by Relay 1. */
+  gitRemoteEdge?: Maybe<GitRemotesEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our delete `GitRemote` mutation. */
+export type DeleteGitRemotePayloadGitRemoteEdgeArgs = {
+  orderBy?: InputMaybe<Array<GitRemotesOrderBy>>;
 };
 
 /** All input for the `deleteGithubActionsWorkflowById` mutation. */
@@ -2413,6 +2553,50 @@ export type DeleteGosecRepoScanPayload = {
 /** The output of our delete `GosecRepoScan` mutation. */
 export type DeleteGosecRepoScanPayloadGosecRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GosecRepoScansOrderBy>>;
+};
+
+/** All input for the `deleteGrypeRepoScanByNodeId` mutation. */
+export type DeleteGrypeRepoScanByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `GrypeRepoScan` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** All input for the `deleteGrypeRepoScan` mutation. */
+export type DeleteGrypeRepoScanInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+};
+
+/** The output of our delete `GrypeRepoScan` mutation. */
+export type DeleteGrypeRepoScanPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  deletedGrypeRepoScanNodeId?: Maybe<Scalars['ID']>;
+  /** The `GrypeRepoScan` that was deleted by this mutation. */
+  grypeRepoScan?: Maybe<GrypeRepoScan>;
+  /** An edge for our `GrypeRepoScan`. May be used by Relay 1. */
+  grypeRepoScanEdge?: Maybe<GrypeRepoScansEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our delete `GrypeRepoScan` mutation. */
+export type DeleteGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
+  orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
 /** All input for the `deleteLabelAssociationByLabelAndRepoSyncType` mutation. */
@@ -3046,6 +3230,49 @@ export type DeleteRepoSyncTypePayload = {
 /** The output of our delete `RepoSyncType` mutation. */
 export type DeleteRepoSyncTypePayloadRepoSyncTypeEdgeArgs = {
   orderBy?: InputMaybe<Array<RepoSyncTypesOrderBy>>;
+};
+
+/** All input for the `deleteSavedQueryByNodeId` mutation. */
+export type DeleteSavedQueryByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `SavedQuery` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** All input for the `deleteSavedQuery` mutation. */
+export type DeleteSavedQueryInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  id: Scalars['UUID'];
+};
+
+/** The output of our delete `SavedQuery` mutation. */
+export type DeleteSavedQueryPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  deletedSavedQueryNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** The `SavedQuery` that was deleted by this mutation. */
+  savedQuery?: Maybe<SavedQuery>;
+  /** An edge for our `SavedQuery`. May be used by Relay 1. */
+  savedQueryEdge?: Maybe<SavedQueriesEdge>;
+};
+
+
+/** The output of our delete `SavedQuery` mutation. */
+export type DeleteSavedQueryPayloadSavedQueryEdgeArgs = {
+  orderBy?: InputMaybe<Array<SavedQueriesOrderBy>>;
 };
 
 /** All input for the `deleteSchemaMigrationByNodeId` mutation. */
@@ -4354,6 +4581,112 @@ export enum GitRefsOrderBy {
   TargetDesc = 'TARGET_DESC',
   TypeAsc = 'TYPE_ASC',
   TypeDesc = 'TYPE_DESC',
+  MergestatSyncedAtAsc = '_MERGESTAT_SYNCED_AT_ASC',
+  MergestatSyncedAtDesc = '_MERGESTAT_SYNCED_AT_DESC'
+}
+
+/** table of git repo remotes */
+export type GitRemote = Node & {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt: Scalars['Datetime'];
+  /** name of the remote */
+  name: Scalars['String'];
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+  /** url of the remote */
+  url: Scalars['String'];
+};
+
+/**
+ * A condition to be used against `GitRemote` object types. All fields are tested
+ * for equality and combined with a logical ‘and.’
+ */
+export type GitRemoteCondition = {
+  /** Checks for equality with the object’s `_mergestatSyncedAt` field. */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `name` field. */
+  name?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `repoId` field. */
+  repoId?: InputMaybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `url` field. */
+  url?: InputMaybe<Scalars['String']>;
+};
+
+/** A filter to be used against `GitRemote` object types. All fields are combined with a logical ‘and.’ */
+export type GitRemoteFilter = {
+  /** Filter by the object’s `_mergestatSyncedAt` field. */
+  _mergestatSyncedAt?: InputMaybe<DatetimeFilter>;
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<GitRemoteFilter>>;
+  /** Filter by the object’s `name` field. */
+  name?: InputMaybe<StringFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<GitRemoteFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<GitRemoteFilter>>;
+  /** Filter by the object’s `repoId` field. */
+  repoId?: InputMaybe<UuidFilter>;
+  /** Filter by the object’s `url` field. */
+  url?: InputMaybe<StringFilter>;
+};
+
+/** An input for mutations affecting `GitRemote` */
+export type GitRemoteInput = {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** name of the remote */
+  name: Scalars['String'];
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+  /** url of the remote */
+  url: Scalars['String'];
+};
+
+/** Represents an update to a `GitRemote`. Fields that are set will be updated. */
+export type GitRemotePatch = {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** name of the remote */
+  name?: InputMaybe<Scalars['String']>;
+  /** foreign key for public.repos.id */
+  repoId?: InputMaybe<Scalars['UUID']>;
+  /** url of the remote */
+  url?: InputMaybe<Scalars['String']>;
+};
+
+/** A connection to a list of `GitRemote` values. */
+export type GitRemotesConnection = {
+  /** A list of edges which contains the `GitRemote` and cursor to aid in pagination. */
+  edges: Array<GitRemotesEdge>;
+  /** A list of `GitRemote` objects. */
+  nodes: Array<GitRemote>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `GitRemote` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `GitRemote` edge in the connection. */
+export type GitRemotesEdge = {
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `GitRemote` at the end of the edge. */
+  node: GitRemote;
+};
+
+/** Methods to use when ordering `GitRemote`. */
+export enum GitRemotesOrderBy {
+  NameAsc = 'NAME_ASC',
+  NameDesc = 'NAME_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  RepoIdAsc = 'REPO_ID_ASC',
+  RepoIdDesc = 'REPO_ID_DESC',
+  UrlAsc = 'URL_ASC',
+  UrlDesc = 'URL_DESC',
   MergestatSyncedAtAsc = '_MERGESTAT_SYNCED_AT_ASC',
   MergestatSyncedAtDesc = '_MERGESTAT_SYNCED_AT_DESC'
 }
@@ -7815,6 +8148,210 @@ export enum GosecRepoScansOrderBy {
   MergestatSyncedAtDesc = '_MERGESTAT_SYNCED_AT_DESC'
 }
 
+/** Table for Grype repo scan results */
+export type GrypeRepoScan = Node & {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt: Scalars['Datetime'];
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+  /** JSON results of Grype repo scanner */
+  results: Scalars['JSON'];
+};
+
+/**
+ * A condition to be used against `GrypeRepoScan` object types. All fields are
+ * tested for equality and combined with a logical ‘and.’
+ */
+export type GrypeRepoScanCondition = {
+  /** Checks for equality with the object’s `_mergestatSyncedAt` field. */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `repoId` field. */
+  repoId?: InputMaybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `results` field. */
+  results?: InputMaybe<Scalars['JSON']>;
+};
+
+/** A filter to be used against `GrypeRepoScan` object types. All fields are combined with a logical ‘and.’ */
+export type GrypeRepoScanFilter = {
+  /** Filter by the object’s `_mergestatSyncedAt` field. */
+  _mergestatSyncedAt?: InputMaybe<DatetimeFilter>;
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<GrypeRepoScanFilter>>;
+  /** Negates the expression. */
+  not?: InputMaybe<GrypeRepoScanFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<GrypeRepoScanFilter>>;
+  /** Filter by the object’s `repoId` field. */
+  repoId?: InputMaybe<UuidFilter>;
+  /** Filter by the object’s `results` field. */
+  results?: InputMaybe<JsonFilter>;
+};
+
+/** An input for mutations affecting `GrypeRepoScan` */
+export type GrypeRepoScanInput = {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+  /** JSON results of Grype repo scanner */
+  results: Scalars['JSON'];
+};
+
+/** Represents an update to a `GrypeRepoScan`. Fields that are set will be updated. */
+export type GrypeRepoScanPatch = {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** foreign key for public.repos.id */
+  repoId?: InputMaybe<Scalars['UUID']>;
+  /** JSON results of Grype repo scanner */
+  results?: InputMaybe<Scalars['JSON']>;
+};
+
+/** A connection to a list of `GrypeRepoScan` values. */
+export type GrypeRepoScansConnection = {
+  /** A list of edges which contains the `GrypeRepoScan` and cursor to aid in pagination. */
+  edges: Array<GrypeRepoScansEdge>;
+  /** A list of `GrypeRepoScan` objects. */
+  nodes: Array<GrypeRepoScan>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `GrypeRepoScan` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `GrypeRepoScan` edge in the connection. */
+export type GrypeRepoScansEdge = {
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `GrypeRepoScan` at the end of the edge. */
+  node: GrypeRepoScan;
+};
+
+/** Methods to use when ordering `GrypeRepoScan`. */
+export enum GrypeRepoScansOrderBy {
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  RepoIdAsc = 'REPO_ID_ASC',
+  RepoIdDesc = 'REPO_ID_DESC',
+  ResultsAsc = 'RESULTS_ASC',
+  ResultsDesc = 'RESULTS_DESC',
+  MergestatSyncedAtAsc = '_MERGESTAT_SYNCED_AT_ASC',
+  MergestatSyncedAtDesc = '_MERGESTAT_SYNCED_AT_DESC'
+}
+
+/** A connection to a list of `GrypeRepoVulnerability` values. */
+export type GrypeRepoVulnerabilitiesConnection = {
+  /** A list of edges which contains the `GrypeRepoVulnerability` and cursor to aid in pagination. */
+  edges: Array<GrypeRepoVulnerabilitiesEdge>;
+  /** A list of `GrypeRepoVulnerability` objects. */
+  nodes: Array<GrypeRepoVulnerability>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `GrypeRepoVulnerability` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `GrypeRepoVulnerability` edge in the connection. */
+export type GrypeRepoVulnerabilitiesEdge = {
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `GrypeRepoVulnerability` at the end of the edge. */
+  node: GrypeRepoVulnerability;
+};
+
+/** Methods to use when ordering `GrypeRepoVulnerability`. */
+export enum GrypeRepoVulnerabilitiesOrderBy {
+  DescriptionAsc = 'DESCRIPTION_ASC',
+  DescriptionDesc = 'DESCRIPTION_DESC',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  LanguageAsc = 'LANGUAGE_ASC',
+  LanguageDesc = 'LANGUAGE_DESC',
+  Natural = 'NATURAL',
+  PathAsc = 'PATH_ASC',
+  PathDesc = 'PATH_DESC',
+  RepoIdAsc = 'REPO_ID_ASC',
+  RepoIdDesc = 'REPO_ID_DESC',
+  SeverityAsc = 'SEVERITY_ASC',
+  SeverityDesc = 'SEVERITY_DESC',
+  TypeAsc = 'TYPE_ASC',
+  TypeDesc = 'TYPE_DESC',
+  VersionAsc = 'VERSION_ASC',
+  VersionDesc = 'VERSION_DESC'
+}
+
+/** view of Grype repo scans results */
+export type GrypeRepoVulnerability = {
+  /** description  of vulnerability */
+  description?: Maybe<Scalars['String']>;
+  /** id of the current vulnerability */
+  id?: Maybe<Scalars['String']>;
+  /** programming language associated to vulnerability */
+  language?: Maybe<Scalars['String']>;
+  /** path to file of current vulnerability */
+  path?: Maybe<Scalars['String']>;
+  /** foreign key for public.repos.id */
+  repoId?: Maybe<Scalars['UUID']>;
+  /** level of severity */
+  severity?: Maybe<Scalars['String']>;
+  /** type of vulnerability */
+  type?: Maybe<Scalars['String']>;
+  /** current version of package vulnerable */
+  version?: Maybe<Scalars['String']>;
+};
+
+/**
+ * A condition to be used against `GrypeRepoVulnerability` object types. All fields
+ * are tested for equality and combined with a logical ‘and.’
+ */
+export type GrypeRepoVulnerabilityCondition = {
+  /** Checks for equality with the object’s `description` field. */
+  description?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `id` field. */
+  id?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `language` field. */
+  language?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `path` field. */
+  path?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `repoId` field. */
+  repoId?: InputMaybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `severity` field. */
+  severity?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `type` field. */
+  type?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `version` field. */
+  version?: InputMaybe<Scalars['String']>;
+};
+
+/** A filter to be used against `GrypeRepoVulnerability` object types. All fields are combined with a logical ‘and.’ */
+export type GrypeRepoVulnerabilityFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<GrypeRepoVulnerabilityFilter>>;
+  /** Filter by the object’s `description` field. */
+  description?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `id` field. */
+  id?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `language` field. */
+  language?: InputMaybe<StringFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<GrypeRepoVulnerabilityFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<GrypeRepoVulnerabilityFilter>>;
+  /** Filter by the object’s `path` field. */
+  path?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `repoId` field. */
+  repoId?: InputMaybe<UuidFilter>;
+  /** Filter by the object’s `severity` field. */
+  severity?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `type` field. */
+  type?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `version` field. */
+  version?: InputMaybe<StringFilter>;
+};
+
 /** A filter to be used against Int fields. All fields are combined with a logical ‘and.’ */
 export type IntFilter = {
   /** Not equal to the specified value, treating null like an ordinary value. */
@@ -8215,6 +8752,8 @@ export type Mutation = {
   createGitFile?: Maybe<CreateGitFilePayload>;
   /** Creates a single `GitRef`. */
   createGitRef?: Maybe<CreateGitRefPayload>;
+  /** Creates a single `GitRemote`. */
+  createGitRemote?: Maybe<CreateGitRemotePayload>;
   /** Creates a single `GitTag`. */
   createGitTag?: Maybe<CreateGitTagPayload>;
   /** Creates a single `GithubActionsWorkflow`. */
@@ -8239,6 +8778,8 @@ export type Mutation = {
   createGitleaksRepoScan?: Maybe<CreateGitleaksRepoScanPayload>;
   /** Creates a single `GosecRepoScan`. */
   createGosecRepoScan?: Maybe<CreateGosecRepoScanPayload>;
+  /** Creates a single `GrypeRepoScan`. */
+  createGrypeRepoScan?: Maybe<CreateGrypeRepoScanPayload>;
   /** Creates a single `Label`. */
   createLabel?: Maybe<CreateLabelPayload>;
   /** Creates a single `LabelAssociation`. */
@@ -8269,6 +8810,8 @@ export type Mutation = {
   createRepoSyncType?: Maybe<CreateRepoSyncTypePayload>;
   /** Creates a single `RepoSyncTypeGroup`. */
   createRepoSyncTypeGroup?: Maybe<CreateRepoSyncTypeGroupPayload>;
+  /** Creates a single `SavedQuery`. */
+  createSavedQuery?: Maybe<CreateSavedQueryPayload>;
   /** Creates a single `SchemaMigration`. */
   createSchemaMigration?: Maybe<CreateSchemaMigrationPayload>;
   /** Creates a single `SchemaMigrationsHistory`. */
@@ -8305,6 +8848,10 @@ export type Mutation = {
   deleteGitRef?: Maybe<DeleteGitRefPayload>;
   /** Deletes a single `GitRef` using its globally unique id. */
   deleteGitRefByNodeId?: Maybe<DeleteGitRefPayload>;
+  /** Deletes a single `GitRemote` using a unique key. */
+  deleteGitRemote?: Maybe<DeleteGitRemotePayload>;
+  /** Deletes a single `GitRemote` using its globally unique id. */
+  deleteGitRemoteByNodeId?: Maybe<DeleteGitRemotePayload>;
   /** Deletes a single `GithubActionsWorkflow` using a unique key. */
   deleteGithubActionsWorkflow?: Maybe<DeleteGithubActionsWorkflowPayload>;
   /** Deletes a single `GithubActionsWorkflow` using a unique key. */
@@ -8357,6 +8904,10 @@ export type Mutation = {
   deleteGosecRepoScan?: Maybe<DeleteGosecRepoScanPayload>;
   /** Deletes a single `GosecRepoScan` using its globally unique id. */
   deleteGosecRepoScanByNodeId?: Maybe<DeleteGosecRepoScanPayload>;
+  /** Deletes a single `GrypeRepoScan` using a unique key. */
+  deleteGrypeRepoScan?: Maybe<DeleteGrypeRepoScanPayload>;
+  /** Deletes a single `GrypeRepoScan` using its globally unique id. */
+  deleteGrypeRepoScanByNodeId?: Maybe<DeleteGrypeRepoScanPayload>;
   /** Deletes a single `Label` using a unique key. */
   deleteLabel?: Maybe<DeleteLabelPayload>;
   /** Deletes a single `LabelAssociation` using a unique key. */
@@ -8413,6 +8964,10 @@ export type Mutation = {
   deleteRepoSyncTypeGroup?: Maybe<DeleteRepoSyncTypeGroupPayload>;
   /** Deletes a single `RepoSyncTypeGroup` using its globally unique id. */
   deleteRepoSyncTypeGroupByNodeId?: Maybe<DeleteRepoSyncTypeGroupPayload>;
+  /** Deletes a single `SavedQuery` using a unique key. */
+  deleteSavedQuery?: Maybe<DeleteSavedQueryPayload>;
+  /** Deletes a single `SavedQuery` using its globally unique id. */
+  deleteSavedQueryByNodeId?: Maybe<DeleteSavedQueryPayload>;
   /** Deletes a single `SchemaMigration` using a unique key. */
   deleteSchemaMigration?: Maybe<DeleteSchemaMigrationPayload>;
   /** Deletes a single `SchemaMigration` using its globally unique id. */
@@ -8470,6 +9025,10 @@ export type Mutation = {
   updateGitRef?: Maybe<UpdateGitRefPayload>;
   /** Updates a single `GitRef` using its globally unique id and a patch. */
   updateGitRefByNodeId?: Maybe<UpdateGitRefPayload>;
+  /** Updates a single `GitRemote` using a unique key and a patch. */
+  updateGitRemote?: Maybe<UpdateGitRemotePayload>;
+  /** Updates a single `GitRemote` using its globally unique id and a patch. */
+  updateGitRemoteByNodeId?: Maybe<UpdateGitRemotePayload>;
   /** Updates a single `GithubActionsWorkflow` using a unique key and a patch. */
   updateGithubActionsWorkflow?: Maybe<UpdateGithubActionsWorkflowPayload>;
   /** Updates a single `GithubActionsWorkflow` using a unique key and a patch. */
@@ -8522,6 +9081,10 @@ export type Mutation = {
   updateGosecRepoScan?: Maybe<UpdateGosecRepoScanPayload>;
   /** Updates a single `GosecRepoScan` using its globally unique id and a patch. */
   updateGosecRepoScanByNodeId?: Maybe<UpdateGosecRepoScanPayload>;
+  /** Updates a single `GrypeRepoScan` using a unique key and a patch. */
+  updateGrypeRepoScan?: Maybe<UpdateGrypeRepoScanPayload>;
+  /** Updates a single `GrypeRepoScan` using its globally unique id and a patch. */
+  updateGrypeRepoScanByNodeId?: Maybe<UpdateGrypeRepoScanPayload>;
   /** Updates a single `Label` using a unique key and a patch. */
   updateLabel?: Maybe<UpdateLabelPayload>;
   /** Updates a single `LabelAssociation` using a unique key and a patch. */
@@ -8578,6 +9141,10 @@ export type Mutation = {
   updateRepoSyncTypeGroup?: Maybe<UpdateRepoSyncTypeGroupPayload>;
   /** Updates a single `RepoSyncTypeGroup` using its globally unique id and a patch. */
   updateRepoSyncTypeGroupByNodeId?: Maybe<UpdateRepoSyncTypeGroupPayload>;
+  /** Updates a single `SavedQuery` using a unique key and a patch. */
+  updateSavedQuery?: Maybe<UpdateSavedQueryPayload>;
+  /** Updates a single `SavedQuery` using its globally unique id and a patch. */
+  updateSavedQueryByNodeId?: Maybe<UpdateSavedQueryPayload>;
   /** Updates a single `SchemaMigration` using a unique key and a patch. */
   updateSchemaMigration?: Maybe<UpdateSchemaMigrationPayload>;
   /** Updates a single `SchemaMigration` using its globally unique id and a patch. */
@@ -8662,6 +9229,12 @@ export type MutationCreateGitRefArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateGitRemoteArgs = {
+  input: CreateGitRemoteInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateGitTagArgs = {
   input: CreateGitTagInput;
 };
@@ -8730,6 +9303,12 @@ export type MutationCreateGitleaksRepoScanArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateGosecRepoScanArgs = {
   input: CreateGosecRepoScanInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateGrypeRepoScanArgs = {
+  input: CreateGrypeRepoScanInput;
 };
 
 
@@ -8820,6 +9399,12 @@ export type MutationCreateRepoSyncTypeArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateRepoSyncTypeGroupArgs = {
   input: CreateRepoSyncTypeGroupInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateSavedQueryArgs = {
+  input: CreateSavedQueryInput;
 };
 
 
@@ -8928,6 +9513,18 @@ export type MutationDeleteGitRefArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteGitRefByNodeIdArgs = {
   input: DeleteGitRefByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteGitRemoteArgs = {
+  input: DeleteGitRemoteInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteGitRemoteByNodeIdArgs = {
+  input: DeleteGitRemoteByNodeIdInput;
 };
 
 
@@ -9084,6 +9681,18 @@ export type MutationDeleteGosecRepoScanArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteGosecRepoScanByNodeIdArgs = {
   input: DeleteGosecRepoScanByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteGrypeRepoScanArgs = {
+  input: DeleteGrypeRepoScanInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteGrypeRepoScanByNodeIdArgs = {
+  input: DeleteGrypeRepoScanByNodeIdInput;
 };
 
 
@@ -9252,6 +9861,18 @@ export type MutationDeleteRepoSyncTypeGroupArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteRepoSyncTypeGroupByNodeIdArgs = {
   input: DeleteRepoSyncTypeGroupByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteSavedQueryArgs = {
+  input: DeleteSavedQueryInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteSavedQueryByNodeIdArgs = {
+  input: DeleteSavedQueryByNodeIdInput;
 };
 
 
@@ -9436,6 +10057,18 @@ export type MutationUpdateGitRefByNodeIdArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateGitRemoteArgs = {
+  input: UpdateGitRemoteInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateGitRemoteByNodeIdArgs = {
+  input: UpdateGitRemoteByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateGithubActionsWorkflowArgs = {
   input: UpdateGithubActionsWorkflowInput;
 };
@@ -9588,6 +10221,18 @@ export type MutationUpdateGosecRepoScanArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateGosecRepoScanByNodeIdArgs = {
   input: UpdateGosecRepoScanByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateGrypeRepoScanArgs = {
+  input: UpdateGrypeRepoScanInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateGrypeRepoScanByNodeIdArgs = {
+  input: UpdateGrypeRepoScanByNodeIdInput;
 };
 
 
@@ -9756,6 +10401,18 @@ export type MutationUpdateRepoSyncTypeGroupArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateRepoSyncTypeGroupByNodeIdArgs = {
   input: UpdateRepoSyncTypeGroupByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateSavedQueryArgs = {
+  input: UpdateSavedQueryInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateSavedQueryByNodeIdArgs = {
+  input: UpdateSavedQueryByNodeIdInput;
 };
 
 
@@ -10250,6 +10907,11 @@ export type Query = Node & {
   gitRefByNodeId?: Maybe<GitRef>;
   /** Reads and enables pagination through a set of `GitRef`. */
   gitRefs?: Maybe<GitRefsConnection>;
+  gitRemote?: Maybe<GitRemote>;
+  /** Reads a single `GitRemote` using its globally unique `ID`. */
+  gitRemoteByNodeId?: Maybe<GitRemote>;
+  /** Reads and enables pagination through a set of `GitRemote`. */
+  gitRemotes?: Maybe<GitRemotesConnection>;
   /** Reads and enables pagination through a set of `GitTag`. */
   gitTags?: Maybe<GitTagsConnection>;
   githubActionsWorkflow?: Maybe<GithubActionsWorkflow>;
@@ -10315,6 +10977,13 @@ export type Query = Node & {
   gosecRepoScanByNodeId?: Maybe<GosecRepoScan>;
   /** Reads and enables pagination through a set of `GosecRepoScan`. */
   gosecRepoScans?: Maybe<GosecRepoScansConnection>;
+  grypeRepoScan?: Maybe<GrypeRepoScan>;
+  /** Reads a single `GrypeRepoScan` using its globally unique `ID`. */
+  grypeRepoScanByNodeId?: Maybe<GrypeRepoScan>;
+  /** Reads and enables pagination through a set of `GrypeRepoScan`. */
+  grypeRepoScans?: Maybe<GrypeRepoScansConnection>;
+  /** Reads and enables pagination through a set of `GrypeRepoVulnerability`. */
+  grypeRepoVulnerabilities?: Maybe<GrypeRepoVulnerabilitiesConnection>;
   label?: Maybe<Label>;
   labelAssociationByLabelAndRepoSyncType?: Maybe<LabelAssociation>;
   /** Reads and enables pagination through a set of `LabelAssociation`. */
@@ -10326,7 +10995,7 @@ export type Query = Node & {
   /** Reads and enables pagination through a set of `LatestRepoSync`. */
   latestRepoSyncs?: Maybe<LatestRepoSyncsConnection>;
   /** Fetches an object given its globally unique `ID`. */
-  node?: Maybe<GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | Label | OssfScorecardRepoScan | Query | QueryHistory | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | YelpDetectSecretsRepoScan>;
+  node?: Maybe<GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Label | OssfScorecardRepoScan | Query | QueryHistory | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | YelpDetectSecretsRepoScan>;
   /** The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`. */
   nodeId: Scalars['ID'];
   /** Reads and enables pagination through a set of `OssfScorecardRepoCheckResult`. */
@@ -10399,6 +11068,11 @@ export type Query = Node & {
   repoSyncs?: Maybe<RepoSyncsConnection>;
   /** Reads and enables pagination through a set of `Repo`. */
   repos?: Maybe<ReposConnection>;
+  /** Reads and enables pagination through a set of `SavedQuery`. */
+  savedQueries?: Maybe<SavedQueriesConnection>;
+  savedQuery?: Maybe<SavedQuery>;
+  /** Reads a single `SavedQuery` using its globally unique `ID`. */
+  savedQueryByNodeId?: Maybe<SavedQuery>;
   /** Reads and enables pagination through a set of `SchemaIntrospection`. */
   schemaIntrospections?: Maybe<SchemaIntrospectionsConnection>;
   schemaMigration?: Maybe<SchemaMigration>;
@@ -10602,6 +11276,31 @@ export type QueryGitRefsArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<GitRefsOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryGitRemoteArgs = {
+  repoId: Scalars['UUID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryGitRemoteByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryGitRemotesArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<GitRemoteCondition>;
+  filter?: InputMaybe<GitRemoteFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<GitRemotesOrderBy>>;
 };
 
 
@@ -10950,6 +11649,44 @@ export type QueryGosecRepoScansArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<GosecRepoScansOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryGrypeRepoScanArgs = {
+  repoId: Scalars['UUID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryGrypeRepoScanByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryGrypeRepoScansArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<GrypeRepoScanCondition>;
+  filter?: InputMaybe<GrypeRepoScanFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryGrypeRepoVulnerabilitiesArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<GrypeRepoVulnerabilityCondition>;
+  filter?: InputMaybe<GrypeRepoVulnerabilityFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<GrypeRepoVulnerabilitiesOrderBy>>;
 };
 
 
@@ -11347,6 +12084,31 @@ export type QueryReposArgs = {
   last?: InputMaybe<Scalars['Int']>;
   offset?: InputMaybe<Scalars['Int']>;
   orderBy?: InputMaybe<Array<ReposOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QuerySavedQueriesArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<SavedQueryCondition>;
+  filter?: InputMaybe<SavedQueryFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<SavedQueriesOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QuerySavedQueryArgs = {
+  id: Scalars['UUID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QuerySavedQueryByNodeIdArgs = {
+  nodeId: Scalars['ID'];
 };
 
 
@@ -13174,6 +13936,145 @@ export enum ReposOrderBy {
   TagsDesc = 'TAGS_DESC'
 }
 
+/** A connection to a list of `SavedQuery` values. */
+export type SavedQueriesConnection = {
+  /** A list of edges which contains the `SavedQuery` and cursor to aid in pagination. */
+  edges: Array<SavedQueriesEdge>;
+  /** A list of `SavedQuery` objects. */
+  nodes: Array<SavedQuery>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `SavedQuery` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `SavedQuery` edge in the connection. */
+export type SavedQueriesEdge = {
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `SavedQuery` at the end of the edge. */
+  node: SavedQuery;
+};
+
+/** Methods to use when ordering `SavedQuery`. */
+export enum SavedQueriesOrderBy {
+  CreatedAtAsc = 'CREATED_AT_ASC',
+  CreatedAtDesc = 'CREATED_AT_DESC',
+  CreatedByAsc = 'CREATED_BY_ASC',
+  CreatedByDesc = 'CREATED_BY_DESC',
+  DescriptionAsc = 'DESCRIPTION_ASC',
+  DescriptionDesc = 'DESCRIPTION_DESC',
+  IdAsc = 'ID_ASC',
+  IdDesc = 'ID_DESC',
+  MetadataAsc = 'METADATA_ASC',
+  MetadataDesc = 'METADATA_DESC',
+  NameAsc = 'NAME_ASC',
+  NameDesc = 'NAME_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  SqlAsc = 'SQL_ASC',
+  SqlDesc = 'SQL_DESC'
+}
+
+/** Table to save queries */
+export type SavedQuery = Node & {
+  /** timestamp when query was created */
+  createdAt?: Maybe<Scalars['Datetime']>;
+  /** query creator */
+  createdBy?: Maybe<Scalars['String']>;
+  /** query description */
+  description?: Maybe<Scalars['String']>;
+  id: Scalars['UUID'];
+  /** query metadata */
+  metadata?: Maybe<Scalars['JSON']>;
+  /** query name */
+  name?: Maybe<Scalars['String']>;
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  /** query sql */
+  sql?: Maybe<Scalars['String']>;
+};
+
+/**
+ * A condition to be used against `SavedQuery` object types. All fields are tested
+ * for equality and combined with a logical ‘and.’
+ */
+export type SavedQueryCondition = {
+  /** Checks for equality with the object’s `createdAt` field. */
+  createdAt?: InputMaybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `createdBy` field. */
+  createdBy?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `description` field. */
+  description?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `id` field. */
+  id?: InputMaybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `metadata` field. */
+  metadata?: InputMaybe<Scalars['JSON']>;
+  /** Checks for equality with the object’s `name` field. */
+  name?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `sql` field. */
+  sql?: InputMaybe<Scalars['String']>;
+};
+
+/** A filter to be used against `SavedQuery` object types. All fields are combined with a logical ‘and.’ */
+export type SavedQueryFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<SavedQueryFilter>>;
+  /** Filter by the object’s `createdAt` field. */
+  createdAt?: InputMaybe<DatetimeFilter>;
+  /** Filter by the object’s `createdBy` field. */
+  createdBy?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `description` field. */
+  description?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `id` field. */
+  id?: InputMaybe<UuidFilter>;
+  /** Filter by the object’s `metadata` field. */
+  metadata?: InputMaybe<JsonFilter>;
+  /** Filter by the object’s `name` field. */
+  name?: InputMaybe<StringFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<SavedQueryFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<SavedQueryFilter>>;
+  /** Filter by the object’s `sql` field. */
+  sql?: InputMaybe<StringFilter>;
+};
+
+/** An input for mutations affecting `SavedQuery` */
+export type SavedQueryInput = {
+  /** timestamp when query was created */
+  createdAt?: InputMaybe<Scalars['Datetime']>;
+  /** query creator */
+  createdBy?: InputMaybe<Scalars['String']>;
+  /** query description */
+  description?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['UUID']>;
+  /** query metadata */
+  metadata?: InputMaybe<Scalars['JSON']>;
+  /** query name */
+  name?: InputMaybe<Scalars['String']>;
+  /** query sql */
+  sql?: InputMaybe<Scalars['String']>;
+};
+
+/** Represents an update to a `SavedQuery`. Fields that are set will be updated. */
+export type SavedQueryPatch = {
+  /** timestamp when query was created */
+  createdAt?: InputMaybe<Scalars['Datetime']>;
+  /** query creator */
+  createdBy?: InputMaybe<Scalars['String']>;
+  /** query description */
+  description?: InputMaybe<Scalars['String']>;
+  id?: InputMaybe<Scalars['UUID']>;
+  /** query metadata */
+  metadata?: InputMaybe<Scalars['JSON']>;
+  /** query name */
+  name?: InputMaybe<Scalars['String']>;
+  /** query sql */
+  sql?: InputMaybe<Scalars['String']>;
+};
+
 export type SchemaIntrospection = {
   columnDescription?: Maybe<Scalars['String']>;
   columnName?: Maybe<Scalars['SqlIdentifier']>;
@@ -14728,6 +15629,53 @@ export type UpdateGitRefPayloadGitRefEdgeArgs = {
   orderBy?: InputMaybe<Array<GitRefsOrderBy>>;
 };
 
+/** All input for the `updateGitRemoteByNodeId` mutation. */
+export type UpdateGitRemoteByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `GitRemote` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `GitRemote` being updated. */
+  patch: GitRemotePatch;
+};
+
+/** All input for the `updateGitRemote` mutation. */
+export type UpdateGitRemoteInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `GitRemote` being updated. */
+  patch: GitRemotePatch;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+};
+
+/** The output of our update `GitRemote` mutation. */
+export type UpdateGitRemotePayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `GitRemote` that was updated by this mutation. */
+  gitRemote?: Maybe<GitRemote>;
+  /** An edge for our `GitRemote`. May be used by Relay 1. */
+  gitRemoteEdge?: Maybe<GitRemotesEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our update `GitRemote` mutation. */
+export type UpdateGitRemotePayloadGitRemoteEdgeArgs = {
+  orderBy?: InputMaybe<Array<GitRemotesOrderBy>>;
+};
+
 /** All input for the `updateGithubActionsWorkflowById` mutation. */
 export type UpdateGithubActionsWorkflowByIdInput = {
   /**
@@ -15326,6 +16274,53 @@ export type UpdateGosecRepoScanPayload = {
 /** The output of our update `GosecRepoScan` mutation. */
 export type UpdateGosecRepoScanPayloadGosecRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GosecRepoScansOrderBy>>;
+};
+
+/** All input for the `updateGrypeRepoScanByNodeId` mutation. */
+export type UpdateGrypeRepoScanByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `GrypeRepoScan` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `GrypeRepoScan` being updated. */
+  patch: GrypeRepoScanPatch;
+};
+
+/** All input for the `updateGrypeRepoScan` mutation. */
+export type UpdateGrypeRepoScanInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `GrypeRepoScan` being updated. */
+  patch: GrypeRepoScanPatch;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+};
+
+/** The output of our update `GrypeRepoScan` mutation. */
+export type UpdateGrypeRepoScanPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `GrypeRepoScan` that was updated by this mutation. */
+  grypeRepoScan?: Maybe<GrypeRepoScan>;
+  /** An edge for our `GrypeRepoScan`. May be used by Relay 1. */
+  grypeRepoScanEdge?: Maybe<GrypeRepoScansEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our update `GrypeRepoScan` mutation. */
+export type UpdateGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
+  orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
 /** All input for the `updateLabelAssociationByLabelAndRepoSyncType` mutation. */
@@ -16001,6 +16996,52 @@ export type UpdateRepoSyncTypePayload = {
 /** The output of our update `RepoSyncType` mutation. */
 export type UpdateRepoSyncTypePayloadRepoSyncTypeEdgeArgs = {
   orderBy?: InputMaybe<Array<RepoSyncTypesOrderBy>>;
+};
+
+/** All input for the `updateSavedQueryByNodeId` mutation. */
+export type UpdateSavedQueryByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `SavedQuery` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `SavedQuery` being updated. */
+  patch: SavedQueryPatch;
+};
+
+/** All input for the `updateSavedQuery` mutation. */
+export type UpdateSavedQueryInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  id: Scalars['UUID'];
+  /** An object where the defined keys will be set on the `SavedQuery` being updated. */
+  patch: SavedQueryPatch;
+};
+
+/** The output of our update `SavedQuery` mutation. */
+export type UpdateSavedQueryPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** The `SavedQuery` that was updated by this mutation. */
+  savedQuery?: Maybe<SavedQuery>;
+  /** An edge for our `SavedQuery`. May be used by Relay 1. */
+  savedQueryEdge?: Maybe<SavedQueriesEdge>;
+};
+
+
+/** The output of our update `SavedQuery` mutation. */
+export type UpdateSavedQueryPayloadSavedQueryEdgeArgs = {
+  orderBy?: InputMaybe<Array<SavedQueriesOrderBy>>;
 };
 
 /** All input for the `updateSchemaMigrationByNodeId` mutation. */
@@ -17089,6 +18130,7 @@ export type GetUsersQuery = { userMgmtPgUsers?: { nodes: Array<{ memberof?: Arra
 export type ExecuteSqlQueryVariables = Exact<{
   sql: Scalars['String'];
   disableReadOnly?: InputMaybe<Scalars['Boolean']>;
+  trackHistory?: InputMaybe<Scalars['Boolean']>;
 }>;
 
 

--- a/ui/src/api-logic/graphql/mutations/saved-query.ts
+++ b/ui/src/api-logic/graphql/mutations/saved-query.ts
@@ -1,0 +1,16 @@
+import { gql } from '@apollo/client'
+
+const ADD_SAVED_QUERY = gql`
+  mutation addSavedQuery($createdBy: String!, $createdAt: Datetime!, $description: String!, $name: String!, $sql: String!, $metadata: JSON) {
+    createSavedQuery(
+      input: {savedQuery: {createdBy: $createdBy, name: $name, description: $description, sql: $sql, metadata: $metadata, createdAt: $createdAt}}
+    ) {
+      savedQuery {
+        id
+        name
+      }
+    }
+  }
+`
+
+export { ADD_SAVED_QUERY }

--- a/ui/src/api-logic/graphql/mutations/saved-query.ts
+++ b/ui/src/api-logic/graphql/mutations/saved-query.ts
@@ -1,9 +1,9 @@
 import { gql } from '@apollo/client'
 
 const ADD_SAVED_QUERY = gql`
-  mutation addSavedQuery($createdBy: String!, $createdAt: Datetime!, $description: String!, $name: String!, $sql: String!, $metadata: JSON) {
+  mutation addSavedQuery($createdBy: String!, $createdAt: Datetime!, $name: String!, $description: String!, $sql: String!, $metadata: JSON) {
     createSavedQuery(
-      input: {savedQuery: {createdBy: $createdBy, name: $name, description: $description, sql: $sql, metadata: $metadata, createdAt: $createdAt}}
+      input: {savedQuery: {createdBy: $createdBy, createdAt: $createdAt, name: $name, description: $description, sql: $sql, metadata: $metadata}}
     ) {
       savedQuery {
         id
@@ -13,4 +13,19 @@ const ADD_SAVED_QUERY = gql`
   }
 `
 
-export { ADD_SAVED_QUERY }
+const UPDATE_SAVED_QUERY = gql`
+  mutation updateSavedQuery($id: UUID!, $name: String, $description: String, $sql: String) {
+    updateSavedQuery(
+      input: {patch: {name: $name, description: $description, sql: $sql}, id: $id}
+    ) {
+      savedQuery {
+        id
+        name
+        description
+        sql
+      }
+    }
+  }
+`
+
+export { ADD_SAVED_QUERY, UPDATE_SAVED_QUERY }

--- a/ui/src/api-logic/graphql/mutations/saved-query.ts
+++ b/ui/src/api-logic/graphql/mutations/saved-query.ts
@@ -28,4 +28,12 @@ const UPDATE_SAVED_QUERY = gql`
   }
 `
 
-export { ADD_SAVED_QUERY, UPDATE_SAVED_QUERY }
+const REMOVE_SAVED_QUERY = gql`
+  mutation removeSavedQuery($id: UUID!) {
+    deleteSavedQuery(input: {id: $id}) {
+      deletedSavedQueryNodeId
+    }
+  }
+`
+
+export { ADD_SAVED_QUERY, UPDATE_SAVED_QUERY, REMOVE_SAVED_QUERY }

--- a/ui/src/api-logic/graphql/queries/get-saved-query.ts
+++ b/ui/src/api-logic/graphql/queries/get-saved-query.ts
@@ -1,0 +1,16 @@
+import { gql } from '@apollo/client'
+
+const GET_SAVED_QUERY = gql`
+  query getSavedQuery($id: UUID!) {
+    savedQuery(id: $id) {
+      createdAt
+      createdBy
+      name
+      description
+      sql
+      metadata
+    }
+  }
+`
+
+export { GET_SAVED_QUERY }

--- a/ui/src/api-logic/graphql/queries/get-saved-query.ts
+++ b/ui/src/api-logic/graphql/queries/get-saved-query.ts
@@ -1,5 +1,27 @@
 import { gql } from '@apollo/client'
 
+const GET_SAVED_QUERY_LIST = gql`
+  query getSavedQueryList($search: String!, $first: Int, $offset: Int) {
+    all: savedQueries {
+      totalCount
+    }
+    savedQueries(
+      filter: {name: {includesInsensitive: $search}}
+      first: $first
+      offset: $offset
+    ) {
+      totalCount
+      nodes {
+        id
+        createdAt
+        createdBy
+        name
+        description
+      }
+    }
+  }
+`
+
 const GET_SAVED_QUERY = gql`
   query getSavedQuery($id: UUID!) {
     savedQuery(id: $id) {
@@ -13,4 +35,4 @@ const GET_SAVED_QUERY = gql`
   }
 `
 
-export { GET_SAVED_QUERY }
+export { GET_SAVED_QUERY_LIST, GET_SAVED_QUERY }

--- a/ui/src/components/Sidebar/index.tsx
+++ b/ui/src/components/Sidebar/index.tsx
@@ -31,6 +31,12 @@ const SidebarView: React.FC = () => {
           active={isSidebarActive('queries')}
           onClick={() => push('/queries')}
           icon={<TerminalIcon className='t-icon' />}
+          subNav={
+            <Sidebar.Item compact={false}
+              onClick={() => push('/queries/saved')}
+              active={isSidebarActive('/queries/saved')}
+              label='Saved Queries' level='sub' />
+          }
         />
         <Sidebar.Item
           label='Connect'

--- a/ui/src/pages/queries/saved/[savedQueryId]/index.tsx
+++ b/ui/src/pages/queries/saved/[savedQueryId]/index.tsx
@@ -1,0 +1,30 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { Fragment } from 'react'
+import { QueryTabsProvider } from 'src/state/contexts/query-tabs.context'
+import { QueryProvider } from 'src/state/contexts/query.context'
+import useCrumbsInit from 'src/views/hooks/useCrumbsInit'
+import QueryEditor from 'src/views/sql-query-editor'
+
+const SavedQueryEditionPage: NextPage = () => {
+  useCrumbsInit()
+
+  const router = useRouter()
+  const { savedQueryId } = router.query
+
+  return (
+    <Fragment>
+      <Head>
+        <title>Saved Query Edition - MergeStat</title>
+      </Head>
+      <QueryProvider>
+        <QueryTabsProvider>
+          <QueryEditor savedQueryId={savedQueryId} />
+        </QueryTabsProvider>
+      </QueryProvider>
+    </Fragment>
+  )
+}
+
+export default SavedQueryEditionPage

--- a/ui/src/pages/queries/saved/index.tsx
+++ b/ui/src/pages/queries/saved/index.tsx
@@ -1,7 +1,9 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
 import { Fragment } from 'react'
+import { SavedQueryProvider } from 'src/state/contexts/saved-query.context'
 import useCrumbsInit from 'src/views/hooks/useCrumbsInit'
+import SavedQueryList from 'src/views/saved-queries'
 
 const SavedQueryPage: NextPage = () => {
   useCrumbsInit()
@@ -11,6 +13,9 @@ const SavedQueryPage: NextPage = () => {
       <Head>
         <title>Saved Queries - MergeStat</title>
       </Head>
+      <SavedQueryProvider>
+        <SavedQueryList />
+      </SavedQueryProvider>
     </Fragment>
   )
 }

--- a/ui/src/pages/queries/saved/index.tsx
+++ b/ui/src/pages/queries/saved/index.tsx
@@ -1,0 +1,18 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import { Fragment } from 'react'
+import useCrumbsInit from 'src/views/hooks/useCrumbsInit'
+
+const SavedQueryPage: NextPage = () => {
+  useCrumbsInit()
+
+  return (
+    <Fragment>
+      <Head>
+        <title>Saved Queries - MergeStat</title>
+      </Head>
+    </Fragment>
+  )
+}
+
+export default SavedQueryPage

--- a/ui/src/state/contexts/query.context.tsx
+++ b/ui/src/state/contexts/query.context.tsx
@@ -15,6 +15,7 @@ type QueryContextT = {
   tabs: TabData[]
   dataQuery: QueryResultProps
   projection: string[]
+  showSettingsModal: boolean
 }
 
 type UseQueryContextT = [
@@ -29,7 +30,8 @@ const initialState: QueryContextT = {
   activeTab: 0,
   tabs: [],
   dataQuery: {},
-  projection: []
+  projection: [],
+  showSettingsModal: false
 }
 
 function useQueryEditor(): UseQueryContextT {
@@ -103,6 +105,13 @@ function useQuerySetState() {
     }))
   }
 
+  const setShowSettingsModal = (showSettingsModal: boolean) => {
+    setState(prev => ({
+      ...prev,
+      showSettingsModal
+    }))
+  }
+
   return {
     _,
     setQuery,
@@ -111,7 +120,8 @@ function useQuerySetState() {
     setActiveTab,
     setTabs,
     setDataQuery,
-    setProjection
+    setProjection,
+    setShowSettingsModal
   }
 }
 

--- a/ui/src/state/contexts/saved-query.context.tsx
+++ b/ui/src/state/contexts/saved-query.context.tsx
@@ -1,11 +1,14 @@
 import { createGenericContext } from 'lib/createGenericContext'
 import React, { PropsWithChildren } from 'react'
+import { SavedQueryData } from 'src/@types'
 
 type SavedQueryContext = {
   search: string
   total: number
   rows: number
   page: number
+  showRemoveSQModal: boolean
+  sqToRemove: SavedQueryData | null
 }
 
 type UseSavedQueryContext = [
@@ -17,7 +20,9 @@ const initialState: SavedQueryContext = {
   search: '',
   total: 0,
   rows: 20,
-  page: 0
+  page: 0,
+  showRemoveSQModal: false,
+  sqToRemove: null
 }
 
 function useSavedQuery(): UseSavedQueryContext {
@@ -70,12 +75,28 @@ function useSavedQuerySetState() {
     }))
   }
 
+  const setShowRemoveSQModal = (showRemoveSQModal: boolean) => {
+    setState(prev => ({
+      ...prev,
+      showRemoveSQModal
+    }))
+  }
+
+  const setSqToRemove = (sqToRemove: SavedQueryData) => {
+    setState(prev => ({
+      ...prev,
+      sqToRemove
+    }))
+  }
+
   return {
     _,
     setSearch,
     setTotal,
     setRows,
-    setPage
+    setPage,
+    setShowRemoveSQModal,
+    setSqToRemove
   }
 }
 

--- a/ui/src/state/contexts/saved-query.context.tsx
+++ b/ui/src/state/contexts/saved-query.context.tsx
@@ -1,0 +1,86 @@
+import { createGenericContext } from 'lib/createGenericContext'
+import React, { PropsWithChildren } from 'react'
+
+type SavedQueryContext = {
+  search: string
+  total: number
+  rows: number
+  page: number
+}
+
+type UseSavedQueryContext = [
+  SavedQueryContext,
+  React.Dispatch<React.SetStateAction<SavedQueryContext>>
+]
+
+const initialState: SavedQueryContext = {
+  search: '',
+  total: 0,
+  rows: 20,
+  page: 0
+}
+
+function useSavedQuery(): UseSavedQueryContext {
+  const [state, setState] = React.useState<SavedQueryContext>(initialState)
+  return [state, setState]
+}
+
+// Generate context
+const [useSavedQueryContext, SavedQueryContextProvider] = createGenericContext<UseSavedQueryContext>()
+
+// Generate provider
+const SavedQueryProvider: React.FC<PropsWithChildren> = (props: PropsWithChildren) => {
+  const [savedQueries, setSavedQueries] = useSavedQuery()
+
+  return (
+    <SavedQueryContextProvider value={[savedQueries, setSavedQueries]}>
+      {props.children}
+    </SavedQueryContextProvider>
+  )
+}
+
+function useSavedQuerySetState() {
+  const [_, setState] = useSavedQueryContext()
+
+  const setSearch = (search: string) => {
+    setState(prev => ({
+      ...prev,
+      search
+    }))
+  }
+
+  const setTotal = (total: number) => {
+    setState(prev => ({
+      ...prev,
+      total
+    }))
+  }
+
+  const setRows = (rows: number) => {
+    setState(prev => ({
+      ...prev,
+      rows
+    }))
+  }
+
+  const setPage = (page: number) => {
+    setState(prev => ({
+      ...prev,
+      page
+    }))
+  }
+
+  return {
+    _,
+    setSearch,
+    setTotal,
+    setRows,
+    setPage
+  }
+}
+
+export {
+  useSavedQueryContext,
+  SavedQueryProvider,
+  useSavedQuerySetState,
+}

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -14,6 +14,8 @@ export const MERGESTAT_TITLE = '- MergeStat'
 
 export const FONT_FAMILY = 'Inter, ui-sans-serif, system-ui,-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,sans-serif'
 
+export const MSM_NON_READ_ONLY = 'Non read-only queries are able to make changes in the underlying database, be careful!'
+
 export enum TEST_IDS {
   emptyRepository = 'empty-repository',
   emptyRepositoryTable = 'empty-repository-table',

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -1,7 +1,8 @@
 export const DATE_FORMAT = {
   A: 'MM/dd/yyyy HH:mm:ss',
   B: 'dd LLL yyyy - HH:mm',
-  C: 'dd-MM-yyyy'
+  C: 'dd-MM-yyyy',
+  D: 'LLL dd, yyyy'
 }
 
 export const API = {

--- a/ui/src/views/hooks/useQueryEditor.ts
+++ b/ui/src/views/hooks/useQueryEditor.ts
@@ -1,0 +1,108 @@
+import { useLazyQuery } from '@apollo/client'
+import { useEffect, useState } from 'react'
+import { ColumnInfo } from 'src/@types'
+import { ExecuteSqlQuery } from 'src/api-logic/graphql/generated/schema'
+import { EXECUTE_SQL } from 'src/api-logic/graphql/queries/sql-queries'
+import { useQueryContext, useQuerySetState } from 'src/state/contexts'
+import { useQueryTabsDispatch } from 'src/state/contexts/query-tabs.context'
+import { formatTimeExecution } from 'src/utils'
+import { States } from 'src/utils/constants'
+
+const useQueryEditor = (rowsLimit: number) => {
+  const [{ query, readOnly, expanded, dataQuery, projection, showSettingsModal }] = useQueryContext()
+  const { setQuery, setDataQuery, setProjection, setTabs, setActiveTab, setShowSettingsModal } = useQuerySetState()
+  const dispatch = useQueryTabsDispatch()
+
+  const [state, setState] = useState<States>(States.Empty)
+  const [rowLimitReached, setRowLimitReached] = useState(true)
+  const [executed, setExecuted] = useState(false)
+  const [aborterRef, setAbortRef] = useState(new AbortController())
+  const [loading, setLoading] = useState(false)
+  const [time, setTime] = useState('')
+  const [title, setTitle] = useState<string>('')
+  const [desc, setDesc] = useState<string>('')
+
+  const [executeSQL, { loading: loadingQuery, error, data }] = useLazyQuery<ExecuteSqlQuery>(EXECUTE_SQL, {
+    fetchPolicy: 'no-cache',
+    context: {
+      fetchOptions: {
+        signal: aborterRef.signal
+      },
+      queryDeduplication: false
+    }
+  })
+
+  const projectionChanged = (newProjection: string[]) => {
+    for (const p of newProjection) {
+      if (!projection.includes(p)) {
+        return true
+      }
+    }
+    return false
+  }
+
+  const checkProjection = (columns: ColumnInfo[]) => {
+    const newProjection = columns.map(c => c.name)
+    if (projectionChanged(newProjection)) {
+      setTabs([])
+      setActiveTab(0)
+      setProjection(newProjection)
+      dispatch({ reset: true })
+    }
+  }
+
+  useEffect(() => {
+    setLoading(loadingQuery)
+  }, [loadingQuery])
+
+  useEffect(() => {
+    if (data?.execSQL.rows?.length && data?.execSQL.rows?.length > 0) {
+      checkProjection(data?.execSQL.columns as ColumnInfo[])
+      setDataQuery(data?.execSQL)
+      setTime(formatTimeExecution(data?.execSQL.queryRunningTimeMs || 0))
+      setState(States.Filled)
+      setRowLimitReached(data?.execSQL.rows?.length > rowsLimit)
+    } else {
+      error ? setState(States.Error) : setState(States.Empty)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, error])
+
+  const executeSQLQuery = () => {
+    setLoading(true)
+    setAbortRef(new AbortController())
+    executeSQL({ variables: { sql: query, disableReadOnly: !readOnly, trackHistory: true } })
+    setExecuted(true)
+  }
+
+  const cancelSQLQuery = () => {
+    setState(States.Canceled)
+    aborterRef.abort()
+    setLoading(false)
+  }
+
+  return {
+    setQuery,
+    setShowSettingsModal,
+    setTitle,
+    setDesc,
+    executeSQLQuery,
+    cancelSQLQuery,
+    expanded,
+    dataQuery,
+    showSettingsModal,
+    state,
+    rowLimitReached,
+    executed,
+    readOnly,
+    loading,
+    error,
+    query,
+    data,
+    time,
+    title,
+    desc
+  }
+}
+
+export default useQueryEditor

--- a/ui/src/views/hooks/useSavedQuery.ts
+++ b/ui/src/views/hooks/useSavedQuery.ts
@@ -1,0 +1,67 @@
+import { useLazyQuery, useMutation } from '@apollo/client'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { AddSavedQueryMutation, GetSavedQueryQuery } from 'src/api-logic/graphql/generated/schema'
+import { ADD_SAVED_QUERY, UPDATE_SAVED_QUERY } from 'src/api-logic/graphql/mutations/saved-query'
+import { GET_SAVED_QUERY } from 'src/api-logic/graphql/queries/get-saved-query'
+import { showSuccessAlert } from 'src/utils/alerts'
+import useCurrentUser from './useCurrentUser'
+
+type useSavedQueryProps = {
+  savedQueryId?: string | string[]
+  title?: string
+  desc?: string
+  query?: string
+}
+
+const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps) => {
+  const router = useRouter()
+  const { data: userData } = useCurrentUser()
+
+  const [getSavedQuery, { data }] = useLazyQuery<GetSavedQueryQuery>(GET_SAVED_QUERY, { fetchPolicy: 'no-cache' })
+
+  useEffect(() => {
+    savedQueryId && getSavedQuery({ variables: { id: savedQueryId } })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const [addSavedQuery] = useMutation(ADD_SAVED_QUERY, {
+    onCompleted: (data: AddSavedQueryMutation) => {
+      router.push(`/queries/saved/${data.createSavedQuery?.savedQuery?.id}`)
+      showSuccessAlert('Saved as new query')
+    }
+  })
+
+  const [updateSavedQuery] = useMutation(UPDATE_SAVED_QUERY, {
+    onCompleted: () => {
+      showSuccessAlert('Query saved')
+    }
+  })
+
+  const addSavedQueryHandler = () => {
+    addSavedQuery({
+      variables: {
+        createdBy: userData?.currentMergeStatUser,
+        createdAt: 'now',
+        name: title,
+        description: desc,
+        sql: query
+      }
+    })
+  }
+
+  const updateSavedQueryHandler = () => {
+    updateSavedQuery({
+      variables: {
+        id: savedQueryId,
+        name: title,
+        description: desc,
+        sql: query
+      }
+    })
+  }
+
+  return { savedQuery: data?.savedQuery, addSavedQueryHandler, updateSavedQueryHandler }
+}
+
+export default useSavedQuery

--- a/ui/src/views/hooks/useSavedQuery.ts
+++ b/ui/src/views/hooks/useSavedQuery.ts
@@ -34,6 +34,7 @@ const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps)
   })
 
   const [updateSavedQuery] = useMutation(UPDATE_SAVED_QUERY, {
+    onError: () => null,
     onCompleted: () => {
       showSuccessAlert('Query saved')
     }

--- a/ui/src/views/hooks/useSavedQuery.ts
+++ b/ui/src/views/hooks/useSavedQuery.ts
@@ -1,6 +1,6 @@
 import { useLazyQuery, useMutation } from '@apollo/client'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { AddSavedQueryMutation, GetSavedQueryQuery } from 'src/api-logic/graphql/generated/schema'
 import { ADD_SAVED_QUERY, UPDATE_SAVED_QUERY } from 'src/api-logic/graphql/mutations/saved-query'
 import { GET_SAVED_QUERY } from 'src/api-logic/graphql/queries/get-saved-query'
@@ -17,6 +17,7 @@ type useSavedQueryProps = {
 const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps) => {
   const router = useRouter()
   const { data: userData } = useCurrentUser()
+  const [titleError, setTitleError] = useState<boolean>(false)
 
   const [getSavedQuery, { data }] = useLazyQuery<GetSavedQueryQuery>(GET_SAVED_QUERY, { fetchPolicy: 'no-cache' })
 
@@ -39,29 +40,37 @@ const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps)
   })
 
   const addSavedQueryHandler = () => {
-    addSavedQuery({
-      variables: {
-        createdBy: userData?.currentMergeStatUser,
-        createdAt: 'now',
-        name: title,
-        description: desc,
-        sql: query
-      }
-    })
+    if (title) {
+      addSavedQuery({
+        variables: {
+          createdBy: userData?.currentMergeStatUser,
+          createdAt: 'now',
+          name: title,
+          description: desc,
+          sql: query
+        }
+      })
+    } else {
+      setTitleError(true)
+    }
   }
 
   const updateSavedQueryHandler = () => {
-    updateSavedQuery({
-      variables: {
-        id: savedQueryId,
-        name: title,
-        description: desc,
-        sql: query
-      }
-    })
+    if (title) {
+      updateSavedQuery({
+        variables: {
+          id: savedQueryId,
+          name: title,
+          description: desc,
+          sql: query
+        }
+      })
+    } else {
+      setTitleError(true)
+    }
   }
 
-  return { savedQuery: data?.savedQuery, addSavedQueryHandler, updateSavedQueryHandler }
+  return { savedQuery: data?.savedQuery, titleError, setTitleError, addSavedQueryHandler, updateSavedQueryHandler }
 }
 
 export default useSavedQuery

--- a/ui/src/views/repositories/components/empty-repository-table.tsx
+++ b/ui/src/views/repositories/components/empty-repository-table.tsx
@@ -1,13 +1,12 @@
 import { Button, Panel } from '@mergestat/blocks'
 import { BookIcon, GithubIcon } from '@mergestat/icons'
 import Image from 'next/image'
-import Link from 'next/link'
+import { useRouter } from 'next/router'
 import React from 'react'
-// import { useRepositoriesSetState } from 'src/state/contexts/repositories.context'
 import { TEST_IDS } from 'src/utils/constants'
 
 export const EmptyRepositoryTable: React.FC = () => {
-  // const { setShowAddRepositoryModal } = useRepositoriesSetState()
+  const router = useRouter()
 
   return (
     <div data-testid={TEST_IDS.emptyRepositoryTable} className="flex-1 flex flex-col items-center justify-center">
@@ -18,11 +17,12 @@ export const EmptyRepositoryTable: React.FC = () => {
               <div className="w-full md_w-8/12 lg_w-6/12 p-8 lg_p-10 mx-auto">
                 <Image
                   className="inline-block"
-                  src={'/assets/illustration-repo-syncs.png'}
+                  src={'/assets/illustration-repos.png'}
                   width={300}
                   height={178}
                   layout="responsive"
                   alt=""
+                  priority
                 />
               </div>
 
@@ -31,9 +31,10 @@ export const EmptyRepositoryTable: React.FC = () => {
                 <h3 className="t-h3 mb-2">GitHub Authentication Token</h3>
                 <p className="t-text-muted">Add a personal access token to start importing from GitHub (and to work with private repos).</p>
                 <div className="t-button-toolbar mt-8">
-                  <Link href="/settings/github-authentication">
-                    <Button label="Authenticate GitHub" endIcon={<GithubIcon className="t-icon" />} />
-                  </Link>
+                  <Button label="Authenticate GitHub"
+                    endIcon={<GithubIcon className="t-icon" />}
+                    onClick={() => router.push('/settings/github-authentication')}
+                  />
                   <a href="https://docs.mergestat.com/mergestat/setup/github-authentication" target="_blank" rel="noreferrer" >
                     <Button
                       endIcon={<BookIcon className="t-icon" />}

--- a/ui/src/views/saved-queries/components/empty-saved-queries.tsx
+++ b/ui/src/views/saved-queries/components/empty-saved-queries.tsx
@@ -1,0 +1,14 @@
+import { Avatar } from '@mergestat/blocks'
+import { TerminalIcon } from '@mergestat/icons'
+import React from 'react'
+
+export const EmptySavedQueries: React.FC = () => {
+  return (
+    <div className="flex items-center justify-center h-full w-full">
+      <div className="flex flex-col items-center">
+        <Avatar icon={<TerminalIcon className="t-icon" />} size='lg' />
+        <p className="t-text-muted py-5">No saved queries yet</p>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/views/saved-queries/components/filter-footer.tsx
+++ b/ui/src/views/saved-queries/components/filter-footer.tsx
@@ -1,0 +1,65 @@
+import { Button, Label, Select, Toolbar } from '@mergestat/blocks'
+import { ChevronLeftIcon, ChevronRightIcon } from '@mergestat/icons'
+import React from 'react'
+import { useSavedQueryContext, useSavedQuerySetState } from 'src/state/contexts/saved-query.context'
+import { getMaxPagination } from 'src/utils'
+
+export const FilterFooter: React.FC = () => {
+  const [{ total, rows, page }] = useSavedQueryContext()
+  const { setRows, setPage } = useSavedQuerySetState()
+
+  return (
+    <div className='px-8 py-3 w-full flex bg-white border-t-2 border-gray-100'>
+      <div className='flex-1 overflow-x-auto overflow-y-hidden'>
+        <Toolbar className='t-toolbar flex-1 w-auto h-full space-x-4'>
+          <Toolbar.Left className='space-x-4 divide-x'>
+            <Toolbar.Item>
+              <div className='flex items-center'>
+                <Label className='mr-2 whitespace-nowrap text-gray-500' htmlFor='resultsPerPage'>
+                  Results per page
+                </Label>
+                <Select
+                  id='resultsPerPage'
+                  className="w-20"
+                  defaultValue='20'
+                  onChange={e => {
+                    setPage(0)
+                    setRows(+e.target.value)
+                  }}
+                >
+                  <option value='10'>10</option>
+                  <option value='20'>20</option>
+                  <option value='50'>50</option>
+                  <option value='100'>100</option>
+                </Select>
+              </div>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right className='space-x-4 divide-x'>
+            <Toolbar.Item className='pl-4 pr-1'>
+              <div className='flex items-center space-x-2 py-1'>
+                <p className='t-text-muted whitespace-nowrap text-sm'>
+                  {`${(page * rows) + 1}-${getMaxPagination(page, rows, total)} of ${total}`}
+                </p>
+                <Button
+                  isIconOnly
+                  disabled={page === 0}
+                  skin='borderless'
+                  startIcon={<ChevronLeftIcon className='t-icon' />}
+                  onClick={() => setPage(page - 1)}
+                />
+                <Button
+                  isIconOnly
+                  disabled={getMaxPagination(page, rows, total) >= total}
+                  skin='borderless'
+                  startIcon={<ChevronRightIcon className='t-icon' />}
+                  onClick={() => setPage(page + 1)}
+                />
+              </div>
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/views/saved-queries/components/filter-header.tsx
+++ b/ui/src/views/saved-queries/components/filter-header.tsx
@@ -1,0 +1,23 @@
+import { Input } from '@mergestat/blocks'
+import { SearchIcon } from '@mergestat/icons'
+import { debounce } from 'lodash'
+import React, { KeyboardEvent } from 'react'
+import { useSavedQuerySetState } from 'src/state/contexts/saved-query.context'
+
+export const FilterHeader: React.FC = () => {
+  const { setSearch } = useSavedQuerySetState()
+  const onChange = debounce((e) => setSearch(e.target.value), 300)
+
+  return (
+    <div className='px-8 py-3 w-full flex'>
+      <div className='flex-1 overflow-x-auto overflow-y-hidden'>
+        <Input placeholder="Search..."
+          startIcon={<SearchIcon className="t-icon t-icon-muted" />}
+          className="lg_w-2/5"
+          onChange={onChange}
+          onKeyUp={(e: KeyboardEvent<HTMLInputElement>) => (e.key === 'Enter' && setSearch((e.target as HTMLInputElement).value))}
+        />
+      </div>
+    </div>
+  )
+}

--- a/ui/src/views/saved-queries/components/saved-queries-table.tsx
+++ b/ui/src/views/saved-queries/components/saved-queries-table.tsx
@@ -1,4 +1,4 @@
-import { Button, EditableText } from '@mergestat/blocks'
+import { Button, EditableText, Panel } from '@mergestat/blocks'
 import { TerminalIcon, TrashIcon } from '@mergestat/icons'
 import { format } from 'date-fns'
 import { useRouter } from 'next/router'
@@ -26,64 +26,71 @@ export const SavedQueriesTable: React.FC<SavedQueriesTableProps> = ({ savedQueri
   return (
     <div className='flex flex-col flex-1'>
       {savedQueries.length < 1
-        ? <div className='flex flex-1 justify-center items-center bg-white py-5'>
-          Couldn&#39;t find any saved query!
+        ? <div className='flex justify-center py-5'>
+          <Panel className='rounded-md w-full shadow-sm mx-8'>
+            <Panel.Body className='p-0'>
+              <div className='flex justify-center items-center bg-white py-5'>
+                Couldn&#39;t find any saved query!
+              </div>
+            </Panel.Body>
+          </Panel>
         </div>
-        : <div className='flex flex-col min-w-0 bg-white h-full'>
-          <div className='flex-1 overflow-x-auto overflow-y-hidden'>
-            <table className='t-table-default t-table-hover border-b'>
-              <thead>
-                <tr className='bg-white'>
-                  <th scope='col' key='name' className='whitespace-nowrap'>Name</th>
-                  <th scope='col' key='createdAt' className='whitespace-nowrap'>Created At</th>
-                  <th scope='col' key='createdBy' className='whitespace-nowrap w-0 text-center'>Created By</th>
-                  <th scope='col' key='remove' className='whitespace-nowrap px-4'></th>
-                </tr>
-              </thead>
-
-              <tbody className='bg-white'>
-                {savedQueries.map((query) => (
-                  <tr key={query.id}>
-                    <td className=''>
-                      <EditableText
-                        className='flex-grow mr-5'
-                        icon={<TerminalIcon className="t-icon" />}
-                        title={{
-                          value: query.name || '',
-                          readOnly: true,
-                          onClick: () => router.push(`/queries/saved/${query.id}`)
-                        }}
-                        desc={{
-                          value: query.description || '',
-                          readOnly: true
-                        }}
-                      />
-                    </td>
-                    <td className='text-gray-500'>
-                      {query.createdAt ? format(new Date(query.createdAt?.toString()), DATE_FORMAT.D) : ''}
-                    </td>
-                    <td className='text-gray-500'>
-                      {query.createdBy === userData?.currentMergeStatUser ? 'Me' : query.createdBy}
-                    </td>
-                    <td className='text-gray-500 py-4 pl-4 pr-8'>
-                      <div className='t-button-toolbar'>
-                        {query.createdBy === userData?.currentMergeStatUser &&
-                          <Button isIconOnly
-                            skin="borderless-muted"
-                            startIcon={<TrashIcon className="t-icon" />}
-                            onClick={() => prepareToRemove(query)} />
-                        }
-                      </div>
-                    </td>
+        : <>
+          <div className='flex flex-col min-w-0 bg-white h-full'>
+            <div className='flex-1 overflow-x-auto overflow-y-hidden'>
+              <table className='t-table-default t-table-hover border-b'>
+                <thead>
+                  <tr className='bg-white'>
+                    <th scope='col' key='name' className='whitespace-nowrap'>Name</th>
+                    <th scope='col' key='createdAt' className='whitespace-nowrap'>Created At</th>
+                    <th scope='col' key='createdBy' className='whitespace-nowrap w-0 text-center'>Created By</th>
+                    <th scope='col' key='remove' className='whitespace-nowrap px-4'></th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      }
+                </thead>
 
-      <FilterFooter />
+                <tbody className='bg-white'>
+                  {savedQueries.map((query) => (
+                    <tr key={query.id}>
+                      <td>
+                        <EditableText
+                          className='flex-grow mr-5'
+                          icon={<TerminalIcon className="t-icon" />}
+                          title={{
+                            value: query.name || '',
+                            readOnly: true,
+                            onClick: () => router.push(`/queries/saved/${query.id}`)
+                          }}
+                          desc={{
+                            value: query.description || '',
+                            readOnly: true
+                          }}
+                        />
+                      </td>
+                      <td className='text-gray-500 py-5'>
+                        {query.createdAt ? format(new Date(query.createdAt?.toString()), DATE_FORMAT.D) : ''}
+                      </td>
+                      <td className='text-gray-500'>
+                        {query.createdBy === userData?.currentMergeStatUser ? 'Me' : query.createdBy}
+                      </td>
+                      <td className='text-gray-500 pl-4 pr-8'>
+                        <div className='t-button-toolbar'>
+                          {query.createdBy === userData?.currentMergeStatUser &&
+                            <Button isIconOnly
+                              skin="borderless-muted"
+                              startIcon={<TrashIcon className="t-icon" />}
+                              onClick={() => prepareToRemove(query)} />
+                          }
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+          <FilterFooter />
+        </>
+      }
     </div>
   )
 }

--- a/ui/src/views/saved-queries/components/saved-queries-table.tsx
+++ b/ui/src/views/saved-queries/components/saved-queries-table.tsx
@@ -1,0 +1,76 @@
+import { Button, EditableText } from '@mergestat/blocks'
+import { TerminalIcon, TrashIcon } from '@mergestat/icons'
+import { format } from 'date-fns'
+import Link from 'next/link'
+import React, { PropsWithChildren } from 'react'
+import { SavedQueryData } from 'src/@types'
+import { DATE_FORMAT } from 'src/utils/constants'
+import useCurrentUser from 'src/views/hooks/useCurrentUser'
+import { FilterFooter } from './filter-footer'
+
+type SavedQueriesTableProps = PropsWithChildren<{
+  savedQueries: SavedQueryData[]
+}>
+
+export const SavedQueriesTable: React.FC<SavedQueriesTableProps> = ({ savedQueries }: SavedQueriesTableProps) => {
+  const { data: userData } = useCurrentUser()
+
+  return (
+    <div className='flex flex-col flex-1'>
+      {savedQueries.length < 1
+        ? <div className='flex flex-1 justify-center items-center bg-white py-5'>
+          Couldn&#39;t find any saved query!
+        </div>
+        : <div className='flex flex-col min-w-0 bg-white h-full'>
+          <div className='flex-1 overflow-x-auto overflow-y-hidden'>
+            <table className='t-table-default t-table-hover border-b'>
+              <thead>
+                <tr className='bg-white'>
+                  <th scope='col' key='name' className='whitespace-nowrap'>Name</th>
+                  <th scope='col' key='createdAt' className='whitespace-nowrap'>Created At</th>
+                  <th scope='col' key='createdBy' className='whitespace-nowrap w-0 text-center'>Created By</th>
+                  <th scope='col' key='remove' className='whitespace-nowrap px-4'></th>
+                </tr>
+              </thead>
+
+              <tbody className='bg-white'>
+                {savedQueries.map((query) => (
+                  <tr key={query.id}>
+                    <td className=''>
+                      <EditableText
+                        className='flex-grow mr-5'
+                        icon={<TerminalIcon className="t-icon" />}
+                        title={{ value: query.name || '', readOnly: true }}
+                        desc={{ value: query.description || '', readOnly: true }}
+                      />
+                    </td>
+                    <td className='text-gray-500'>
+                      <Link href={`/queries/saved/${query.id}`}>
+                        <h4 className='text-gray-500 font-medium mb-0.5 t-text-default cursor-pointer hover_text-blue-600'>
+                          {query.createdAt ? format(new Date(query.createdAt?.toString()), DATE_FORMAT.D) : ''}
+                        </h4>
+                      </Link>
+                    </td>
+                    <td className='text-gray-500'>
+                      {query.createdBy === userData?.currentMergeStatUser ? 'Me' : query.createdBy}
+                    </td>
+                    <td className='text-gray-500 py-4 pl-4 pr-8'>
+                      <div className='t-button-toolbar'>
+                        <Button isIconOnly
+                          skin="borderless-muted"
+                          startIcon={<TrashIcon className="t-icon" />}
+                          onClick={() => null} />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      }
+
+      <FilterFooter />
+    </div>
+  )
+}

--- a/ui/src/views/saved-queries/components/saved-queries-table.tsx
+++ b/ui/src/views/saved-queries/components/saved-queries-table.tsx
@@ -30,7 +30,7 @@ export const SavedQueriesTable: React.FC<SavedQueriesTableProps> = ({ savedQueri
           <Panel className='rounded-md w-full shadow-sm mx-8'>
             <Panel.Body className='p-0'>
               <div className='flex justify-center items-center bg-white py-5'>
-                Couldn&#39;t find any saved query!
+                Couldn&#39;t find any saved queries.
               </div>
             </Panel.Body>
           </Panel>

--- a/ui/src/views/saved-queries/components/saved-queries-table.tsx
+++ b/ui/src/views/saved-queries/components/saved-queries-table.tsx
@@ -1,9 +1,10 @@
 import { Button, EditableText } from '@mergestat/blocks'
 import { TerminalIcon, TrashIcon } from '@mergestat/icons'
 import { format } from 'date-fns'
-import Link from 'next/link'
+import { useRouter } from 'next/router'
 import React, { PropsWithChildren } from 'react'
 import { SavedQueryData } from 'src/@types'
+import { useSavedQuerySetState } from 'src/state/contexts/saved-query.context'
 import { DATE_FORMAT } from 'src/utils/constants'
 import useCurrentUser from 'src/views/hooks/useCurrentUser'
 import { FilterFooter } from './filter-footer'
@@ -13,7 +14,14 @@ type SavedQueriesTableProps = PropsWithChildren<{
 }>
 
 export const SavedQueriesTable: React.FC<SavedQueriesTableProps> = ({ savedQueries }: SavedQueriesTableProps) => {
+  const router = useRouter()
   const { data: userData } = useCurrentUser()
+  const { setShowRemoveSQModal, setSqToRemove } = useSavedQuerySetState()
+
+  const prepareToRemove = (sq: SavedQueryData) => {
+    setSqToRemove(sq)
+    setShowRemoveSQModal(true)
+  }
 
   return (
     <div className='flex flex-col flex-1'>
@@ -40,26 +48,31 @@ export const SavedQueriesTable: React.FC<SavedQueriesTableProps> = ({ savedQueri
                       <EditableText
                         className='flex-grow mr-5'
                         icon={<TerminalIcon className="t-icon" />}
-                        title={{ value: query.name || '', readOnly: true }}
-                        desc={{ value: query.description || '', readOnly: true }}
+                        title={{
+                          value: query.name || '',
+                          readOnly: true,
+                          onClick: () => router.push(`/queries/saved/${query.id}`)
+                        }}
+                        desc={{
+                          value: query.description || '',
+                          readOnly: true
+                        }}
                       />
                     </td>
                     <td className='text-gray-500'>
-                      <Link href={`/queries/saved/${query.id}`}>
-                        <h4 className='text-gray-500 font-medium mb-0.5 t-text-default cursor-pointer hover_text-blue-600'>
-                          {query.createdAt ? format(new Date(query.createdAt?.toString()), DATE_FORMAT.D) : ''}
-                        </h4>
-                      </Link>
+                      {query.createdAt ? format(new Date(query.createdAt?.toString()), DATE_FORMAT.D) : ''}
                     </td>
                     <td className='text-gray-500'>
                       {query.createdBy === userData?.currentMergeStatUser ? 'Me' : query.createdBy}
                     </td>
                     <td className='text-gray-500 py-4 pl-4 pr-8'>
                       <div className='t-button-toolbar'>
-                        <Button isIconOnly
-                          skin="borderless-muted"
-                          startIcon={<TrashIcon className="t-icon" />}
-                          onClick={() => null} />
+                        {query.createdBy === userData?.currentMergeStatUser &&
+                          <Button isIconOnly
+                            skin="borderless-muted"
+                            startIcon={<TrashIcon className="t-icon" />}
+                            onClick={() => prepareToRemove(query)} />
+                        }
                       </div>
                     </td>
                   </tr>

--- a/ui/src/views/saved-queries/index.tsx
+++ b/ui/src/views/saved-queries/index.tsx
@@ -9,11 +9,12 @@ import { useSavedQueryContext, useSavedQuerySetState } from 'src/state/contexts/
 import { EmptySavedQueries } from './components/empty-saved-queries'
 import { FilterHeader } from './components/filter-header'
 import { SavedQueriesTable } from './components/saved-queries-table'
+import { RemoveSavedQueryModal } from './modals/remove-saved-query'
 
 const SavedQueryList: React.FC = () => {
   const router = useRouter()
 
-  const [{ search, rows, page }] = useSavedQueryContext()
+  const [{ search, rows, page, showRemoveSQModal }] = useSavedQueryContext()
   const { setTotal } = useSavedQuerySetState()
   const [pageLoaded, setPageLoaded] = useState(false)
   const [records, setRecords] = useState(false)
@@ -70,6 +71,8 @@ const SavedQueryList: React.FC = () => {
         ? <SavedQueriesTable savedQueries={data?.savedQueries ? data?.savedQueries.nodes : []} />
         : <EmptySavedQueries />
       }
+
+      {showRemoveSQModal && <RemoveSavedQueryModal />}
     </>
   )
 }

--- a/ui/src/views/saved-queries/index.tsx
+++ b/ui/src/views/saved-queries/index.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@apollo/client'
 import { Button } from '@mergestat/blocks'
-import { PlusIcon } from '@mergestat/icons'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { GetSavedQueryListQuery } from 'src/api-logic/graphql/generated/schema'
@@ -49,19 +48,11 @@ const SavedQueryList: React.FC = () => {
         <div className="text-xl font-semibold">Saved Queries</div>
 
         <div className='flex items-center gap-x-7'>
-          {records
-            ? <Button
-              className='whitespace-nowrap justify-center'
-              label='Query'
-              onClick={gotToQueryEditor}
-            />
-            : <Button
-              className='whitespace-nowrap justify-center'
-              label='Add Query'
-              startIcon={<PlusIcon className='t-icon' />}
-              onClick={gotToQueryEditor}
-            />
-          }
+          <Button
+            className='whitespace-nowrap justify-center'
+            label='Query'
+            onClick={gotToQueryEditor}
+          />
         </div>
       </div>
 

--- a/ui/src/views/saved-queries/index.tsx
+++ b/ui/src/views/saved-queries/index.tsx
@@ -1,0 +1,77 @@
+import { useQuery } from '@apollo/client'
+import { Button } from '@mergestat/blocks'
+import { PlusIcon } from '@mergestat/icons'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { GetSavedQueryListQuery } from 'src/api-logic/graphql/generated/schema'
+import { GET_SAVED_QUERY_LIST } from 'src/api-logic/graphql/queries/get-saved-query'
+import { useSavedQueryContext, useSavedQuerySetState } from 'src/state/contexts/saved-query.context'
+import { EmptySavedQueries } from './components/empty-saved-queries'
+import { FilterHeader } from './components/filter-header'
+import { SavedQueriesTable } from './components/saved-queries-table'
+
+const SavedQueryList: React.FC = () => {
+  const router = useRouter()
+
+  const [{ search, rows, page }] = useSavedQueryContext()
+  const { setTotal } = useSavedQuerySetState()
+  const [pageLoaded, setPageLoaded] = useState(false)
+  const [records, setRecords] = useState(false)
+
+  const { data, refetch } = useQuery<GetSavedQueryListQuery>(GET_SAVED_QUERY_LIST, {
+    variables: { search, first: rows, offset: (page * rows) },
+    fetchPolicy: 'no-cache'
+  })
+
+  useEffect(() => {
+    setTotal(data?.savedQueries?.totalCount || 0)
+
+    if (!pageLoaded && data?.all) {
+      setRecords(data?.all?.totalCount > 0)
+      setPageLoaded(true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
+
+  useEffect(() => {
+    refetch({ search, first: rows, offset: (page * rows) })
+  }, [refetch, search, rows, page])
+
+  const gotToQueryEditor = () => {
+    router.push('/queries')
+  }
+
+  return (
+    <>
+      {/* Header */}
+      <div className='bg-white overflow-auto flex justify-between items-center h-17 w-full border-b px-8 py-2'>
+        <div className="text-xl font-semibold">Saved Queries</div>
+
+        <div className='flex items-center gap-x-7'>
+          {records
+            ? <Button
+              className='whitespace-nowrap justify-center'
+              label='Query'
+              onClick={gotToQueryEditor}
+            />
+            : <Button
+              className='whitespace-nowrap justify-center'
+              label='Add Query'
+              startIcon={<PlusIcon className='t-icon' />}
+              onClick={gotToQueryEditor}
+            />
+          }
+        </div>
+      </div>
+
+      {/* Body */}
+      {records && <FilterHeader />}
+      {records
+        ? <SavedQueriesTable savedQueries={data?.savedQueries ? data?.savedQueries.nodes : []} />
+        : <EmptySavedQueries />
+      }
+    </>
+  )
+}
+
+export default SavedQueryList

--- a/ui/src/views/saved-queries/modals/remove-saved-query.tsx
+++ b/ui/src/views/saved-queries/modals/remove-saved-query.tsx
@@ -1,0 +1,78 @@
+import { useMutation } from '@apollo/client'
+import { Button, Modal, Toolbar } from '@mergestat/blocks'
+import { TrashIcon, XIcon } from '@mergestat/icons'
+import React, { useCallback } from 'react'
+import { REMOVE_SAVED_QUERY } from 'src/api-logic/graphql/mutations/saved-query'
+import { useSavedQueryContext, useSavedQuerySetState } from 'src/state/contexts/saved-query.context'
+import { showSuccessAlert } from 'src/utils/alerts'
+
+export const RemoveSavedQueryModal: React.FC = () => {
+  const [{ sqToRemove }] = useSavedQueryContext()
+  const { setShowRemoveSQModal } = useSavedQuerySetState()
+
+  const close = useCallback(() => {
+    setShowRemoveSQModal(false)
+  }, [setShowRemoveSQModal])
+
+  const [removeImport] = useMutation(REMOVE_SAVED_QUERY, {
+    onCompleted: () => {
+      showSuccessAlert('Saved query removed')
+      close()
+    },
+    awaitRefetchQueries: true,
+    refetchQueries: () => ['getSavedQueryList']
+  })
+
+  return (
+    <Modal open onClose={close} size="sm">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>Remove Saved Query</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body>
+        <div className='px-6 py-6'>
+          Are you sure you want to remove <strong className="font-semibold text-gray-800">{sqToRemove?.name}</strong> query?
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="secondary"
+                onClick={close}
+                className="my-3 mr-3"
+              >
+                Cancel
+              </Button>
+              <Button
+                skin="danger"
+                onClick={() => removeImport({
+                  variables: { id: sqToRemove?.id }
+                })}
+                startIcon={<TrashIcon className="t-icon" />}
+                className="my-3"
+              >
+                Remove
+              </Button>
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/ui/src/views/sql-query-editor/components/sql-editor-section.tsx
+++ b/ui/src/views/sql-query-editor/components/sql-editor-section.tsx
@@ -1,6 +1,4 @@
 
-import { Toggle, Tooltip } from '@mergestat/blocks'
-import { CircleInformationIcon } from '@mergestat/icons'
 import Editor from '@monaco-editor/react'
 import { useEffect, useRef } from 'react'
 import { useQueryContext, useQuerySetState } from 'src/state/contexts/query.context'
@@ -11,9 +9,8 @@ type SQLEditorSectionProps = {
 }
 
 const SQLEditorSection: React.FC<SQLEditorSectionProps> = ({ onEnterKey }: SQLEditorSectionProps) => {
-  const [{ query, readOnly }] = useQueryContext()
-  const { setQuery, setReadOnly } = useQuerySetState()
-  const message = 'Non read-only queries are able to make changes in the underlying database, be careful!'
+  const [{ query }] = useQueryContext()
+  const { setQuery } = useQuerySetState()
 
   const resizeElement = useRef<HTMLDivElement | null>(null)
   const resizerElement = useRef<HTMLDivElement | null>(null)
@@ -82,13 +79,6 @@ const SQLEditorSection: React.FC<SQLEditorSectionProps> = ({ onEnterKey }: SQLEd
               },
             }}
           />
-          <div className='flex items-center pl-4 py-4 border-t border-gray-300'>
-            <Toggle isChecked={readOnly} onChange={(value) => setReadOnly(value)} />
-            <span className='text-gray-500 pl-2 pr-1'>Read-only</span>
-            <Tooltip content={message} offset={[0, 10]}>
-              <CircleInformationIcon className='t-icon t-icon-muted pl-1' />
-            </Tooltip>
-          </div>
         </div>
       </div>
       <div className='t-resizer z-10' ref={resizerElement} />

--- a/ui/src/views/sql-query-editor/components/sql-editor-section.tsx
+++ b/ui/src/views/sql-query-editor/components/sql-editor-section.tsx
@@ -64,11 +64,11 @@ const SQLEditorSection: React.FC<SQLEditorSectionProps> = ({ onEnterKey }: SQLEd
   return (
     <>
       <div
-        className='w-full p-8'
+        className='w-full'
         ref={resizeElement}
         style={{ height: '360px', minHeight: '200px' }}
       >
-        <div className='h-full flex-col relative pb-14 pt-4 bg-white rounded border border-gray-300'>
+        <div className='h-full flex-col relative pb-14 pt-4 bg-white'>
           <Editor
             className='text-sm font-mono'
             value={query}

--- a/ui/src/views/sql-query-editor/components/state-filled.tsx
+++ b/ui/src/views/sql-query-editor/components/state-filled.tsx
@@ -93,9 +93,9 @@ const QueryEditorFilled: React.FC<QueryEditorFilledProps> = ({ rowLimit, rowLimi
                   onClick={() => setExpanded(!expanded)}
                 />
               </Toolbar.Item>
-            </Toolbar.Right >
-          </Toolbar >
-        </Tabs.List >
+            </Toolbar.Right>
+          </Toolbar>
+        </Tabs.List>
         <Tabs.Panels className='flex-1 overflow-auto'>
           {tabs.map((tab, index) => (
             <Tabs.Panel key={`tab-panel-${index}`} className='h-full flex flex-col'>
@@ -103,8 +103,8 @@ const QueryEditorFilled: React.FC<QueryEditorFilledProps> = ({ rowLimit, rowLimi
             </Tabs.Panel>
           ))}
         </Tabs.Panels>
-      </Tabs >
-    </div >
+      </Tabs>
+    </div>
   )
 }
 

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -129,11 +129,17 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
               </Tooltip>
             </div>}
 
-            <CogIcon className='t-icon cursor-pointer text-gray-500'
+            <Button isIconOnly
+              skin='borderless-muted'
+              startIcon={<CogIcon className='t-icon' />}
               onClick={() => setShowSettingsModal(true)}
             />
 
-            <ClockHistoryIcon className='t-icon cursor-pointer text-gray-500' />
+            <Button isIconOnly
+              skin='borderless-muted'
+              startIcon={<ClockHistoryIcon className='t-icon' />}
+              onClick={() => null}
+            />
 
             <div className='flex gap-x-2'>
               <SplitButton

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -1,6 +1,7 @@
 import { useLazyQuery } from '@apollo/client'
-import { Alert, Button, Spinner, Toolbar } from '@mergestat/blocks'
-import { useEffect, useState } from 'react'
+import { Alert, Button, EditableText, Spinner, SplitButton } from '@mergestat/blocks'
+import { ClockHistoryIcon, CogIcon, TerminalIcon } from '@mergestat/icons'
+import { ChangeEvent, useEffect, useState } from 'react'
 import { ColumnInfo } from 'src/@types'
 import { ExecuteSqlQuery } from 'src/api-logic/graphql/generated/schema'
 import { EXECUTE_SQL } from 'src/api-logic/graphql/queries/sql-queries'
@@ -28,6 +29,8 @@ const QueryEditor: React.FC = () => {
   const [aborterRef, setAbortRef] = useState(new AbortController())
   const [loading, setLoading] = useState(false)
   const [time, setTime] = useState('')
+  const [title, setTitle] = useState<string>('')
+  const [desc, setDesc] = useState<string>('')
 
   const [executeSQL, { loading: loadingQuery, error, data }] = useLazyQuery<ExecuteSqlQuery>(EXECUTE_SQL, {
     fetchPolicy: 'no-cache',
@@ -91,23 +94,55 @@ const QueryEditor: React.FC = () => {
   return (
     <>
       {/* Header */}
-      {!expanded && <div className='bg-white overflow-auto flex h-16 w-full border-b px-8'>
-        <Toolbar className='flex-1 space-x-4 w-auto h-full'>
-          <Toolbar.Left>
-            <h2 className='t-h2 mb-0'>Queries</h2>
-          </Toolbar.Left>
-          <Toolbar.Right>
-            <Button skin="secondary" onClick={cancelSQLQuery} disabled={!loading}>
-              Cancel
-            </Button>
-            <Button className='whitespace-nowrap' label='Execute (Shift + Enter)'
-              endIcon={loading && <Spinner size='sm' className='ml-2' />}
-              disabled={loading}
-              onClick={() => executeSQLQuery()}
-            />
-          </Toolbar.Right>
-        </Toolbar>
-      </div>}
+      {!expanded &&
+        <div className='bg-white overflow-auto flex justify-between items-center h-17 w-full border-b px-8 py-2'>
+          <EditableText
+            className='flex-grow mr-5'
+            icon={<TerminalIcon className="t-icon" />}
+            title={{
+              placeholder: 'Untitled',
+              value: title,
+              onChange: (e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)
+            }}
+            desc={{
+              placeholder: 'This is a short description',
+              value: desc,
+              onChange: (e: ChangeEvent<HTMLInputElement>) => setDesc(e.target.value)
+            }}
+          />
+
+          <div className='flex items-center gap-x-8'>
+            <CogIcon className='t-icon cursor-pointer text-gray-500' />
+            <ClockHistoryIcon className='t-icon cursor-pointer text-gray-500' />
+
+            <div className='flex gap-x-2'>
+              <SplitButton
+                text="Save"
+                items={[
+                  {
+                    text: 'Save as new...',
+                  }
+                ]}
+                onButtonClick={() => console.log('button click')}
+                onItemClick={(index: number) => console.log('item click: ' + index)}
+              />
+
+              {loading
+                ? <Button
+                  className='whitespace-nowrap justify-center w-32'
+                  label='Cancel'
+                  skin="secondary"
+                  startIcon={loading && <Spinner size='sm' className='mr-4' />}
+                  onClick={cancelSQLQuery} />
+                : <Button
+                  className='whitespace-nowrap justify-center ml-0 w-32'
+                  label='Run (⇧ + ↵)'
+                  onClick={() => executeSQLQuery()}
+                />}
+            </div>
+          </div>
+        </div>}
+
       {!readOnly && !expanded && <Alert isInline type="warning" className='pl-4 p-3 bg-yellow-50 border-b border-yellow-300'>
         <span className='text-yellow-900'>
           Non read-only queries are able to make changes in the underlying database, be careful!

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -1,14 +1,9 @@
-import { useLazyQuery } from '@apollo/client'
 import { Button, EditableText, Spinner, SplitButton, Tooltip } from '@mergestat/blocks'
 import { ClockHistoryIcon, CogIcon, TerminalIcon, WarningFilledIcon } from '@mergestat/icons'
-import { ChangeEvent, useEffect, useState } from 'react'
-import { ColumnInfo } from 'src/@types'
-import { ExecuteSqlQuery } from 'src/api-logic/graphql/generated/schema'
-import { EXECUTE_SQL } from 'src/api-logic/graphql/queries/sql-queries'
-import { useQueryTabsDispatch } from 'src/state/contexts/query-tabs.context'
-import { useQueryContext, useQuerySetState } from 'src/state/contexts/query.context'
-import { formatTimeExecution } from 'src/utils'
+import { ChangeEvent, useEffect } from 'react'
 import { MSM_NON_READ_ONLY, States } from 'src/utils/constants'
+import useQueryEditor from '../hooks/useQueryEditor'
+import useSavedQuery from '../hooks/useSavedQuery'
 import SQLEditorSection from './components/sql-editor-section'
 import QueryEditorCanceled from './components/state-canceled'
 import QueryEditorEmpty from './components/state-empty'
@@ -25,79 +20,19 @@ type QueryEditorProps = {
 const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorProps) => {
   const ROWS_LIMIT = 1000
 
-  console.log('Saved Query ID: ', savedQueryId)
+  const {
+    setQuery, setShowSettingsModal, setTitle, setDesc, executeSQLQuery, cancelSQLQuery,
+    expanded, dataQuery, showSettingsModal, state, rowLimitReached, executed, readOnly, loading, error, query, data, time, title, desc
+  } = useQueryEditor(ROWS_LIMIT)
 
-  const [{ query, readOnly, expanded, dataQuery, projection, showSettingsModal }] = useQueryContext()
-  const { setDataQuery, setProjection, setTabs, setActiveTab, setShowSettingsModal } = useQuerySetState()
-  const dispatch = useQueryTabsDispatch()
-
-  const [state, setState] = useState<States>(States.Empty)
-  const [rowLimitReached, setRowLimitReached] = useState(true)
-  const [executed, setExecuted] = useState(false)
-  const [aborterRef, setAbortRef] = useState(new AbortController())
-  const [loading, setLoading] = useState(false)
-  const [time, setTime] = useState('')
-  const [title, setTitle] = useState<string>('')
-  const [desc, setDesc] = useState<string>('')
-
-  const [executeSQL, { loading: loadingQuery, error, data }] = useLazyQuery<ExecuteSqlQuery>(EXECUTE_SQL, {
-    fetchPolicy: 'no-cache',
-    context: {
-      fetchOptions: {
-        signal: aborterRef.signal
-      },
-      queryDeduplication: false
-    }
-  })
-
-  const projectionChanged = (newProjection: string[]) => {
-    for (const p of newProjection) {
-      if (!projection.includes(p)) {
-        return true
-      }
-    }
-    return false
-  }
-
-  const checkProjection = (columns: ColumnInfo[]) => {
-    const newProjection = columns.map(c => c.name)
-    if (projectionChanged(newProjection)) {
-      setTabs([])
-      setActiveTab(0)
-      setProjection(newProjection)
-      dispatch({ reset: true })
-    }
-  }
+  const { savedQuery, addSavedQueryHandler, updateSavedQueryHandler } = useSavedQuery({ savedQueryId, title, desc, query })
 
   useEffect(() => {
-    setLoading(loadingQuery)
-  }, [loadingQuery])
-
-  useEffect(() => {
-    if (data?.execSQL.rows?.length && data?.execSQL.rows?.length > 0) {
-      checkProjection(data?.execSQL.columns as ColumnInfo[])
-      setDataQuery(data?.execSQL)
-      setTime(formatTimeExecution(data?.execSQL.queryRunningTimeMs || 0))
-      setState(States.Filled)
-      setRowLimitReached(data?.execSQL.rows?.length > ROWS_LIMIT)
-    } else {
-      error ? setState(States.Error) : setState(States.Empty)
-    }
+    setTitle(savedQuery?.name || '')
+    setDesc(savedQuery?.description || '')
+    setQuery(savedQuery?.sql || '')
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, error])
-
-  const executeSQLQuery = () => {
-    setLoading(true)
-    setAbortRef(new AbortController())
-    executeSQL({ variables: { sql: query, disableReadOnly: !readOnly, trackHistory: true } })
-    setExecuted(true)
-  }
-
-  const cancelSQLQuery = () => {
-    setState(States.Canceled)
-    aborterRef.abort()
-    setLoading(false)
-  }
+  }, [savedQuery])
 
   return (
     <>
@@ -108,12 +43,12 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
             className='flex-grow mr-5'
             icon={<TerminalIcon className="t-icon" />}
             title={{
-              placeholder: 'Untitled',
+              placeholder: 'Untitled Saved Query',
               value: title,
               onChange: (e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)
             }}
             desc={{
-              placeholder: 'This is a short description',
+              placeholder: 'Enter a short description for this query (optional)',
               value: desc,
               onChange: (e: ChangeEvent<HTMLInputElement>) => setDesc(e.target.value)
             }}
@@ -142,16 +77,19 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
             />
 
             <div className='flex gap-x-2'>
-              <SplitButton
-                text="Save"
-                items={[
-                  {
-                    text: 'Save as new...',
-                  }
-                ]}
-                onButtonClick={() => console.log('button click')}
-                onItemClick={(index: number) => console.log('item click: ' + index)}
-              />
+              {savedQueryId
+                ? <SplitButton
+                  text="Save"
+                  items={[{ text: 'Save as new...' }]}
+                  onButtonClick={updateSavedQueryHandler}
+                  onItemClick={addSavedQueryHandler}
+                />
+                : <Button
+                  className='whitespace-nowrap justify-center'
+                  label='Save as new'
+                  skin="secondary"
+                  onClick={addSavedQueryHandler}
+                />}
 
               {loading
                 ? <Button

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -51,7 +51,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
             title={{
               placeholder: 'Untitled Saved Query',
               value: title,
-              error: titleError,
+              required: titleError,
               onChange: (e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)
             }}
             desc={{

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -77,11 +77,13 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
               onClick={() => setShowSettingsModal(true)}
             />
 
-            <Button isIconOnly
-              skin='borderless-muted'
-              startIcon={<ClockHistoryIcon className='t-icon' />}
-              onClick={() => null}
-            />
+            <Tooltip content='Query history coming soon' placement='bottom' offset={[0, 10]}>
+              <Button isIconOnly disabled
+                skin='borderless-muted'
+                startIcon={<ClockHistoryIcon className='t-icon' />}
+                onClick={() => null}
+              />
+            </Tooltip>
 
             <div className='flex gap-x-2'>
               {savedQueryId

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -26,7 +26,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
     loading, error, query, data, time, title, desc
   } = useQueryEditor(ROWS_LIMIT)
 
-  const { savedQuery, addSavedQueryHandler, updateSavedQueryHandler } = useSavedQuery({ savedQueryId, title, desc, query })
+  const { savedQuery, titleError, setTitleError, addSavedQueryHandler, updateSavedQueryHandler } = useSavedQuery({ savedQueryId, title, desc, query })
 
   useEffect(() => {
     setTitle(savedQuery?.name || '')
@@ -34,6 +34,11 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
     savedQueryId && setQuery(savedQuery?.sql || '')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [savedQuery])
+
+  useEffect(() => {
+    title !== '' && setTitleError(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [title])
 
   return (
     <>
@@ -46,6 +51,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
             title={{
               placeholder: 'Untitled Saved Query',
               value: title,
+              error: titleError,
               onChange: (e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)
             }}
             desc={{

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -17,8 +17,15 @@ import QueryEditorFilled from './components/state-filled'
 import QueryEditorLoading from './components/state-loading'
 import { QuerySettingsModal } from './modals/query-setting'
 
-const QueryEditor: React.FC = () => {
+type QueryEditorProps = {
+  savedQueryId?: string | string[]
+  children?: React.ReactNode
+}
+
+const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorProps) => {
   const ROWS_LIMIT = 1000
+
+  console.log('Saved Query ID: ', savedQueryId)
 
   const [{ query, readOnly, expanded, dataQuery, projection, showSettingsModal }] = useQueryContext()
   const { setDataQuery, setProjection, setTabs, setActiveTab, setShowSettingsModal } = useQuerySetState()

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -22,7 +22,8 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
 
   const {
     setQuery, setShowSettingsModal, setTitle, setDesc, executeSQLQuery, cancelSQLQuery,
-    expanded, dataQuery, showSettingsModal, state, rowLimitReached, executed, readOnly, loading, error, query, data, time, title, desc
+    expanded, dataQuery, showSettingsModal, state, rowLimitReached, executed, readOnly,
+    loading, error, query, data, time, title, desc
   } = useQueryEditor(ROWS_LIMIT)
 
   const { savedQuery, addSavedQueryHandler, updateSavedQueryHandler } = useSavedQuery({ savedQueryId, title, desc, query })
@@ -30,7 +31,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
   useEffect(() => {
     setTitle(savedQuery?.name || '')
     setDesc(savedQuery?.description || '')
-    setQuery(savedQuery?.sql || '')
+    savedQueryId && setQuery(savedQuery?.sql || '')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [savedQuery])
 
@@ -107,6 +108,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
           </div>
         </div>}
 
+      {/* Body */}
       <div className='flex flex-col flex-1 items-center overflow-auto'>
         {/* SQL editor */}
         {!expanded && <SQLEditorSection

--- a/ui/src/views/sql-query-editor/modals/query-setting.tsx
+++ b/ui/src/views/sql-query-editor/modals/query-setting.tsx
@@ -1,0 +1,68 @@
+import { Button, Modal, Toggle, Toolbar } from '@mergestat/blocks'
+import { XIcon } from '@mergestat/icons'
+import React, { useCallback, useState } from 'react'
+import { useQueryContext, useQuerySetState } from 'src/state/contexts'
+import { MSM_NON_READ_ONLY } from 'src/utils/constants'
+
+export const QuerySettingsModal: React.FC = () => {
+  const [{ readOnly }] = useQueryContext()
+  const { setShowSettingsModal, setReadOnly } = useQuerySetState()
+  const [readOnlyLocal, setReadOnlyLocal] = useState(readOnly)
+
+  const close = useCallback(() => {
+    setShowSettingsModal(false)
+  }, [setShowSettingsModal])
+
+  return (
+    <Modal open onClose={close} size="sm">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>Query Settings</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body>
+        <div className='flex px-6 py-6'>
+          <div className='flex justify-center mt-1'>
+            <Toggle isChecked={readOnlyLocal} onChange={(value) => setReadOnlyLocal(value)} />
+          </div>
+          <div className='flex flex-col pl-4'>
+            <span className='text-gray-600 mb-2'>Read-only</span>
+            <span className='text-gray-500 text-sm'>{MSM_NON_READ_ONLY}</span>
+          </div>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button skin="secondary" onClick={close} className="my-3 mr-3" >
+                Cancel
+              </Button>
+              <Button className="my-3"
+                onClick={() => {
+                  setReadOnly(readOnlyLocal)
+                  close()
+                }}
+              >
+                Save
+              </Button>
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Footer>
+    </Modal>
+  )
+}


### PR DESCRIPTION
Starting implementation for `Saved Queries`. (Resolves #783)

- Implementing first approach for Saved queries.
- Fixing bug for empty repository (no showing image).

![saved-queries](https://user-images.githubusercontent.com/109089565/217122061-4deab7ab-26ea-455c-b210-243c6096b1f4.png)
