### PR TITLE
fix(migrations):Deleting orphan records

### DIFF
--- a/migrations/900000000000029_fk_to_orphan_tables.up.sql
+++ b/migrations/900000000000029_fk_to_orphan_tables.up.sql
@@ -1,5 +1,11 @@
 BEGIN;
 
+DELETE FROM syft_repo_scans WHERE repo_id NOT IN (SELECT id FROM repos);
+DELETE FROM public.grype_repo_scans WHERE repo_id NOT IN (SELECT id FROM repos);
+DELETE FROM public.git_remotes WHERE repo_id NOT IN (SELECT id FROM repos);
+DELETE FROM public.yelp_detect_secrets_repo_scans WHERE repo_id NOT IN (SELECT id FROM repos);
+DELETE FROM public.gitleaks_repo_scans WHERE repo_id NOT IN (SELECT id FROM repos);
+
 ALTER TABLE public.syft_repo_scans
 ADD CONSTRAINT syft_repo_scans_repo_id_fkey
 FOREIGN KEY (repo_id) REFERENCES public.repos(id) ON UPDATE RESTRICT ON DELETE CASCADE;


### PR DESCRIPTION
Taking in consideration orphan records,  to test this code:

1. Comment the content of 29 migration and run mergestat
2. Import mergestat repos and set the next default syncs syft,grype,git_remotes,yelp and gitleaks and let them finish.
3. delete the import and check if the information of this syncs  persist, now set the schema_migrations to 028 or below and delete the schema_history until that one also.
4. uncomment the content of 029 and run make docker-build-worker
5. After a make dev  check if the tables are empty if so the migrations solves our issue

Closes #833 