### PR TITLE
fix: `grype` and `gitleaks` scanners had some perms/misconfig issues

### DIFF
--- a/internal/syncer/grype_repo_scan.go
+++ b/internal/syncer/grype_repo_scan.go
@@ -26,7 +26,7 @@ func (w *worker) handleGrypeRepoScan(ctx context.Context, j *db.DequeueSyncJobRo
 		}
 	}()
 
-	if err = w.clone(ctx, j.Repo, j); err != nil {
+	if err = w.clone(ctx, tmpPath, j); err != nil {
 		return fmt.Errorf("git clone: %w", err)
 	}
 


### PR DESCRIPTION
validated locally. see diff for summary of fixes. my guess is recent `Dockerfile` changes caused the issue with Gitleaks at least.