### PR TITLE
fix: add a description field to the `container_images` table

### DIFF
--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -658,17 +658,18 @@ type GrypeRepoVulnerability struct {
 }
 
 type MergestatContainerImage struct {
-	ID         uuid.UUID
-	Name       string
-	Type       string
-	Url        string
-	Version    string
-	Parameters pgtype.JSONB
+	ID          uuid.UUID
+	Name        string
+	Type        string
+	Url         string
+	Version     string
+	Parameters  pgtype.JSONB
+	Description sql.NullString
 }
 
 type MergestatContainerImageType struct {
 	Name        string
-	Displayname string
+	DisplayName string
 	Description sql.NullString
 }
 

--- a/migrations/900000000000048_container_based_sync_tweaks.up.sql
+++ b/migrations/900000000000048_container_based_sync_tweaks.up.sql
@@ -1,0 +1,10 @@
+-- SQL migration to make some tweaks to Container-based sync setup
+BEGIN;
+
+-- Add a description field to the container_images table
+ALTER TABLE "mergestat"."container_images" ADD COLUMN "description" text;
+
+-- Rename the displayname column to display_name
+ALTER TABLE "mergestat"."container_image_types" RENAME COLUMN displayname TO display_name;
+
+COMMIT;


### PR DESCRIPTION
Closes #946.

Also rename the `displayname` column to `display_name` in `mergestat.container_image_types`