### PR TITLE
fix: if there's no token (during repo clone) don't supply any auth

### DIFF
--- a/internal/syncer/syncer.go
+++ b/internal/syncer/syncer.go
@@ -278,7 +278,10 @@ func (w *worker) clone(ctx context.Context, path string, job *db.DequeueSyncJobR
 		if username == "" {
 			username = "git"
 		}
-		auth = &http.BasicAuth{Username: username, Password: token}
+
+		if token != "" {
+			auth = &http.BasicAuth{Username: username, Password: token}
+		}
 	}
 
 	// fs and target are different! target is a subdirectory of fs. target stores git objects (like commits, etc.)

--- a/ui/src/views/repo-git-sources/git-source-detail/components/repos/components/manual-import-table.tsx
+++ b/ui/src/views/repo-git-sources/git-source-detail/components/repos/components/manual-import-table.tsx
@@ -24,7 +24,7 @@ export const ManualImportTable: React.FC<ManualImportTableProps> = ({ repos }: M
     <>
       <div className='flex flex-col flex-1'>
         {repos?.length < 1
-          ? <NoDataFound message='Couldn&#39;t find any repo.' />
+          ? <NoDataFound message='Couldn&#39;t find any repos.' />
           : <>
             <div className='flex flex-col min-w-0 bg-gray-50 h-full'>
               <div className='flex-1 overflow-x-auto overflow-y-hidden'>


### PR DESCRIPTION
(i.e. use a `nil` auth). Closes #925 