### PR TITLE
chore: updates some foreign keys with `ON DELETE CASCADE`

### DIFF
--- a/migrations/900000000000049_container_based_sync_fk_cascade.up.sql
+++ b/migrations/900000000000049_container_based_sync_fk_cascade.up.sql
@@ -1,0 +1,14 @@
+-- SQL migration to add ON DELETE CASCADE to foreign key constraint
+BEGIN;
+
+ALTER TABLE "mergestat"."container_sync_schedules"
+DROP CONSTRAINT "fk_schedule_sync",
+ADD CONSTRAINT "fk_schedule_sync" FOREIGN KEY ("sync_id") REFERENCES "mergestat"."container_syncs"("id") ON DELETE CASCADE;
+
+ALTER TABLE "mergestat"."container_sync_executions"
+DROP CONSTRAINT "fk_execution_sync",
+DROP CONSTRAINT "fk_execution_job",
+ADD CONSTRAINT "fk_execution_sync" FOREIGN KEY ("sync_id") REFERENCES "mergestat"."container_syncs"("id") ON DELETE CASCADE,
+ADD CONSTRAINT "fk_execution_job" FOREIGN KEY ("job_id") REFERENCES "sqlq"."jobs"("id") ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
This allows for cascading deletes for now. May need to be modified in the future, especially if we move towards a soft delete approach (to retain history of entities)