### PR TITLE
fix: the logic for highlighting the `Repos` top-level navbar item

### DIFF
--- a/ui/src/components/Sidebar/index.tsx
+++ b/ui/src/components/Sidebar/index.tsx
@@ -15,7 +15,7 @@ const SidebarView: React.FC = () => {
         <Sidebar.Item
           label='Repos'
           compact={false}
-          active={isSidebarActive(/^\/repos$/)}
+          active={isSidebarActive(/^\/repos/) && !isSidebarActive(/^\/repos\/repo-auto-imports/)}
           icon={<RepositoryIcon className='t-icon' />}
           onClick={() => push('/repos')}
           subNav={


### PR DESCRIPTION
Previously, for _subpages_ of `/repos` nothing would be highlighted in the navbar. Now, we highlight the top level (`Repos`) when we're on a page such as `/repos/0c7fa3ae-2197-4e8e-95ee-2d6dd2febe91/d3dba41f-8c98-4ca1-a516-a627a4394275` but _not_ on `/repos/repo-auto-imports`