### PR TITLE
fix(editor): checking for rows affected in query editor

### DIFF
--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -98,7 +98,8 @@ export enum States {
   Loading = 'Loading',
   Filled = 'Filled',
   Canceled = 'Canceled',
-  Error = 'Error'
+  Error = 'Error',
+  Affected = 'Affected'
 }
 
 export enum EXPORT_FORMAT {

--- a/ui/src/views/hooks/useQueryEditor.ts
+++ b/ui/src/views/hooks/useQueryEditor.ts
@@ -56,12 +56,20 @@ const useQueryEditor = (rowsLimit: number) => {
   }, [loadingQuery])
 
   useEffect(() => {
-    if (data?.execSQL.rows?.length && data?.execSQL.rows?.length > 0) {
+    const rowsExist = data?.execSQL.rows?.length && data?.execSQL.rows?.length > 0
+    const rowsAffected = data?.execSQL?.rowCount && data?.execSQL?.rowCount > 0
+    const currentState = rowsExist ? States.Filled : States.Affected
+
+    if (rowsExist || rowsAffected) {
       checkProjection(data?.execSQL.columns as ColumnInfo[])
       setDataQuery(data?.execSQL)
       setTime(formatTimeExecution(data?.execSQL.queryRunningTimeMs || 0))
-      setState(States.Filled)
-      setRowLimitReached(data?.execSQL.rows?.length > rowsLimit)
+      setState(currentState)
+      if (data?.execSQL.rows?.length) {
+        setRowLimitReached(data?.execSQL.rows?.length > rowsLimit)
+      } else {
+        setRowLimitReached(false)
+      }
     } else {
       error ? setState(States.Error) : setState(States.Empty)
     }

--- a/ui/src/views/sql-query-editor/components/state-empty.tsx
+++ b/ui/src/views/sql-query-editor/components/state-empty.tsx
@@ -1,10 +1,10 @@
 import { Avatar } from '@mergestat/blocks'
 import { CircleInformationIcon, MinusIcon } from '@mergestat/icons'
-import { QueryResultProps } from 'src/@types'
+import { ExecuteSqlQuery } from 'src/api-logic/graphql/generated/schema'
 
 type QueryEditorEmptyProps = {
   executed: boolean
-  data: QueryResultProps | undefined
+  data: ExecuteSqlQuery | undefined
   children?: React.ReactNode
 }
 
@@ -13,10 +13,10 @@ const QueryEditorEmpty: React.FC<QueryEditorEmptyProps> = ({ executed, data }: Q
     if (!executed) {
       return 'Execute query to show results.'
     } else {
-      if (data?.rowCount && data.rowCount > 0) {
-        return `${data.rowCount} row${data.rowCount > 1 ? 's' : ''} impacted`
+      if (data?.execSQL.rowCount && data.execSQL.rowCount > 0) {
+        return `${data.execSQL.rowCount} row${data.execSQL.rowCount > 1 ? 's' : ''} impacted`
       } else {
-        return data?.columns && data.columns.length > 0 ? 'Empty result set (no rows returned).' : 'No rows impacted'
+        return data?.execSQL.columns && data.execSQL.columns.length > 0 ? 'Empty result set (no rows returned).' : 'No rows impacted'
       }
     }
   }

--- a/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
+++ b/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
@@ -1,18 +1,18 @@
 import { Avatar } from '@mergestat/blocks'
 import { MinusIcon } from '@mergestat/icons'
-import { QueryResultProps } from 'src/@types'
+import { ExecuteSqlQuery } from 'src/api-logic/graphql/generated/schema'
 
 type QueryEditorRowsImpactedProps = {
-    data: QueryResultProps | undefined
-    children?: React.ReactNode
+  data: ExecuteSqlQuery | undefined
+  children?: React.ReactNode
 }
 
 const QueryEditorRowsImpacted: React.FC<QueryEditorRowsImpactedProps> = ({ data }: QueryEditorRowsImpactedProps) => (
-    <div className='flex-1 h-1/2 flex flex-col items-center justify-center p-8'>
-        <Avatar icon={<MinusIcon className="t-icon" />} />
-        <p className='t-text-muted mt-6'>
-            {`rows impacted ${data?.rowCount}`}
-        </p>
-    </div>)
+  <div className='flex-1 h-1/2 flex flex-col items-center justify-center p-8'>
+    <Avatar icon={<MinusIcon className="t-icon" />} />
+    <p className='t-text-muted mt-6'>
+      {`rows impacted ${data?.execSQL.rowCount}`}
+    </p>
+  </div>)
 
 export default QueryEditorRowsImpacted

--- a/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
+++ b/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
@@ -1,0 +1,18 @@
+import { Avatar } from '@mergestat/blocks'
+import { MinusIcon } from '@mergestat/icons'
+import { QueryResultProps } from 'src/@types'
+
+type QueryEditorRowsImpactedProps = {
+    data: QueryResultProps | undefined
+    children?: React.ReactNode
+}
+
+const QueryEditorRowsImpacted: React.FC<QueryEditorRowsImpactedProps> = ({ data }: QueryEditorRowsImpactedProps) => (
+    <div className='flex-1 h-1/2 flex flex-col items-center justify-center p-8'>
+        <Avatar icon={<MinusIcon className="t-icon" />} />
+        <p className='t-text-muted mt-6'>
+            {`rows impacted ${data?.rowCount}`}
+        </p>
+    </div>)
+
+export default QueryEditorRowsImpacted

--- a/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
+++ b/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
@@ -11,7 +11,7 @@ const QueryEditorRowsImpacted: React.FC<QueryEditorRowsImpactedProps> = ({ data 
   <div className='flex-1 h-1/2 flex flex-col items-center justify-center p-8'>
     <Avatar icon={<MinusIcon className="t-icon" />} />
     <p className='t-text-muted mt-6'>
-      {`rows impacted ${data?.execSQL.rowCount}`}
+      `${data.execSQL.rowCount} row${data.execSQL.rowCount > 1 ? 's' : ''} impacted`
     </p>
   </div>)
 

--- a/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
+++ b/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
@@ -11,7 +11,7 @@ const QueryEditorRowsImpacted: React.FC<QueryEditorRowsImpactedProps> = ({ data 
   <div className='flex-1 h-1/2 flex flex-col items-center justify-center p-8'>
     <Avatar icon={<MinusIcon className="t-icon" />} />
     <p className='t-text-muted mt-6'>
-      `${data?.execSQL?.rowCount} row${data?.execSQL?.rowCount ? 's' : ''} impacted`
+      {data?.execSQL?.rowCount} {data?.execSQL?.rowCount === 1 ? 'row' : 'rows'} impacted
     </p>
   </div>)
 

--- a/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
+++ b/ui/src/views/sql-query-editor/components/state-rows-affected.tsx
@@ -11,7 +11,7 @@ const QueryEditorRowsImpacted: React.FC<QueryEditorRowsImpactedProps> = ({ data 
   <div className='flex-1 h-1/2 flex flex-col items-center justify-center p-8'>
     <Avatar icon={<MinusIcon className="t-icon" />} />
     <p className='t-text-muted mt-6'>
-      `${data.execSQL.rowCount} row${data.execSQL.rowCount > 1 ? 's' : ''} impacted`
+      `${data?.execSQL?.rowCount} row${data?.execSQL?.rowCount ? 's' : ''} impacted`
     </p>
   </div>)
 

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -10,6 +10,7 @@ import QueryEditorEmpty from './components/state-empty'
 import QueryEditorError from './components/state-error'
 import QueryEditorFilled from './components/state-filled'
 import QueryEditorLoading from './components/state-loading'
+import QueryEditorRowsImpacted from './components/state-rows-affected'
 import { QuerySettingsModal } from './modals/query-setting'
 
 type QueryEditorProps = {
@@ -136,6 +137,10 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
 
         {/* Loading state */}
         {loading && <QueryEditorLoading />}
+
+        {!error && !loading && data?.execSQL.rows?.length === 0 && state === States.Affected && data.execSQL.rowCount &&
+          <QueryEditorRowsImpacted data={dataQuery} />
+        }
 
         {/* Filled state */}
         {!error && !loading && data && state === States.Filled &&

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -20,10 +20,9 @@ type QueryEditorProps = {
 
 const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorProps) => {
   const ROWS_LIMIT = 1000
-
   const {
     setQuery, setShowSettingsModal, setTitle, setDesc, executeSQLQuery, cancelSQLQuery,
-    expanded, dataQuery, showSettingsModal, state, rowLimitReached, executed, readOnly,
+    expanded, showSettingsModal, state, rowLimitReached, executed, readOnly,
     loading, error, query, data, time, title, desc
   } = useQueryEditor(ROWS_LIMIT)
 
@@ -127,7 +126,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
         />}
 
         {/* Empty state */}
-        {!error && !loading && state === States.Empty && <QueryEditorEmpty executed={executed} data={dataQuery} />}
+        {!error && !loading && state === States.Empty && <QueryEditorEmpty executed={executed} data={data} />}
 
         {/* Canceled state */}
         {!error && !loading && state === States.Canceled && <QueryEditorCanceled />}
@@ -139,7 +138,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
         {loading && <QueryEditorLoading />}
 
         {!error && !loading && data?.execSQL.rows?.length === 0 && state === States.Affected && data.execSQL.rowCount &&
-          <QueryEditorRowsImpacted data={dataQuery} />
+          <QueryEditorRowsImpacted data={data} />
         }
 
         {/* Filled state */}


### PR DESCRIPTION
So we werent checking for rows counts / rows affected  so when we did and operation with no rows returned we ommited the result and  show the empty editor when actually we had rows affected.
With this changes we take in consideration all rows and rows count/affected.

To test you need to :
1. do any operation that returns no rows and also affect rows
2. you should see the rows impacted but that query

![screen_shot_2023-02-23_at_11 21 22_am_720](https://user-images.githubusercontent.com/43893061/220967361-8bf2097f-dbce-4292-b298-a6766b1552a8.png)


Closes #824 
