### PR TITLE
feat: bump `blocks` and use `defaultOpen` prop in `<Sidebar />`

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,7 +11,7 @@
         "@apollo/client": "^3.7.7",
         "@apollo/react-testing": "^4.0.0",
         "@blueprintjs/table": "^4.7.20",
-        "@mergestat/blocks": "^1.5.55",
+        "@mergestat/blocks": "^1.5.56",
         "@mergestat/icons": "1.2.17",
         "@monaco-editor/react": "^4.4.6",
         "@next/bundle-analyzer": "^12.3.4",
@@ -3386,9 +3386,9 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.5.55",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.55.tgz",
-      "integrity": "sha512-DkRKOIgkYZlbiIZk/MPdPu+P3LLvAtQcvpGWfQyYS8FoNQcPZvrUQ6o2MuC4S0sywa3LCsDIpHC7/NxNmSg7CA==",
+      "version": "1.5.56",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.56.tgz",
+      "integrity": "sha512-juwgB/0RLmnUdCOkcQ+zKd8hp9B4o5VAw5KIHHUycMK+A+aONrZpDNN3mXQsjNbUGlTkJWqdBtIkXJ1sQdh7OQ==",
       "dependencies": {
         "@floating-ui/react": "0.19.2",
         "@headlessui/react": "1.7.11",

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.7",
     "@apollo/react-testing": "^4.0.0",
-    "@mergestat/blocks": "^1.5.55",
+    "@mergestat/blocks": "^1.5.56",
     "@mergestat/icons": "1.2.17",
     "@blueprintjs/table": "^4.7.20",
     "@monaco-editor/react": "^4.4.6",

--- a/ui/src/components/Sidebar/index.tsx
+++ b/ui/src/components/Sidebar/index.tsx
@@ -16,6 +16,7 @@ const SidebarView: React.FC = () => {
           label='Repos'
           compact={false}
           active={isSidebarActive(/^\/repos/) && !isSidebarActive(/^\/repos\/git-sources/) && !isSidebarActive(/^\/repos\/add-git-source/)}
+          defaultOpen={isSidebarActive(/^\/repos/)}
           icon={<RepositoryIcon className='t-icon' />}
           onClick={() => push('/repos')}
           subNav={
@@ -31,6 +32,7 @@ const SidebarView: React.FC = () => {
           label='Queries'
           compact={false}
           active={isSidebarActive(/^\/queries$/)}
+          defaultOpen={isSidebarActive(/^\/queries/)}
           onClick={() => push('/queries')}
           icon={<TerminalIcon className='t-icon' />}
           subNav={
@@ -51,6 +53,7 @@ const SidebarView: React.FC = () => {
         <Sidebar.Item
           label='Settings'
           compact={false}
+          defaultOpen={isSidebarActive(/^\/settings/)}
           icon={<CogIcon className='t-icon' />}
           subNav={
             <>


### PR DESCRIPTION
This should enable a better sidebar UX when a user is directly linked to a child page or refresh a child page.