### PR TITLE
fix: Adding a repo by URL - if a repo has a GitHub URL, can we extract the owner/name and display it without the `https://github.com/` prefix for brevity

### DIFF
--- a/ui/src/views/repositories/modals/add-repository-modal/add-repository-from-url-modal.tsx
+++ b/ui/src/views/repositories/modals/add-repository-modal/add-repository-from-url-modal.tsx
@@ -63,17 +63,25 @@ export const AddRepositoryFromURLModal: React.FC = () => {
         {reposToAdd.length === 0 && <EmptyRepositories />}
         {reposToAdd.length > 0 && (
           <div className="border border-gray-200 rounded">
-            {reposToAdd.map((repository, index) => (
-              <ListItem
-                key={index}
-                title={repository}
-                subline={repository}
-                className={'p-2 border-b'}
-                startIcon={<RepoIcon repository={repository} />}
-                onClick={() => false}
-                onTrashClick={() => removeURL(repository)}
-              />
-            ))}
+            {reposToAdd.map((repository, index) => {
+              let formattedRepo = repository
+              if (repository.includes('https://github.com/')) {
+                const [owner, repo] = repository.replace('https://github.com/', '').split('/')
+                formattedRepo = `${owner}/${repo}`
+              }
+
+              return (
+                <ListItem
+                  key={index}
+                  title={formattedRepo}
+                  subline={formattedRepo}
+                  className={'p-2 border-b'}
+                  startIcon={<RepoIcon repository={repository} />}
+                  onClick={() => false}
+                  onTrashClick={() => removeURL(repository)}
+                />
+              )
+            })}
           </div>
         )}
       </div>


### PR DESCRIPTION
Loom video 
https://user-images.githubusercontent.com/57623705/219366546-5df956d1-5033-42c3-9b01-4eef58edfc53.mov

Closes https://github.com/mergestat/mergestat/issues/691

