### PR TITLE
fix: navbar highlighting for `Repos`

### DIFF
--- a/ui/src/components/Sidebar/index.tsx
+++ b/ui/src/components/Sidebar/index.tsx
@@ -15,7 +15,7 @@ const SidebarView: React.FC = () => {
         <Sidebar.Item
           label='Repos'
           compact={false}
-          active={isSidebarActive(/^\/repos/) && !isSidebarActive(/^\/repos\/repo-auto-imports/)}
+          active={isSidebarActive(/^\/repos/) && !isSidebarActive(/^\/repos\/git-sources/)}
           icon={<RepositoryIcon className='t-icon' />}
           onClick={() => push('/repos')}
           subNav={


### PR DESCRIPTION
don't double highlight `Repos` and `Git Sources`