### PR TITLE
fix: issue with grype scanner reusing previous tmp dir location

### DIFF
--- a/internal/syncer/grype_repo_scan.go
+++ b/internal/syncer/grype_repo_scan.go
@@ -16,7 +16,7 @@ import (
 func (w *worker) handleGrypeRepoScan(ctx context.Context, j *db.DequeueSyncJobRow) error {
 	l := w.loggerForJob(j)
 
-	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-")
+	tmpPath, cleanup, err := helper.CreateTempDir(os.Getenv("GIT_CLONE_PATH"), "mergestat-repo-*")
 	if err != nil {
 		return fmt.Errorf("temp dir: %w", err)
 	}


### PR DESCRIPTION
Grype scanner was failing on _second_ runs because we were reusing the same clone dir across runs. This should address that.

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/57259/224425354-95959522-609d-4b22-91dd-491cc1d917e4.png">
