### PR TITLE
feat(importer):Adding rate limit and handling syncs to respect imports in progress

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -16,9 +16,12 @@ import (
 	"time"
 
 	"github.com/mergestat/mergestat/internal/cron"
+	"github.com/mergestat/mergestat/internal/db"
+	"github.com/mergestat/mergestat/internal/helper"
 	"github.com/mergestat/mergestat/internal/jobs/repo"
 	"github.com/mergestat/mergestat/internal/syncer"
 	"github.com/mergestat/mergestat/internal/timeout"
+	"github.com/mergestat/mergestat/queries"
 	"github.com/mergestat/sqlq"
 	"github.com/mergestat/sqlq/runtime/embed"
 	"github.com/mergestat/sqlq/schema"
@@ -176,6 +179,8 @@ func main() {
 		if rlr.Remaining <= 400 {
 			delayDur = untilResetDur
 		}
+
+		helper.WaitForImports(ctx, &l, queries.NewQuerier(db.New(pool)))
 
 		logger.Info().
 			Int("remaining", rlr.Remaining).

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -180,7 +180,9 @@ func main() {
 			delayDur = untilResetDur
 		}
 
-		helper.WaitForImports(ctx, &l, queries.NewQuerier(db.New(pool)))
+		if err := helper.WaitForImports(ctx, &l, queries.NewQuerier(db.New(pool))); err != nil {
+			l.Err(err).Msgf("error waiting for imports:%v", err)
+		}
 
 		logger.Info().
 			Int("remaining", rlr.Remaining).

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -181,7 +181,7 @@ func main() {
 		}
 
 		if err := helper.WaitForImports(ctx, &l, queries.NewQuerier(db.New(pool))); err != nil {
-			l.Err(err).Msgf("error waiting for imports:%v", err)
+			l.Err(err).Msgf("error waiting for imports: %v", err)
 		}
 
 		logger.Info().

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/libgit2/git2go/v33 v33.0.9
 	github.com/mergestat/gitutils v0.0.0-20221108145951-dde3591e4b3b
-	github.com/mergestat/sqlq v0.0.0-20230210225402-daece01122ea
+	github.com/mergestat/sqlq v0.0.0-20230220180215-4d3d6bf73f52
 	github.com/prometheus/client_golang v1.14.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/shurcooL/githubv4 v0.0.0-20221229060216-a8d4a561cc93

--- a/go.sum
+++ b/go.sum
@@ -917,6 +917,8 @@ github.com/mergestat/mergestat-lite v0.5.10 h1:3KBUQoRwC27bLHLXUWU7UDjP9IBtumb4v
 github.com/mergestat/mergestat-lite v0.5.10/go.mod h1:tQYFBsEpWDfJ37DQIh3I9ZC2qmVpES9mtJPMDUG64zM=
 github.com/mergestat/sqlq v0.0.0-20230210225402-daece01122ea h1:ChYPcwyZ1Q1t7T0OXFRNIj2OTU/scRKK3Ulga1AbIZc=
 github.com/mergestat/sqlq v0.0.0-20230210225402-daece01122ea/go.mod h1:zAYNS4EWE+yQGz1vIfqUV0V6MIYobv446Gc3toCHmZs=
+github.com/mergestat/sqlq v0.0.0-20230220180215-4d3d6bf73f52 h1:FZhGK0maKd6B0g13U7K+swRRihx8XIvI3+QFmcPVIOE=
+github.com/mergestat/sqlq v0.0.0-20230220180215-4d3d6bf73f52/go.mod h1:zAYNS4EWE+yQGz1vIfqUV0V6MIYobv446Gc3toCHmZs=
 github.com/mergestat/timediff v0.0.3 h1:ucCNh4/ZrTPjFZ081PccNbhx9spymCJkFxSzgVuPU+Y=
 github.com/mergestat/timediff v0.0.3/go.mod h1:yvMUaRu2oetc+9IbPLYBJviz6sA7xz8OXMDfhBl7YSI=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -766,11 +766,11 @@ type MergestatSavedQuery struct {
 	// timestamp when query was created
 	CreatedAt sql.NullTime
 	// query name
-	Name sql.NullString
+	Name string
 	// query description
 	Description sql.NullString
 	// query sql
-	Sql sql.NullString
+	Sql string
 	// query metadata
 	Metadata pgtype.JSONB
 }

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -11,6 +11,7 @@ import (
 )
 
 type Querier interface {
+	CheckRunningImps(ctx context.Context) (int64, error)
 	CleanOldRepoSyncQueue(ctx context.Context, dollar_1 int32) error
 	DeleteGitHubRepoInfo(ctx context.Context, repoID uuid.UUID) error
 	DeleteRemovedRepos(ctx context.Context, arg DeleteRemovedReposParams) error

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -21,6 +21,9 @@ SELECT id, created_at, updated_at, type, settings FROM dequeued;
 -- name: UpdateImportStatus :exec
 UPDATE mergestat.repo_imports SET import_status = @status::TEXT, import_error = @error::TEXT WHERE id = @ID;
 
+-- name: CheckRunningImps :one
+SELECT COUNT(*) FROM mergestat.repo_imports WHERE import_status = 'RUNNING';
+
 -- name: UpsertRepo :exec
 INSERT INTO public.repos (repo, is_github, repo_import_id) VALUES($1, $2, $3)
 ON CONFLICT (repo, (ref IS NULL)) WHERE ref IS NULL

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -14,6 +14,17 @@ import (
 	"github.com/jackc/pgtype"
 )
 
+const checkRunningImps = `-- name: CheckRunningImps :one
+SELECT COUNT(*) FROM mergestat.repo_imports WHERE import_status = 'RUNNING'
+`
+
+func (q *Queries) CheckRunningImps(ctx context.Context) (int64, error) {
+	row := q.db.QueryRow(ctx, checkRunningImps)
+	var count int64
+	err := row.Scan(&count)
+	return count, err
+}
+
 const cleanOldRepoSyncQueue = `-- name: CleanOldRepoSyncQueue :exec
 SELECT mergestat.simple_repo_sync_queue_cleanup($1::INTEGER)
 `

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -78,7 +78,9 @@ func RestRatelimitHandler(ctx context.Context, resp *github.Response, l *zerolog
 	// we check whether an import process is the  one calling this handler
 	// or not,if it is we omit this clause.
 	if !impRunning {
-		WaitForImports(ctx, l, qry)
+		if err := WaitForImports(ctx, l, qry); err != nil {
+			l.Err(err).Msgf("error waiting for imports:%v", err)
+		}
 	}
 
 	if remaining <= 400 {

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -120,7 +120,7 @@ func WaitForImports(ctx context.Context, l *zerolog.Logger, qry queries.Querier)
 		case <-time.After(2 * time.Second):
 
 			//TODO:(ramiro) should we log the imp ids ?
-			l.Info().Msg("Waiting for import to finish")
+			l.Info().Msg("waiting for import to finish")
 
 			if imp, err = qry.CheckRunningImps(ctx); err != nil {
 				return err

--- a/internal/jobs/repo/import.go
+++ b/internal/jobs/repo/import.go
@@ -120,12 +120,15 @@ func handleImport(ctx context.Context, qry *db.Queries, imp db.ListRepoImportsDu
 
 	client := github.NewClient(tc)
 
-	// we check the rate limit before any call to the GitHub API
-	if _, resp, err = client.RateLimits(ctx); err != nil {
-		return err
+	if len(ghToken) > 0 {
+		// we check the rate limit before any call to the GitHub API
+		if _, resp, err = client.RateLimits(ctx); err != nil {
+			return err
+		}
+
+		helper.RestRatelimitHandler(ctx, resp, l, queries.NewQuerier(qry), true)
 	}
-	l.Info().Msgf("remaining github quota %d", resp.Rate.Remaining)
-	helper.RestRatelimitHandler(ctx, resp, l, queries.NewQuerier(qry), true)
+
 	// determine the kind of import (Org vs. User) and parse the settings
 	switch imp.Type {
 	case "GITHUB_ORG":
@@ -294,8 +297,10 @@ func fetchGitHubReposByOrg(ctx context.Context, client *github.Client, repoOwner
 			return repositories, err
 		}
 
-		// we check the rate limit after a call to the GitHub API
-		helper.RestRatelimitHandler(ctx, resp, l, queries.NewQuerier(qry), true)
+		if len(ghToken) > 0 {
+			// we check the rate limit after a call to the GitHub API
+			helper.RestRatelimitHandler(ctx, resp, l, queries.NewQuerier(qry), true)
+		}
 
 		for _, repo := range repos {
 
@@ -339,8 +344,10 @@ func fetchGitHubReposByUser(ctx context.Context, client *github.Client, repoOwne
 			return repositories, err
 		}
 
-		// we check the rate limit after a call to the GitHub API
-		helper.RestRatelimitHandler(ctx, resp, l, queries.NewQuerier(qry), true)
+		if len(ghToken) > 0 {
+			// we check the rate limit after a call to the GitHub API
+			helper.RestRatelimitHandler(ctx, resp, l, queries.NewQuerier(qry), true)
+		}
 
 		for _, repo := range repos {
 

--- a/internal/jobs/repo/import.go
+++ b/internal/jobs/repo/import.go
@@ -74,11 +74,11 @@ func AutoImport(l *zerolog.Logger, pool *pgxpool.Pool) sqlq.HandlerFunc {
 				l.Warn().Msgf("import(%s) failed: %v", imp.ID, importError.Error())
 
 				if err = tx.Rollback(ctx); err != nil {
-					jobErrors = errors.Wrap(err, "failer to rollback transaccion")
+					jobErrors = errors.Wrap(err, "failed to rollback transaction")
 					return jobErrors
 				}
 
-				jobErrors = errors.Wrap(importError, "failer to handle import")
+				jobErrors = errors.Wrap(importError, "failed to handle import")
 
 			} else {
 				// if the import was successful, commit the changes

--- a/internal/mocks/mock_queries.go
+++ b/internal/mocks/mock_queries.go
@@ -38,6 +38,21 @@ func (m *MockQuerier) EXPECT() *MockQuerierMockRecorder {
 	return m.recorder
 }
 
+// CheckRunningImps mocks base method.
+func (m *MockQuerier) CheckRunningImps(ctx context.Context) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckRunningImps", ctx)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CheckRunningImps indicates an expected call of CheckRunningImps.
+func (mr *MockQuerierMockRecorder) CheckRunningImps(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRunningImps", reflect.TypeOf((*MockQuerier)(nil).CheckRunningImps), ctx)
+}
+
 // CleanOldRepoSyncQueue mocks base method.
 func (m *MockQuerier) CleanOldRepoSyncQueue(ctx context.Context, dollar_1 int32) error {
 	m.ctrl.T.Helper()

--- a/internal/warehouse/github_actions.go
+++ b/internal/warehouse/github_actions.go
@@ -33,7 +33,7 @@ func (w *warehouse) GitHubActions(ctx context.Context, j *db.DequeueSyncJobRow) 
 		return err
 	}
 
-	w.restRatelimitHandler(ctx, resp)
+	helper.RestRatelimitHandler(ctx, resp, w.logger, w.db, false)
 
 	w.logger.Info().Msgf("starting to retrieve all github actions from repo %s", repoName)
 
@@ -86,7 +86,7 @@ func (w *warehouse) handleWorkflows(ctx context.Context, owner, repo string, job
 			continue
 		}
 
-		w.restRatelimitHandler(ctx, resp)
+		helper.RestRatelimitHandler(ctx, resp, w.logger, w.db, false)
 
 		if *workflowsPage.TotalCount > 0 && len(workflowsPage.Workflows) > 0 {
 			if err := w.handleWorkflowsUpsert(ctx, workflowsPage.Workflows, repoID); err != nil {
@@ -189,7 +189,7 @@ func (w *warehouse) handleWorkflowRuns(ctx context.Context, owner, repo string, 
 				}
 			}
 
-			w.restRatelimitHandler(ctx, resp)
+			helper.RestRatelimitHandler(ctx, resp, w.logger, w.db, false)
 
 			if resp.NextPage == 0 {
 				break
@@ -269,7 +269,7 @@ func (w *warehouse) handleWorkflowRunsJobs(ctx context.Context, owner, repo stri
 				}
 			}
 
-			w.restRatelimitHandler(ctx, resp)
+			helper.RestRatelimitHandler(ctx, resp, w.logger, w.db, false)
 
 			if resp.NextPage == 0 {
 				break
@@ -343,7 +343,7 @@ func (w *warehouse) handleWorkflowJobLogs(ctx context.Context, owner, repo strin
 			}
 		}
 
-		w.restRatelimitHandler(ctx, resp)
+		helper.RestRatelimitHandler(ctx, resp, w.logger, w.db, false)
 
 		if err := w.handleWorkflowJobUpsert(ctx, workflowJob, log, repoID); err != nil {
 			return err

--- a/internal/warehouse/github_actions_test.go
+++ b/internal/warehouse/github_actions_test.go
@@ -127,6 +127,8 @@ func TestWarehouseHandleWorkflowsOK(t *testing.T) {
 			gomock.InOrder(
 				mockedPool.EXPECT().CopyFrom(ctx, pgx.Identifier{"mergestat", "repo_sync_logs"}, []string{"log_type", "message", "repo_sync_queue_id"}, pgx.CopyFromRows(inputRuns)).Return(int64(0), nil).MaxTimes(5))
 
+			gomock.InOrder(mockedDb.EXPECT().CheckRunningImps(ctx))
+
 			// mocking batch logs values for jobs
 			getInputBatches = func(batch []*syncLog) [][]interface{} {
 				return inputJobs
@@ -303,7 +305,8 @@ func TestWarehouseWorkflowRunsOK(t *testing.T) {
 					Headrepositoryurl: helper.StringToSqlNullString(workflowRunHeadRepoUrl),
 				}).Return(nil).MaxTimes(1),
 				mockedTx.EXPECT().Commit(ctx).Return(nil),
-				mockedTx.EXPECT().Rollback(ctx).Return(nil))
+				mockedTx.EXPECT().Rollback(ctx).Return(nil),
+				mockedDb.EXPECT().CheckRunningImps(ctx))
 
 		},
 	}}
@@ -420,7 +423,8 @@ func TestWarehouseWorkflowJobsOK(t *testing.T) {
 					Runnergroupname: helper.StringToSqlNullString(testJobs.RunnerGroupName),
 				}).Return(nil).MaxTimes(1),
 				mockedTx.EXPECT().Commit(ctx).Return(nil),
-				mockedTx.EXPECT().Rollback(ctx).Return(nil))
+				mockedTx.EXPECT().Rollback(ctx).Return(nil),
+				mockedDb.EXPECT().CheckRunningImps(ctx))
 		},
 		expectedErr: nil},
 	}

--- a/internal/warehouse/warehouse.go
+++ b/internal/warehouse/warehouse.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"time"
 
 	"github.com/cavaliergopher/grab/v3"
 	"github.com/google/go-github/v47/github"
@@ -46,31 +45,6 @@ func New(ctx context.Context, db *db.Queries, pgpool *pgxpool.Pool, logger *zero
 		pool:         pool,
 		db:           queries,
 	}
-}
-
-func (w *warehouse) restRatelimitHandler(ctx context.Context, resp *github.Response) {
-	var remaining = resp.Rate.Remaining
-	var delay = 800 * time.Millisecond
-	var untilResetDur = time.Until(resp.Rate.Reset.Time)
-	secondsRemaining := untilResetDur.Seconds()
-
-	if remaining <= 400 {
-		delay = time.Duration(untilResetDur)
-		w.logger.Info().
-			Int("remaining", remaining).
-			Time("resets", resp.Rate.Reset.Time).
-			Str("until-reset", untilResetDur.String()).
-			Float64("delay-seconds", float64(delay)).
-			Msgf("received rate limit info from GitHub API: %d remaining in next %ds. Delaying %ss", remaining, int(secondsRemaining), strconv.FormatFloat(delay.Seconds(), 'f', 2, 64))
-
-	}
-
-	// Allow for shutdown during the delay
-	select {
-	case <-ctx.Done():
-	case <-time.After(delay):
-	}
-
 }
 
 func (w *warehouse) parseJobLogs(logsUrl *url.URL, filepathDir string, n int) (string, error) {

--- a/ui/src/views/hooks/useRepos.ts
+++ b/ui/src/views/hooks/useRepos.ts
@@ -24,8 +24,6 @@ const useRepos = () => {
       setShowReposTable(true)
     }
 
-    console.log(data?.repoImports?.nodes)
-
     setFailedImports(data?.repoImports?.nodes?.filter(imp => imp.importError !== null && (imp.importError as string) !== '').map(imp => ({
       id: imp.id,
       name: imp.type === SYNC_REPO_METHOD.GH_USER ? imp.settings.user : imp.settings.org,

--- a/ui/src/views/hooks/useRepos.ts
+++ b/ui/src/views/hooks/useRepos.ts
@@ -24,14 +24,16 @@ const useRepos = () => {
       setShowReposTable(true)
     }
 
-    setFailedImports(data?.repoImports?.nodes?.filter(imp => imp.importError !== null).map(imp => ({
+    console.log(data?.repoImports?.nodes)
+
+    setFailedImports(data?.repoImports?.nodes?.filter(imp => imp.importError !== null && (imp.importError as string) !== '').map(imp => ({
       id: imp.id,
       name: imp.type === SYNC_REPO_METHOD.GH_USER ? imp.settings.user : imp.settings.org,
       type: imp.type === SYNC_REPO_METHOD.GH_USER ? 'GitHub user' : 'GitHub org',
       error: imp.importError
     })) || [])
 
-    setRunningImports(data?.repoImports?.nodes?.filter(imp => imp.importError === null).map(imp => ({
+    setRunningImports(data?.repoImports?.nodes?.filter(imp => imp.importError === null || (imp.importError as string) === '').map(imp => ({
       id: imp.id,
       name: imp.type === SYNC_REPO_METHOD.GH_USER ? imp.settings.user : imp.settings.org,
       type: imp.type === SYNC_REPO_METHOD.GH_USER ? 'GitHub user' : 'GitHub org'


### PR DESCRIPTION
We implement here a way for our import to respect concurrency requirements of github APi by making our syncs aware of a running import is it a running import the context of that sync/operation will wait until the import finishes  its process.WE ONLY DO THIS WHEN A PAT IS PROVIDED, when is not we let the syncs and imports to hit the rate limit of github.

To test this:
No Pat Scenario:
1. log without pat
2. import Google as a repo ORG,wait and see the error of rate limit displayed in the UI

PAT scenario:
1. log with pat.
2. import mergestat as a repo ORG wait for it to finish.
3. go to mergestat/mergestat and run github actions.
4. Import google, then check the logs of your docker  and wait for this logs  indicating that we are waiting for the import to finish
<img width="1440" alt="Screen Shot 2023-02-15 at 10 46 07 AM" src="https://user-images.githubusercontent.com/43893061/219078060-54a4fa50-55c8-4db0-9ec8-73041c0071f5.png">

Test the grapql API:

1. after a clean run log in and import mergestat again.
2. go to mergestat/mergestat and sync github pr commits and the import google again.
3. wait for the import to  start and check if you r have the logs saying that is waiting for the import to finish 

<img width="1440" alt="Screen Shot 2023-02-15 at 10 50 37 AM" src="https://user-images.githubusercontent.com/43893061/219079855-1d4e6856-fa65-4119-acbd-34ff6ecefdda.png">




Closes #791 