### PR TITLE
chore: upgrade `blocks` and `icons` to latest

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@apollo/client": "^3.7.0",
         "@apollo/react-testing": "^4.0.0",
-        "@mergestat/blocks": "1.5.49",
-        "@mergestat/icons": "1.2.15",
+        "@mergestat/blocks": "1.5.53",
+        "@mergestat/icons": "1.2.16",
         "@monaco-editor/react": "^4.4.6",
         "@next/bundle-analyzer": "^12.1.4",
         "@tailwindcss/line-clamp": "^0.4.2",
@@ -1524,24 +1524,24 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-zbsLwtnHo84w1Kc8rScAo5GMk1GdecSlrflIbfnEBJwvTSj1SL6kkOYV+nHraMCPEy+RNZZUaZyL8JosDGCtGQ=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-LSqwPZkK3rYfD7GKoIeExXOyYx6Q1O4iqZWwIehDNuv3Dv425FIAE8PRwtAx1imEolFTHgBEcoFHm9MDnYgPCg=="
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.1.0.tgz",
-      "integrity": "sha512-TSogMPVxbRe77QCj1dt8NmRiJasPvuc+eT5jnJ6YpLqgOD2zXc5UA3S1qwybN+GVCDNdKfpKy1oj8RpzLJvh6A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.1.tgz",
+      "integrity": "sha512-Rt45SmRiV8eU+xXSB9t0uMYiQ/ZWGE/jumse2o3i5RGlyvcbqOF4q+1qBnzLE2kZ5JGhq0iMkcGXUKbFe7MpTA==",
       "dependencies": {
-        "@floating-ui/core": "^1.0.5"
+        "@floating-ui/core": "^1.2.1"
       }
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.18.0.tgz",
-      "integrity": "sha512-zxgwWigxaph1TIBdezCDdc3eo+4FUDKY2MiBR3gywZtx5Eeb0KBRRZ9PyzznTXuYO5Y9BFHAC0Yikqp7rr+oKQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.19.2.tgz",
+      "integrity": "sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==",
       "dependencies": {
-        "@floating-ui/react-dom": "^1.2.1",
+        "@floating-ui/react-dom": "^1.3.0",
         "aria-hidden": "^1.1.3",
         "tabbable": "^6.0.1"
       },
@@ -1551,11 +1551,11 @@
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.2.1.tgz",
-      "integrity": "sha512-YCLlqibZtgUhxUpxkSp1oekvYgH/jI4KdZEJv85E62twlZHN43xdlQNe6JcF4ROD3/Zu6juNHN+aOygN+6yZjg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
+      "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
       "dependencies": {
-        "@floating-ui/dom": "^1.1.0"
+        "@floating-ui/dom": "^1.2.1"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2697,9 +2697,9 @@
       }
     },
     "node_modules/@headlessui/react": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.10.tgz",
-      "integrity": "sha512-1m66h/5eayTEZVT2PI13/2PG3EVC7a9XalmUtVSC8X76pcyKYMuyX1XAL2RUtCr8WhoMa/KrDEyoeU5v+kSQOw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.11.tgz",
+      "integrity": "sha512-EaDbVgcyiylhtskZZf4Qb/JiiByY7cYbd0qgZ9xm2pm2X7hKojG0P4TaQYKgPOV3vojPhd/pZyQh3nmRkkcSyw==",
       "dependencies": {
         "client-only": "^0.0.1"
       },
@@ -3210,32 +3210,23 @@
       }
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.5.49",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.49.tgz",
-      "integrity": "sha512-uf6SXflMou+1oRXiNKqb4bKVOibkE8u2VWTybRieBG0g6RARhAKbXqfSzH7yg6j6zEHvQDn03unL0Cfp9D3IRQ==",
+      "version": "1.5.53",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.53.tgz",
+      "integrity": "sha512-X+z21fX750CiAA7xZ9Fzm1L0zZ82r5YmsZ/lQb+xTPZngKQ1jmZG9cYQf2bXkEc1Rd3MB+jLYc5xyht8hUpt6Q==",
       "dependencies": {
-        "@floating-ui/react": "0.18.0",
-        "@headlessui/react": "1.7.10",
-        "@mergestat/icons": "1.2.14",
+        "@floating-ui/react": "0.19.2",
+        "@headlessui/react": "1.7.11",
+        "@mergestat/icons": "1.2.16",
         "classnames": "2.3.2",
         "rc-notification": "4.6.1",
         "react": "18.2.0",
         "react-overlays": "5.2.1"
       }
     },
-    "node_modules/@mergestat/blocks/node_modules/@mergestat/icons": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@mergestat/icons/-/icons-1.2.14.tgz",
-      "integrity": "sha512-8I/Y+QaJJEErqjB0h/J4oXe69g7PbLSWn1QVXmGo0ZSgsgzRAXldanEywBdjbOGNrme9MZyRIfCj4cHyKJaysA==",
-      "peerDependencies": {
-        "classnames": "2.3.2",
-        "react": "18.2.0"
-      }
-    },
     "node_modules/@mergestat/icons": {
-      "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@mergestat/icons/-/icons-1.2.15.tgz",
-      "integrity": "sha512-YHf4U2SAxQ4HKXcirTZMca8IRsFvtlJn+drfQcjybHoF5Lf1F2kMa2v8AlG1jfTEQ6GSBq+EUoiRvzcoaHXYow==",
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@mergestat/icons/-/icons-1.2.16.tgz",
+      "integrity": "sha512-kJ8oVYQmS249n1I7qV2q1ULYrspSOFixDdzlssCCNPp31PNy9J+oeH88Ld+ElPxPUnLv6NXhw35jTarYOmhZjA==",
       "peerDependencies": {
         "classnames": "2.3.2",
         "react": "18.2.0"
@@ -12830,9 +12821,9 @@
       }
     },
     "node_modules/tabbable": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.1.tgz",
-      "integrity": "sha512-SYJSIgeyXW7EuX1ytdneO5e8jip42oHWg9xl/o3oTYhmXusZVgiA+VlPvjIN+kHii9v90AmzTZEBcsEvuAY+TA=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.1.1.tgz",
+      "integrity": "sha512-4kl5w+nCB44EVRdO0g/UGoOp3vlwgycUVtkk/7DPyeLZUCuNFFKCFG6/t/DgHLrUPHjrZg6s5tNm+56Q2B0xyg=="
     },
     "node_modules/tailwindcss": {
       "version": "2.2.19",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "@apollo/client": "^3.7.0",
     "@apollo/react-testing": "^4.0.0",
-    "@mergestat/blocks": "1.5.49",
-    "@mergestat/icons": "1.2.15",
+    "@mergestat/blocks": "1.5.53",
+    "@mergestat/icons": "1.2.16",
     "@monaco-editor/react": "^4.4.6",
     "@next/bundle-analyzer": "^12.1.4",
     "@tailwindcss/line-clamp": "^0.4.2",


### PR DESCRIPTION
Should pull in some new updates, including the new navigation interactions