### PR TITLE
feat: Implement frontend experience for Initial Query History (with visual improvements)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -36,6 +36,7 @@
         "react-apexcharts": "^1.4.0",
         "react-dom": "18.2.0",
         "react-error-boundary": "^3.1.4",
+        "react-syntax-highlighter": "^15.5.0",
         "sharp": "^0.31.0",
         "styled-components": "^5.3.7",
         "uuid": "^9.0.0"
@@ -57,6 +58,7 @@
         "@types/ramda": "^0.28.7",
         "@types/react": "^18.0.26",
         "@types/react-dom": "^18.0.9",
+        "@types/react-syntax-highlighter": "^15.5.6",
         "@types/uuid": "^9.0.0",
         "@typescript-eslint/eslint-plugin": "^5.47.0",
         "@typescript-eslint/parser": "^5.33.0",
@@ -4228,6 +4230,15 @@
       "version": "18.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
       "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+      "dev": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.6",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.6.tgz",
+      "integrity": "sha512-i7wFuLbIAFlabTeD2I1cLjEOrG/xdMa/rpx2zwzAoGHuXJDhSqp9BSfDlMHSh9JSuNfxHk9eEmMX6D55GiyjGg==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"

--- a/ui/package.json
+++ b/ui/package.json
@@ -46,6 +46,7 @@
     "react-apexcharts": "^1.4.0",
     "react-dom": "18.2.0",
     "react-error-boundary": "^3.1.4",
+    "react-syntax-highlighter": "^15.5.0",
     "sharp": "^0.31.0",
     "styled-components": "^5.3.7",
     "uuid": "^9.0.0"
@@ -67,6 +68,7 @@
     "@types/ramda": "^0.28.7",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
+    "@types/react-syntax-highlighter": "^15.5.6",
     "@types/uuid": "^9.0.0",
     "@typescript-eslint/eslint-plugin": "^5.47.0",
     "@typescript-eslint/parser": "^5.33.0",

--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -275,6 +275,15 @@ export type SavedQueryData = {
   description?: string | null | undefined
 }
 
+/** Query History */
+
+export type QueryHistoryData = {
+  id: string;
+  runAt?: Date;
+  runBy: string;
+  query: string;
+}
+
 /** Git Sources */
 
 export type GitSourceData = {

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -73,6 +73,28 @@ export type BooleanFilter = {
   notIn?: InputMaybe<Array<Scalars['Boolean']>>;
 };
 
+/** All input for the `cancellingJob` mutation. */
+export type CancellingJobInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  jobId?: InputMaybe<Scalars['UUID']>;
+};
+
+/** The output of our `cancellingJob` mutation. */
+export type CancellingJobPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  jobStates?: Maybe<JobStates>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
 /** A filter to be used against CardinalNumber fields. All fields are combined with a logical ‘and.’ */
 export type CardinalNumberFilter = {
   /** Not equal to the specified value, treating null like an ordinary value. */
@@ -175,6 +197,29 @@ export type CharacterDataFilter = {
   startsWith?: InputMaybe<Scalars['CharacterData']>;
   /** Starts with the specified string (case-insensitive). */
   startsWithInsensitive?: InputMaybe<Scalars['CharacterData']>;
+};
+
+/** All input for the `checkJobStatus` mutation. */
+export type CheckJobStatusInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  jobId?: InputMaybe<Scalars['UUID']>;
+  state?: InputMaybe<JobStates>;
+};
+
+/** The output of our `checkJobStatus` mutation. */
+export type CheckJobStatusPayload = {
+  boolean?: Maybe<Scalars['Boolean']>;
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
 };
 
 export type ContainerImage = Node & {
@@ -478,6 +523,8 @@ export type ContainerSyncCondition = {
 
 export type ContainerSyncExecution = {
   createdAt?: Maybe<Scalars['Datetime']>;
+  /** Reads a single `Job` that is related to this `ContainerSyncExecution`. */
+  job?: Maybe<Job>;
   jobId: Scalars['UUID'];
   /** Reads a single `ContainerSync` that is related to this `ContainerSyncExecution`. */
   sync?: Maybe<ContainerSync>;
@@ -794,6 +841,8 @@ export type CreateContainerSyncExecutionPayload = {
   containerSyncExecution?: Maybe<ContainerSyncExecution>;
   /** An edge for our `ContainerSyncExecution`. May be used by Relay 1. */
   containerSyncExecutionEdge?: Maybe<ContainerSyncExecutionsEdge>;
+  /** Reads a single `Job` that is related to this `ContainerSyncExecution`. */
+  job?: Maybe<Job>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
   /** Reads a single `ContainerSync` that is related to this `ContainerSyncExecution`. */
@@ -1552,6 +1601,74 @@ export type CreateGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
+/** All input for the create `Job` mutation. */
+export type CreateJobInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The `Job` to be created by this mutation. */
+  job: JobInput;
+};
+
+/** All input for the create `JobLog` mutation. */
+export type CreateJobLogInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The `JobLog` to be created by this mutation. */
+  jobLog: JobLogInput;
+};
+
+/** The output of our create `JobLog` mutation. */
+export type CreateJobLogPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Reads a single `Job` that is related to this `JobLog`. */
+  jobByJob?: Maybe<Job>;
+  /** The `JobLog` that was created by this mutation. */
+  jobLog?: Maybe<JobLog>;
+  /** An edge for our `JobLog`. May be used by Relay 1. */
+  jobLogEdge?: Maybe<JobLogsEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our create `JobLog` mutation. */
+export type CreateJobLogPayloadJobLogEdgeArgs = {
+  orderBy?: InputMaybe<Array<JobLogsOrderBy>>;
+};
+
+/** The output of our create `Job` mutation. */
+export type CreateJobPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `Job` that was created by this mutation. */
+  job?: Maybe<Job>;
+  /** An edge for our `Job`. May be used by Relay 1. */
+  jobEdge?: Maybe<JobsEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Queue` that is related to this `Job`. */
+  queueByQueue?: Maybe<Queue>;
+};
+
+
+/** The output of our create `Job` mutation. */
+export type CreateJobPayloadJobEdgeArgs = {
+  orderBy?: InputMaybe<Array<JobsOrderBy>>;
+};
+
 /** All input for the create `LabelAssociation` mutation. */
 export type CreateLabelAssociationInput = {
   /**
@@ -1750,6 +1867,38 @@ export type CreateQueryHistoryPayload = {
 /** The output of our create `QueryHistory` mutation. */
 export type CreateQueryHistoryPayloadQueryHistoryEdgeArgs = {
   orderBy?: InputMaybe<Array<QueryHistoriesOrderBy>>;
+};
+
+/** All input for the create `Queue` mutation. */
+export type CreateQueueInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The `Queue` to be created by this mutation. */
+  queue: QueueInput;
+};
+
+/** The output of our create `Queue` mutation. */
+export type CreateQueuePayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** The `Queue` that was created by this mutation. */
+  queue?: Maybe<Queue>;
+  /** An edge for our `Queue`. May be used by Relay 1. */
+  queueEdge?: Maybe<QueuesEdge>;
+};
+
+
+/** The output of our create `Queue` mutation. */
+export type CreateQueuePayloadQueueEdgeArgs = {
+  orderBy?: InputMaybe<Array<QueuesOrderBy>>;
 };
 
 /** All input for the create `RepoImport` mutation. */
@@ -2583,6 +2732,17 @@ export type DeleteContainerSyncByNodeIdInput = {
   clientMutationId?: InputMaybe<Scalars['String']>;
   /** The globally unique `ID` which will identify a single `ContainerSync` to be deleted. */
   nodeId: Scalars['ID'];
+};
+
+/** All input for the `deleteContainerSyncByRepoIdAndImageId` mutation. */
+export type DeleteContainerSyncByRepoIdAndImageIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  imageId: Scalars['UUID'];
+  repoId: Scalars['UUID'];
 };
 
 /** All input for the `deleteContainerSync` mutation. */
@@ -3564,6 +3724,96 @@ export type DeleteGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
+/** All input for the `deleteJobByNodeId` mutation. */
+export type DeleteJobByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `Job` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** All input for the `deleteJob` mutation. */
+export type DeleteJobInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  id: Scalars['UUID'];
+};
+
+/** All input for the `deleteJobLogByNodeId` mutation. */
+export type DeleteJobLogByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `JobLog` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** All input for the `deleteJobLog` mutation. */
+export type DeleteJobLogInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  id: Scalars['UUID'];
+};
+
+/** The output of our delete `JobLog` mutation. */
+export type DeleteJobLogPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  deletedJobLogNodeId?: Maybe<Scalars['ID']>;
+  /** Reads a single `Job` that is related to this `JobLog`. */
+  jobByJob?: Maybe<Job>;
+  /** The `JobLog` that was deleted by this mutation. */
+  jobLog?: Maybe<JobLog>;
+  /** An edge for our `JobLog`. May be used by Relay 1. */
+  jobLogEdge?: Maybe<JobLogsEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our delete `JobLog` mutation. */
+export type DeleteJobLogPayloadJobLogEdgeArgs = {
+  orderBy?: InputMaybe<Array<JobLogsOrderBy>>;
+};
+
+/** The output of our delete `Job` mutation. */
+export type DeleteJobPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  deletedJobNodeId?: Maybe<Scalars['ID']>;
+  /** The `Job` that was deleted by this mutation. */
+  job?: Maybe<Job>;
+  /** An edge for our `Job`. May be used by Relay 1. */
+  jobEdge?: Maybe<JobsEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Queue` that is related to this `Job`. */
+  queueByQueue?: Maybe<Queue>;
+};
+
+
+/** The output of our delete `Job` mutation. */
+export type DeleteJobPayloadJobEdgeArgs = {
+  orderBy?: InputMaybe<Array<JobsOrderBy>>;
+};
+
 /** All input for the `deleteLabelAssociationByLabelAndRepoSyncType` mutation. */
 export type DeleteLabelAssociationByLabelAndRepoSyncTypeInput = {
   /**
@@ -3786,6 +4036,49 @@ export type DeleteQueryHistoryPayload = {
 /** The output of our delete `QueryHistory` mutation. */
 export type DeleteQueryHistoryPayloadQueryHistoryEdgeArgs = {
   orderBy?: InputMaybe<Array<QueryHistoriesOrderBy>>;
+};
+
+/** All input for the `deleteQueueByNodeId` mutation. */
+export type DeleteQueueByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `Queue` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** All input for the `deleteQueue` mutation. */
+export type DeleteQueueInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  name: Scalars['String'];
+};
+
+/** The output of our delete `Queue` mutation. */
+export type DeleteQueuePayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  deletedQueueNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** The `Queue` that was deleted by this mutation. */
+  queue?: Maybe<Queue>;
+  /** An edge for our `Queue`. May be used by Relay 1. */
+  queueEdge?: Maybe<QueuesEdge>;
+};
+
+
+/** The output of our delete `Queue` mutation. */
+export type DeleteQueuePayloadQueueEdgeArgs = {
+  orderBy?: InputMaybe<Array<QueuesOrderBy>>;
 };
 
 /** All input for the `deleteRepoByNodeId` mutation. */
@@ -4750,6 +5043,29 @@ export type DeleteYelpDetectSecretsRepoScanPayload = {
 /** The output of our delete `YelpDetectSecretsRepoScan` mutation. */
 export type DeleteYelpDetectSecretsRepoScanPayloadYelpDetectSecretsRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<YelpDetectSecretsRepoScansOrderBy>>;
+};
+
+/** All input for the `dequeueJob` mutation. */
+export type DequeueJobInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  jobtypes?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+  queues?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+/** The output of our `dequeueJob` mutation. */
+export type DequeueJobPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  jobs?: Maybe<Array<Job>>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
 };
 
 export type DisplayDatabaseConnection = {
@@ -10305,9 +10621,94 @@ export enum LatestRepoSyncsOrderBy {
   StatusDesc = 'STATUS_DESC'
 }
 
+export enum LogLevel {
+  Debug = 'DEBUG',
+  Error = 'ERROR',
+  Info = 'INFO',
+  Warn = 'WARN'
+}
+
+/** A filter to be used against LogLevel fields. All fields are combined with a logical ‘and.’ */
+export type LogLevelFilter = {
+  /** Not equal to the specified value, treating null like an ordinary value. */
+  distinctFrom?: InputMaybe<LogLevel>;
+  /** Equal to the specified value. */
+  equalTo?: InputMaybe<LogLevel>;
+  /** Greater than the specified value. */
+  greaterThan?: InputMaybe<LogLevel>;
+  /** Greater than or equal to the specified value. */
+  greaterThanOrEqualTo?: InputMaybe<LogLevel>;
+  /** Included in the specified list. */
+  in?: InputMaybe<Array<LogLevel>>;
+  /** Is null (if `true` is specified) or is not null (if `false` is specified). */
+  isNull?: InputMaybe<Scalars['Boolean']>;
+  /** Less than the specified value. */
+  lessThan?: InputMaybe<LogLevel>;
+  /** Less than or equal to the specified value. */
+  lessThanOrEqualTo?: InputMaybe<LogLevel>;
+  /** Equal to the specified value, treating null like an ordinary value. */
+  notDistinctFrom?: InputMaybe<LogLevel>;
+  /** Not equal to the specified value. */
+  notEqualTo?: InputMaybe<LogLevel>;
+  /** Not included in the specified list. */
+  notIn?: InputMaybe<Array<LogLevel>>;
+};
+
+/** All input for the `markFailed` mutation. */
+export type MarkFailedInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  expectedstate?: InputMaybe<JobStates>;
+  id?: InputMaybe<Scalars['UUID']>;
+  retry?: InputMaybe<Scalars['Boolean']>;
+  runAfter?: InputMaybe<Scalars['BigInt']>;
+};
+
+/** The output of our `markFailed` mutation. */
+export type MarkFailedPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  jobs?: Maybe<Array<Job>>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+/** All input for the `markSuccess` mutation. */
+export type MarkSuccessInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  expectedstate?: InputMaybe<JobStates>;
+  id?: InputMaybe<Scalars['UUID']>;
+};
+
+/** The output of our `markSuccess` mutation. */
+export type MarkSuccessPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  jobs?: Maybe<Array<Job>>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
 /** The root mutation type which contains root level fields which mutate data. */
 export type Mutation = {
   addToken?: Maybe<Scalars['Boolean']>;
+  bulkDisableSync?: Maybe<Scalars['Boolean']>;
+  bulkEnableSync?: Maybe<Scalars['Boolean']>;
+  cancellingJob?: Maybe<CancellingJobPayload>;
+  checkJobStatus?: Maybe<CheckJobStatusPayload>;
   /** Creates a single `ContainerImage`. */
   createContainerImage?: Maybe<CreateContainerImagePayload>;
   /** Creates a single `ContainerImageType`. */
@@ -10358,6 +10759,10 @@ export type Mutation = {
   createGosecRepoScan?: Maybe<CreateGosecRepoScanPayload>;
   /** Creates a single `GrypeRepoScan`. */
   createGrypeRepoScan?: Maybe<CreateGrypeRepoScanPayload>;
+  /** Creates a single `Job`. */
+  createJob?: Maybe<CreateJobPayload>;
+  /** Creates a single `JobLog`. */
+  createJobLog?: Maybe<CreateJobLogPayload>;
   /** Creates a single `Label`. */
   createLabel?: Maybe<CreateLabelPayload>;
   /** Creates a single `LabelAssociation`. */
@@ -10370,6 +10775,8 @@ export type Mutation = {
   createProvider?: Maybe<CreateProviderPayload>;
   /** Creates a single `QueryHistory`. */
   createQueryHistory?: Maybe<CreateQueryHistoryPayload>;
+  /** Creates a single `Queue`. */
+  createQueue?: Maybe<CreateQueuePayload>;
   /** Creates a single `Repo`. */
   createRepo?: Maybe<CreateRepoPayload>;
   /** Creates a single `RepoImport`. */
@@ -10424,6 +10831,8 @@ export type Mutation = {
   deleteContainerSync?: Maybe<DeleteContainerSyncPayload>;
   /** Deletes a single `ContainerSync` using its globally unique id. */
   deleteContainerSyncByNodeId?: Maybe<DeleteContainerSyncPayload>;
+  /** Deletes a single `ContainerSync` using a unique key. */
+  deleteContainerSyncByRepoIdAndImageId?: Maybe<DeleteContainerSyncPayload>;
   /** Deletes a single `ContainerSyncSchedule` using a unique key. */
   deleteContainerSyncSchedule?: Maybe<DeleteContainerSyncSchedulePayload>;
   /** Deletes a single `ContainerSyncSchedule` using its globally unique id. */
@@ -10508,6 +10917,14 @@ export type Mutation = {
   deleteGrypeRepoScan?: Maybe<DeleteGrypeRepoScanPayload>;
   /** Deletes a single `GrypeRepoScan` using its globally unique id. */
   deleteGrypeRepoScanByNodeId?: Maybe<DeleteGrypeRepoScanPayload>;
+  /** Deletes a single `Job` using a unique key. */
+  deleteJob?: Maybe<DeleteJobPayload>;
+  /** Deletes a single `Job` using its globally unique id. */
+  deleteJobByNodeId?: Maybe<DeleteJobPayload>;
+  /** Deletes a single `JobLog` using a unique key. */
+  deleteJobLog?: Maybe<DeleteJobLogPayload>;
+  /** Deletes a single `JobLog` using its globally unique id. */
+  deleteJobLogByNodeId?: Maybe<DeleteJobLogPayload>;
   /** Deletes a single `Label` using a unique key. */
   deleteLabel?: Maybe<DeleteLabelPayload>;
   /** Deletes a single `LabelAssociation` using a unique key. */
@@ -10528,6 +10945,10 @@ export type Mutation = {
   deleteQueryHistory?: Maybe<DeleteQueryHistoryPayload>;
   /** Deletes a single `QueryHistory` using its globally unique id. */
   deleteQueryHistoryByNodeId?: Maybe<DeleteQueryHistoryPayload>;
+  /** Deletes a single `Queue` using a unique key. */
+  deleteQueue?: Maybe<DeleteQueuePayload>;
+  /** Deletes a single `Queue` using its globally unique id. */
+  deleteQueueByNodeId?: Maybe<DeleteQueuePayload>;
   /** Deletes a single `Repo` using a unique key. */
   deleteRepo?: Maybe<DeleteRepoPayload>;
   /** Deletes a single `Repo` using its globally unique id. */
@@ -10616,8 +11037,12 @@ export type Mutation = {
   deleteYelpDetectSecretsRepoScan?: Maybe<DeleteYelpDetectSecretsRepoScanPayload>;
   /** Deletes a single `YelpDetectSecretsRepoScan` using its globally unique id. */
   deleteYelpDetectSecretsRepoScanByNodeId?: Maybe<DeleteYelpDetectSecretsRepoScanPayload>;
+  dequeueJob?: Maybe<DequeueJobPayload>;
   fetchServiceAuthCredential?: Maybe<FetchServiceAuthCredentialPayload>;
   jsonbRecursiveMerge?: Maybe<JsonbRecursiveMergePayload>;
+  markFailed?: Maybe<MarkFailedPayload>;
+  markSuccess?: Maybe<MarkSuccessPayload>;
+  reap?: Maybe<ReapPayload>;
   setSyncJobStatus?: Maybe<SetSyncJobStatusPayload>;
   simpleRepoSyncQueueCleanup?: Maybe<SimpleRepoSyncQueueCleanupPayload>;
   syncNow?: Maybe<Scalars['Boolean']>;
@@ -10633,6 +11058,8 @@ export type Mutation = {
   updateContainerSync?: Maybe<UpdateContainerSyncPayload>;
   /** Updates a single `ContainerSync` using its globally unique id and a patch. */
   updateContainerSyncByNodeId?: Maybe<UpdateContainerSyncPayload>;
+  /** Updates a single `ContainerSync` using a unique key and a patch. */
+  updateContainerSyncByRepoIdAndImageId?: Maybe<UpdateContainerSyncPayload>;
   /** Updates a single `ContainerSyncSchedule` using a unique key and a patch. */
   updateContainerSyncSchedule?: Maybe<UpdateContainerSyncSchedulePayload>;
   /** Updates a single `ContainerSyncSchedule` using its globally unique id and a patch. */
@@ -10717,6 +11144,14 @@ export type Mutation = {
   updateGrypeRepoScan?: Maybe<UpdateGrypeRepoScanPayload>;
   /** Updates a single `GrypeRepoScan` using its globally unique id and a patch. */
   updateGrypeRepoScanByNodeId?: Maybe<UpdateGrypeRepoScanPayload>;
+  /** Updates a single `Job` using a unique key and a patch. */
+  updateJob?: Maybe<UpdateJobPayload>;
+  /** Updates a single `Job` using its globally unique id and a patch. */
+  updateJobByNodeId?: Maybe<UpdateJobPayload>;
+  /** Updates a single `JobLog` using a unique key and a patch. */
+  updateJobLog?: Maybe<UpdateJobLogPayload>;
+  /** Updates a single `JobLog` using its globally unique id and a patch. */
+  updateJobLogByNodeId?: Maybe<UpdateJobLogPayload>;
   /** Updates a single `Label` using a unique key and a patch. */
   updateLabel?: Maybe<UpdateLabelPayload>;
   /** Updates a single `LabelAssociation` using a unique key and a patch. */
@@ -10737,6 +11172,10 @@ export type Mutation = {
   updateQueryHistory?: Maybe<UpdateQueryHistoryPayload>;
   /** Updates a single `QueryHistory` using its globally unique id and a patch. */
   updateQueryHistoryByNodeId?: Maybe<UpdateQueryHistoryPayload>;
+  /** Updates a single `Queue` using a unique key and a patch. */
+  updateQueue?: Maybe<UpdateQueuePayload>;
+  /** Updates a single `Queue` using its globally unique id and a patch. */
+  updateQueueByNodeId?: Maybe<UpdateQueuePayload>;
   /** Updates a single `Repo` using a unique key and a patch. */
   updateRepo?: Maybe<UpdateRepoPayload>;
   /** Updates a single `Repo` using its globally unique id and a patch. */
@@ -10838,6 +11277,32 @@ export type MutationAddTokenArgs = {
   token: Scalars['String'];
   type: Scalars['String'];
   username?: InputMaybe<Scalars['String']>;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationBulkDisableSyncArgs = {
+  image: Scalars['UUID'];
+  provider: Scalars['UUID'];
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationBulkEnableSyncArgs = {
+  image: Scalars['UUID'];
+  provider: Scalars['UUID'];
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCancellingJobArgs = {
+  input: CancellingJobInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCheckJobStatusArgs = {
+  input: CheckJobStatusInput;
 };
 
 
@@ -10992,6 +11457,18 @@ export type MutationCreateGrypeRepoScanArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateJobArgs = {
+  input: CreateJobInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateJobLogArgs = {
+  input: CreateJobLogInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateLabelArgs = {
   input: CreateLabelInput;
 };
@@ -11024,6 +11501,12 @@ export type MutationCreateProviderArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateQueryHistoryArgs = {
   input: CreateQueryHistoryInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateQueueArgs = {
+  input: CreateQueueInput;
 };
 
 
@@ -11186,6 +11669,12 @@ export type MutationDeleteContainerSyncArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteContainerSyncByNodeIdArgs = {
   input: DeleteContainerSyncByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteContainerSyncByRepoIdAndImageIdArgs = {
+  input: DeleteContainerSyncByRepoIdAndImageIdInput;
 };
 
 
@@ -11442,6 +11931,30 @@ export type MutationDeleteGrypeRepoScanByNodeIdArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteJobArgs = {
+  input: DeleteJobInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteJobByNodeIdArgs = {
+  input: DeleteJobByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteJobLogArgs = {
+  input: DeleteJobLogInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteJobLogByNodeIdArgs = {
+  input: DeleteJobLogByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteLabelArgs = {
   input: DeleteLabelInput;
 };
@@ -11498,6 +12011,18 @@ export type MutationDeleteQueryHistoryArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteQueryHistoryByNodeIdArgs = {
   input: DeleteQueryHistoryByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteQueueArgs = {
+  input: DeleteQueueInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteQueueByNodeIdArgs = {
+  input: DeleteQueueByNodeIdInput;
 };
 
 
@@ -11766,6 +12291,12 @@ export type MutationDeleteYelpDetectSecretsRepoScanByNodeIdArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationDequeueJobArgs = {
+  input: DequeueJobInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationFetchServiceAuthCredentialArgs = {
   input: FetchServiceAuthCredentialInput;
 };
@@ -11774,6 +12305,24 @@ export type MutationFetchServiceAuthCredentialArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationJsonbRecursiveMergeArgs = {
   input: JsonbRecursiveMergeInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationMarkFailedArgs = {
+  input: MarkFailedInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationMarkSuccessArgs = {
+  input: MarkSuccessInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationReapArgs = {
+  input: ReapInput;
 };
 
 
@@ -11829,6 +12378,12 @@ export type MutationUpdateContainerSyncArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateContainerSyncByNodeIdArgs = {
   input: UpdateContainerSyncByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateContainerSyncByRepoIdAndImageIdArgs = {
+  input: UpdateContainerSyncByRepoIdAndImageIdInput;
 };
 
 
@@ -12085,6 +12640,30 @@ export type MutationUpdateGrypeRepoScanByNodeIdArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateJobArgs = {
+  input: UpdateJobInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateJobByNodeIdArgs = {
+  input: UpdateJobByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateJobLogArgs = {
+  input: UpdateJobLogInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateJobLogByNodeIdArgs = {
+  input: UpdateJobLogByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateLabelArgs = {
   input: UpdateLabelInput;
 };
@@ -12141,6 +12720,18 @@ export type MutationUpdateQueryHistoryArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateQueryHistoryByNodeIdArgs = {
   input: UpdateQueryHistoryByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateQueueArgs = {
+  input: UpdateQueueInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateQueueByNodeIdArgs = {
+  input: UpdateQueueByNodeIdInput;
 };
 
 
@@ -12935,6 +13526,7 @@ export type Query = Node & {
   containerSync?: Maybe<ContainerSync>;
   /** Reads a single `ContainerSync` using its globally unique `ID`. */
   containerSyncByNodeId?: Maybe<ContainerSync>;
+  containerSyncByRepoIdAndImageId?: Maybe<ContainerSync>;
   /** Reads and enables pagination through a set of `ContainerSyncExecution`. */
   containerSyncExecutions?: Maybe<ContainerSyncExecutionsConnection>;
   containerSyncSchedule?: Maybe<ContainerSyncSchedule>;
@@ -13051,6 +13643,16 @@ export type Query = Node & {
   grypeRepoScans?: Maybe<GrypeRepoScansConnection>;
   /** Reads and enables pagination through a set of `GrypeRepoVulnerability`. */
   grypeRepoVulnerabilities?: Maybe<GrypeRepoVulnerabilitiesConnection>;
+  job?: Maybe<Job>;
+  /** Reads a single `Job` using its globally unique `ID`. */
+  jobByNodeId?: Maybe<Job>;
+  jobLog?: Maybe<JobLog>;
+  /** Reads a single `JobLog` using its globally unique `ID`. */
+  jobLogByNodeId?: Maybe<JobLog>;
+  /** Reads and enables pagination through a set of `JobLog`. */
+  jobLogs?: Maybe<JobLogsConnection>;
+  /** Reads and enables pagination through a set of `Job`. */
+  jobs?: Maybe<JobsConnection>;
   label?: Maybe<Label>;
   labelAssociationByLabelAndRepoSyncType?: Maybe<LabelAssociation>;
   /** Reads and enables pagination through a set of `LabelAssociation`. */
@@ -13062,7 +13664,7 @@ export type Query = Node & {
   /** Reads and enables pagination through a set of `LatestRepoSync`. */
   latestRepoSyncs?: Maybe<LatestRepoSyncsConnection>;
   /** Fetches an object given its globally unique `ID`. */
-  node?: Maybe<ContainerImage | ContainerImageType | ContainerSync | ContainerSyncSchedule | GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Label | OssfScorecardRepoScan | Provider | Query | QueryHistory | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | Vendor | VendorType | YelpDetectSecretsRepoScan>;
+  node?: Maybe<ContainerImage | ContainerImageType | ContainerSync | ContainerSyncSchedule | GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Job | JobLog | Label | OssfScorecardRepoScan | Provider | Query | QueryHistory | Queue | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | Vendor | VendorType | YelpDetectSecretsRepoScan>;
   /** The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`. */
   nodeId: Scalars['ID'];
   /** Reads and enables pagination through a set of `OssfScorecardRepoCheckResult`. */
@@ -13090,6 +13692,11 @@ export type Query = Node & {
   queryHistory?: Maybe<QueryHistory>;
   /** Reads a single `QueryHistory` using its globally unique `ID`. */
   queryHistoryByNodeId?: Maybe<QueryHistory>;
+  queue?: Maybe<Queue>;
+  /** Reads a single `Queue` using its globally unique `ID`. */
+  queueByNodeId?: Maybe<Queue>;
+  /** Reads and enables pagination through a set of `Queue`. */
+  queues?: Maybe<QueuesConnection>;
   repo?: Maybe<Repo>;
   /** Reads a single `Repo` using its globally unique `ID`. */
   repoByNodeId?: Maybe<Repo>;
@@ -13269,6 +13876,13 @@ export type QueryContainerSyncArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryContainerSyncByNodeIdArgs = {
   nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryContainerSyncByRepoIdAndImageIdArgs = {
+  imageId: Scalars['UUID'];
+  repoId: Scalars['UUID'];
 };
 
 
@@ -13887,6 +14501,56 @@ export type QueryGrypeRepoVulnerabilitiesArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
+export type QueryJobArgs = {
+  id: Scalars['UUID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryJobByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryJobLogArgs = {
+  id: Scalars['UUID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryJobLogByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryJobLogsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<JobLogCondition>;
+  filter?: InputMaybe<JobLogFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<JobLogsOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryJobsArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<JobCondition>;
+  filter?: InputMaybe<JobFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<JobsOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
 export type QueryLabelArgs = {
   label: Scalars['String'];
 };
@@ -14054,6 +14718,31 @@ export type QueryQueryHistoryArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryQueryHistoryByNodeIdArgs = {
   nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryQueueArgs = {
+  name: Scalars['String'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryQueueByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryQueuesArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<QueueCondition>;
+  filter?: InputMaybe<QueueFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<QueuesOrderBy>>;
 };
 
 
@@ -14750,6 +15439,141 @@ export type QueryHistoryPatch = {
   query?: InputMaybe<Scalars['String']>;
   runAt?: InputMaybe<Scalars['Datetime']>;
   runBy?: InputMaybe<Scalars['String']>;
+};
+
+export type Queue = Node & {
+  concurrency?: Maybe<Scalars['Int']>;
+  createdAt: Scalars['Datetime'];
+  description?: Maybe<Scalars['String']>;
+  /** Reads and enables pagination through a set of `Job`. */
+  jobsByQueue: JobsConnection;
+  name: Scalars['String'];
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  priority: Scalars['Int'];
+};
+
+
+export type QueueJobsByQueueArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<JobCondition>;
+  filter?: InputMaybe<JobFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<JobsOrderBy>>;
+};
+
+/** A condition to be used against `Queue` object types. All fields are tested for equality and combined with a logical ‘and.’ */
+export type QueueCondition = {
+  /** Checks for equality with the object’s `concurrency` field. */
+  concurrency?: InputMaybe<Scalars['Int']>;
+  /** Checks for equality with the object’s `createdAt` field. */
+  createdAt?: InputMaybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `description` field. */
+  description?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `name` field. */
+  name?: InputMaybe<Scalars['String']>;
+  /** Checks for equality with the object’s `priority` field. */
+  priority?: InputMaybe<Scalars['Int']>;
+};
+
+/** A filter to be used against `Queue` object types. All fields are combined with a logical ‘and.’ */
+export type QueueFilter = {
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<QueueFilter>>;
+  /** Filter by the object’s `concurrency` field. */
+  concurrency?: InputMaybe<IntFilter>;
+  /** Filter by the object’s `createdAt` field. */
+  createdAt?: InputMaybe<DatetimeFilter>;
+  /** Filter by the object’s `description` field. */
+  description?: InputMaybe<StringFilter>;
+  /** Filter by the object’s `name` field. */
+  name?: InputMaybe<StringFilter>;
+  /** Negates the expression. */
+  not?: InputMaybe<QueueFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<QueueFilter>>;
+  /** Filter by the object’s `priority` field. */
+  priority?: InputMaybe<IntFilter>;
+};
+
+/** An input for mutations affecting `Queue` */
+export type QueueInput = {
+  concurrency?: InputMaybe<Scalars['Int']>;
+  createdAt?: InputMaybe<Scalars['Datetime']>;
+  description?: InputMaybe<Scalars['String']>;
+  name: Scalars['String'];
+  priority?: InputMaybe<Scalars['Int']>;
+};
+
+/** Represents an update to a `Queue`. Fields that are set will be updated. */
+export type QueuePatch = {
+  concurrency?: InputMaybe<Scalars['Int']>;
+  createdAt?: InputMaybe<Scalars['Datetime']>;
+  description?: InputMaybe<Scalars['String']>;
+  name?: InputMaybe<Scalars['String']>;
+  priority?: InputMaybe<Scalars['Int']>;
+};
+
+/** A connection to a list of `Queue` values. */
+export type QueuesConnection = {
+  /** A list of edges which contains the `Queue` and cursor to aid in pagination. */
+  edges: Array<QueuesEdge>;
+  /** A list of `Queue` objects. */
+  nodes: Array<Queue>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `Queue` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `Queue` edge in the connection. */
+export type QueuesEdge = {
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `Queue` at the end of the edge. */
+  node: Queue;
+};
+
+/** Methods to use when ordering `Queue`. */
+export enum QueuesOrderBy {
+  ConcurrencyAsc = 'CONCURRENCY_ASC',
+  ConcurrencyDesc = 'CONCURRENCY_DESC',
+  CreatedAtAsc = 'CREATED_AT_ASC',
+  CreatedAtDesc = 'CREATED_AT_DESC',
+  DescriptionAsc = 'DESCRIPTION_ASC',
+  DescriptionDesc = 'DESCRIPTION_DESC',
+  NameAsc = 'NAME_ASC',
+  NameDesc = 'NAME_DESC',
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  PriorityAsc = 'PRIORITY_ASC',
+  PriorityDesc = 'PRIORITY_DESC'
+}
+
+/** All input for the `reap` mutation. */
+export type ReapInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  queues?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
+};
+
+/** The output of our `reap` mutation. */
+export type ReapPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  integer?: Maybe<Scalars['Int']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
 };
 
 /** git repositories to track */
@@ -17791,6 +18615,19 @@ export type UpdateContainerSyncByNodeIdInput = {
   patch: ContainerSyncPatch;
 };
 
+/** All input for the `updateContainerSyncByRepoIdAndImageId` mutation. */
+export type UpdateContainerSyncByRepoIdAndImageIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  imageId: Scalars['UUID'];
+  /** An object where the defined keys will be set on the `ContainerSync` being updated. */
+  patch: ContainerSyncPatch;
+  repoId: Scalars['UUID'];
+};
+
 /** All input for the `updateContainerSync` mutation. */
 export type UpdateContainerSyncInput = {
   /**
@@ -18836,6 +19673,102 @@ export type UpdateGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
+/** All input for the `updateJobByNodeId` mutation. */
+export type UpdateJobByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `Job` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `Job` being updated. */
+  patch: JobPatch;
+};
+
+/** All input for the `updateJob` mutation. */
+export type UpdateJobInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  id: Scalars['UUID'];
+  /** An object where the defined keys will be set on the `Job` being updated. */
+  patch: JobPatch;
+};
+
+/** All input for the `updateJobLogByNodeId` mutation. */
+export type UpdateJobLogByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `JobLog` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `JobLog` being updated. */
+  patch: JobLogPatch;
+};
+
+/** All input for the `updateJobLog` mutation. */
+export type UpdateJobLogInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  id: Scalars['UUID'];
+  /** An object where the defined keys will be set on the `JobLog` being updated. */
+  patch: JobLogPatch;
+};
+
+/** The output of our update `JobLog` mutation. */
+export type UpdateJobLogPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Reads a single `Job` that is related to this `JobLog`. */
+  jobByJob?: Maybe<Job>;
+  /** The `JobLog` that was updated by this mutation. */
+  jobLog?: Maybe<JobLog>;
+  /** An edge for our `JobLog`. May be used by Relay 1. */
+  jobLogEdge?: Maybe<JobLogsEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+
+/** The output of our update `JobLog` mutation. */
+export type UpdateJobLogPayloadJobLogEdgeArgs = {
+  orderBy?: InputMaybe<Array<JobLogsOrderBy>>;
+};
+
+/** The output of our update `Job` mutation. */
+export type UpdateJobPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** The `Job` that was updated by this mutation. */
+  job?: Maybe<Job>;
+  /** An edge for our `Job`. May be used by Relay 1. */
+  jobEdge?: Maybe<JobsEdge>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Queue` that is related to this `Job`. */
+  queueByQueue?: Maybe<Queue>;
+};
+
+
+/** The output of our update `Job` mutation. */
+export type UpdateJobPayloadJobEdgeArgs = {
+  orderBy?: InputMaybe<Array<JobsOrderBy>>;
+};
+
 /** All input for the `updateLabelAssociationByLabelAndRepoSyncType` mutation. */
 export type UpdateLabelAssociationByLabelAndRepoSyncTypeInput = {
   /**
@@ -19073,6 +20006,52 @@ export type UpdateQueryHistoryPayload = {
 /** The output of our update `QueryHistory` mutation. */
 export type UpdateQueryHistoryPayloadQueryHistoryEdgeArgs = {
   orderBy?: InputMaybe<Array<QueryHistoriesOrderBy>>;
+};
+
+/** All input for the `updateQueueByNodeId` mutation. */
+export type UpdateQueueByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `Queue` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `Queue` being updated. */
+  patch: QueuePatch;
+};
+
+/** All input for the `updateQueue` mutation. */
+export type UpdateQueueInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  name: Scalars['String'];
+  /** An object where the defined keys will be set on the `Queue` being updated. */
+  patch: QueuePatch;
+};
+
+/** The output of our update `Queue` mutation. */
+export type UpdateQueuePayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** The `Queue` that was updated by this mutation. */
+  queue?: Maybe<Queue>;
+  /** An edge for our `Queue`. May be used by Relay 1. */
+  queueEdge?: Maybe<QueuesEdge>;
+};
+
+
+/** The output of our update `Queue` mutation. */
+export type UpdateQueuePayloadQueueEdgeArgs = {
+  orderBy?: InputMaybe<Array<QueuesOrderBy>>;
 };
 
 /** All input for the `updateRepoByNodeId` mutation. */
@@ -21081,6 +22060,15 @@ export type GetGitSourceQueryVariables = Exact<{
 
 
 export type GetGitSourceQuery = { provider?: { id: any, name: string, description?: string | null, vendor: string, settings: any, auth: { nodes: Array<{ id: any, type: string, credentials?: string | null, createdAt: any }> }, auto: { nodes: Array<{ id: any, settings: any, repos: { totalCount: number } }> }, manual: { totalCount: number, nodes: Array<{ id: any, repo: string, settings: any }> } } | null };
+
+export type GetDefaultRepoSyncsQueryVariables = Exact<{
+  search: Scalars['String'];
+  first?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+}>;
+
+
+export type GetDefaultRepoSyncsQuery = { all?: { totalCount: number } | null, containerImages?: { totalCount: number, nodes: Array<{ id: any, name: string, description?: string | null }> } | null };
 
 export type GetQueryHistoryQueryVariables = Exact<{ [key: string]: never; }>;
 

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -21997,14 +21997,10 @@ export type GetGitSourceQueryVariables = Exact<{
 
 export type GetGitSourceQuery = { provider?: { id: any, name: string, description?: string | null, vendor: string, settings: any, auth: { nodes: Array<{ id: any, type: string, credentials?: string | null, createdAt: any }> }, auto: { nodes: Array<{ id: any, settings: any, repos: { totalCount: number } }> }, manual: { totalCount: number, nodes: Array<{ id: any, repo: string, settings: any }> } } | null };
 
-export type GetDefaultRepoSyncsQueryVariables = Exact<{
-  search: Scalars['String'];
-  first?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-}>;
+export type GetQueryHistoryQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetDefaultRepoSyncsQuery = { all?: { totalCount: number } | null, containerImages?: { totalCount: number, nodes: Array<{ id: any, name: string, description?: string | null }> } | null };
+export type GetQueryHistoryQuery = { queryHistories?: { nodes: Array<{ id: any, runAt?: any | null, runBy: string, query: string }> } | null };
 
 export type GetRepoImportsQueryVariables = Exact<{
   idProvider: Scalars['UUID'];

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -73,28 +73,6 @@ export type BooleanFilter = {
   notIn?: InputMaybe<Array<Scalars['Boolean']>>;
 };
 
-/** All input for the `cancellingJob` mutation. */
-export type CancellingJobInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  jobId?: InputMaybe<Scalars['UUID']>;
-};
-
-/** The output of our `cancellingJob` mutation. */
-export type CancellingJobPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  jobStates?: Maybe<JobStates>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-};
-
 /** A filter to be used against CardinalNumber fields. All fields are combined with a logical ‘and.’ */
 export type CardinalNumberFilter = {
   /** Not equal to the specified value, treating null like an ordinary value. */
@@ -197,29 +175,6 @@ export type CharacterDataFilter = {
   startsWith?: InputMaybe<Scalars['CharacterData']>;
   /** Starts with the specified string (case-insensitive). */
   startsWithInsensitive?: InputMaybe<Scalars['CharacterData']>;
-};
-
-/** All input for the `checkJobStatus` mutation. */
-export type CheckJobStatusInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  jobId?: InputMaybe<Scalars['UUID']>;
-  state?: InputMaybe<JobStates>;
-};
-
-/** The output of our `checkJobStatus` mutation. */
-export type CheckJobStatusPayload = {
-  boolean?: Maybe<Scalars['Boolean']>;
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
 };
 
 export type ContainerImage = Node & {
@@ -523,8 +478,6 @@ export type ContainerSyncCondition = {
 
 export type ContainerSyncExecution = {
   createdAt?: Maybe<Scalars['Datetime']>;
-  /** Reads a single `Job` that is related to this `ContainerSyncExecution`. */
-  job?: Maybe<Job>;
   jobId: Scalars['UUID'];
   /** Reads a single `ContainerSync` that is related to this `ContainerSyncExecution`. */
   sync?: Maybe<ContainerSync>;
@@ -841,8 +794,6 @@ export type CreateContainerSyncExecutionPayload = {
   containerSyncExecution?: Maybe<ContainerSyncExecution>;
   /** An edge for our `ContainerSyncExecution`. May be used by Relay 1. */
   containerSyncExecutionEdge?: Maybe<ContainerSyncExecutionsEdge>;
-  /** Reads a single `Job` that is related to this `ContainerSyncExecution`. */
-  job?: Maybe<Job>;
   /** Our root query field type. Allows us to run any query from our mutation payload. */
   query?: Maybe<Query>;
   /** Reads a single `ContainerSync` that is related to this `ContainerSyncExecution`. */
@@ -1601,74 +1552,6 @@ export type CreateGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
-/** All input for the create `Job` mutation. */
-export type CreateJobInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The `Job` to be created by this mutation. */
-  job: JobInput;
-};
-
-/** All input for the create `JobLog` mutation. */
-export type CreateJobLogInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The `JobLog` to be created by this mutation. */
-  jobLog: JobLogInput;
-};
-
-/** The output of our create `JobLog` mutation. */
-export type CreateJobLogPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** Reads a single `Job` that is related to this `JobLog`. */
-  jobByJob?: Maybe<Job>;
-  /** The `JobLog` that was created by this mutation. */
-  jobLog?: Maybe<JobLog>;
-  /** An edge for our `JobLog`. May be used by Relay 1. */
-  jobLogEdge?: Maybe<JobLogsEdge>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-};
-
-
-/** The output of our create `JobLog` mutation. */
-export type CreateJobLogPayloadJobLogEdgeArgs = {
-  orderBy?: InputMaybe<Array<JobLogsOrderBy>>;
-};
-
-/** The output of our create `Job` mutation. */
-export type CreateJobPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `Job` that was created by this mutation. */
-  job?: Maybe<Job>;
-  /** An edge for our `Job`. May be used by Relay 1. */
-  jobEdge?: Maybe<JobsEdge>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Queue` that is related to this `Job`. */
-  queueByQueue?: Maybe<Queue>;
-};
-
-
-/** The output of our create `Job` mutation. */
-export type CreateJobPayloadJobEdgeArgs = {
-  orderBy?: InputMaybe<Array<JobsOrderBy>>;
-};
-
 /** All input for the create `LabelAssociation` mutation. */
 export type CreateLabelAssociationInput = {
   /**
@@ -1867,38 +1750,6 @@ export type CreateQueryHistoryPayload = {
 /** The output of our create `QueryHistory` mutation. */
 export type CreateQueryHistoryPayloadQueryHistoryEdgeArgs = {
   orderBy?: InputMaybe<Array<QueryHistoriesOrderBy>>;
-};
-
-/** All input for the create `Queue` mutation. */
-export type CreateQueueInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The `Queue` to be created by this mutation. */
-  queue: QueueInput;
-};
-
-/** The output of our create `Queue` mutation. */
-export type CreateQueuePayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** The `Queue` that was created by this mutation. */
-  queue?: Maybe<Queue>;
-  /** An edge for our `Queue`. May be used by Relay 1. */
-  queueEdge?: Maybe<QueuesEdge>;
-};
-
-
-/** The output of our create `Queue` mutation. */
-export type CreateQueuePayloadQueueEdgeArgs = {
-  orderBy?: InputMaybe<Array<QueuesOrderBy>>;
 };
 
 /** All input for the create `RepoImport` mutation. */
@@ -3713,96 +3564,6 @@ export type DeleteGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
-/** All input for the `deleteJobByNodeId` mutation. */
-export type DeleteJobByNodeIdInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `Job` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** All input for the `deleteJob` mutation. */
-export type DeleteJobInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  id: Scalars['UUID'];
-};
-
-/** All input for the `deleteJobLogByNodeId` mutation. */
-export type DeleteJobLogByNodeIdInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `JobLog` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** All input for the `deleteJobLog` mutation. */
-export type DeleteJobLogInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  id: Scalars['UUID'];
-};
-
-/** The output of our delete `JobLog` mutation. */
-export type DeleteJobLogPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  deletedJobLogNodeId?: Maybe<Scalars['ID']>;
-  /** Reads a single `Job` that is related to this `JobLog`. */
-  jobByJob?: Maybe<Job>;
-  /** The `JobLog` that was deleted by this mutation. */
-  jobLog?: Maybe<JobLog>;
-  /** An edge for our `JobLog`. May be used by Relay 1. */
-  jobLogEdge?: Maybe<JobLogsEdge>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-};
-
-
-/** The output of our delete `JobLog` mutation. */
-export type DeleteJobLogPayloadJobLogEdgeArgs = {
-  orderBy?: InputMaybe<Array<JobLogsOrderBy>>;
-};
-
-/** The output of our delete `Job` mutation. */
-export type DeleteJobPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  deletedJobNodeId?: Maybe<Scalars['ID']>;
-  /** The `Job` that was deleted by this mutation. */
-  job?: Maybe<Job>;
-  /** An edge for our `Job`. May be used by Relay 1. */
-  jobEdge?: Maybe<JobsEdge>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Queue` that is related to this `Job`. */
-  queueByQueue?: Maybe<Queue>;
-};
-
-
-/** The output of our delete `Job` mutation. */
-export type DeleteJobPayloadJobEdgeArgs = {
-  orderBy?: InputMaybe<Array<JobsOrderBy>>;
-};
-
 /** All input for the `deleteLabelAssociationByLabelAndRepoSyncType` mutation. */
 export type DeleteLabelAssociationByLabelAndRepoSyncTypeInput = {
   /**
@@ -4025,49 +3786,6 @@ export type DeleteQueryHistoryPayload = {
 /** The output of our delete `QueryHistory` mutation. */
 export type DeleteQueryHistoryPayloadQueryHistoryEdgeArgs = {
   orderBy?: InputMaybe<Array<QueryHistoriesOrderBy>>;
-};
-
-/** All input for the `deleteQueueByNodeId` mutation. */
-export type DeleteQueueByNodeIdInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `Queue` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** All input for the `deleteQueue` mutation. */
-export type DeleteQueueInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-};
-
-/** The output of our delete `Queue` mutation. */
-export type DeleteQueuePayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  deletedQueueNodeId?: Maybe<Scalars['ID']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** The `Queue` that was deleted by this mutation. */
-  queue?: Maybe<Queue>;
-  /** An edge for our `Queue`. May be used by Relay 1. */
-  queueEdge?: Maybe<QueuesEdge>;
-};
-
-
-/** The output of our delete `Queue` mutation. */
-export type DeleteQueuePayloadQueueEdgeArgs = {
-  orderBy?: InputMaybe<Array<QueuesOrderBy>>;
 };
 
 /** All input for the `deleteRepoByNodeId` mutation. */
@@ -5032,29 +4750,6 @@ export type DeleteYelpDetectSecretsRepoScanPayload = {
 /** The output of our delete `YelpDetectSecretsRepoScan` mutation. */
 export type DeleteYelpDetectSecretsRepoScanPayloadYelpDetectSecretsRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<YelpDetectSecretsRepoScansOrderBy>>;
-};
-
-/** All input for the `dequeueJob` mutation. */
-export type DequeueJobInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  jobtypes?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-  queues?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-};
-
-/** The output of our `dequeueJob` mutation. */
-export type DequeueJobPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  jobs?: Maybe<Array<Job>>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
 };
 
 export type DisplayDatabaseConnection = {
@@ -10610,92 +10305,9 @@ export enum LatestRepoSyncsOrderBy {
   StatusDesc = 'STATUS_DESC'
 }
 
-export enum LogLevel {
-  Debug = 'DEBUG',
-  Error = 'ERROR',
-  Info = 'INFO',
-  Warn = 'WARN'
-}
-
-/** A filter to be used against LogLevel fields. All fields are combined with a logical ‘and.’ */
-export type LogLevelFilter = {
-  /** Not equal to the specified value, treating null like an ordinary value. */
-  distinctFrom?: InputMaybe<LogLevel>;
-  /** Equal to the specified value. */
-  equalTo?: InputMaybe<LogLevel>;
-  /** Greater than the specified value. */
-  greaterThan?: InputMaybe<LogLevel>;
-  /** Greater than or equal to the specified value. */
-  greaterThanOrEqualTo?: InputMaybe<LogLevel>;
-  /** Included in the specified list. */
-  in?: InputMaybe<Array<LogLevel>>;
-  /** Is null (if `true` is specified) or is not null (if `false` is specified). */
-  isNull?: InputMaybe<Scalars['Boolean']>;
-  /** Less than the specified value. */
-  lessThan?: InputMaybe<LogLevel>;
-  /** Less than or equal to the specified value. */
-  lessThanOrEqualTo?: InputMaybe<LogLevel>;
-  /** Equal to the specified value, treating null like an ordinary value. */
-  notDistinctFrom?: InputMaybe<LogLevel>;
-  /** Not equal to the specified value. */
-  notEqualTo?: InputMaybe<LogLevel>;
-  /** Not included in the specified list. */
-  notIn?: InputMaybe<Array<LogLevel>>;
-};
-
-/** All input for the `markFailed` mutation. */
-export type MarkFailedInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  expectedstate?: InputMaybe<JobStates>;
-  id?: InputMaybe<Scalars['UUID']>;
-  retry?: InputMaybe<Scalars['Boolean']>;
-  runAfter?: InputMaybe<Scalars['BigInt']>;
-};
-
-/** The output of our `markFailed` mutation. */
-export type MarkFailedPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  jobs?: Maybe<Array<Job>>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-};
-
-/** All input for the `markSuccess` mutation. */
-export type MarkSuccessInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  expectedstate?: InputMaybe<JobStates>;
-  id?: InputMaybe<Scalars['UUID']>;
-};
-
-/** The output of our `markSuccess` mutation. */
-export type MarkSuccessPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  jobs?: Maybe<Array<Job>>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-};
-
 /** The root mutation type which contains root level fields which mutate data. */
 export type Mutation = {
   addToken?: Maybe<Scalars['Boolean']>;
-  cancellingJob?: Maybe<CancellingJobPayload>;
-  checkJobStatus?: Maybe<CheckJobStatusPayload>;
   /** Creates a single `ContainerImage`. */
   createContainerImage?: Maybe<CreateContainerImagePayload>;
   /** Creates a single `ContainerImageType`. */
@@ -10746,10 +10358,6 @@ export type Mutation = {
   createGosecRepoScan?: Maybe<CreateGosecRepoScanPayload>;
   /** Creates a single `GrypeRepoScan`. */
   createGrypeRepoScan?: Maybe<CreateGrypeRepoScanPayload>;
-  /** Creates a single `Job`. */
-  createJob?: Maybe<CreateJobPayload>;
-  /** Creates a single `JobLog`. */
-  createJobLog?: Maybe<CreateJobLogPayload>;
   /** Creates a single `Label`. */
   createLabel?: Maybe<CreateLabelPayload>;
   /** Creates a single `LabelAssociation`. */
@@ -10762,8 +10370,6 @@ export type Mutation = {
   createProvider?: Maybe<CreateProviderPayload>;
   /** Creates a single `QueryHistory`. */
   createQueryHistory?: Maybe<CreateQueryHistoryPayload>;
-  /** Creates a single `Queue`. */
-  createQueue?: Maybe<CreateQueuePayload>;
   /** Creates a single `Repo`. */
   createRepo?: Maybe<CreateRepoPayload>;
   /** Creates a single `RepoImport`. */
@@ -10902,14 +10508,6 @@ export type Mutation = {
   deleteGrypeRepoScan?: Maybe<DeleteGrypeRepoScanPayload>;
   /** Deletes a single `GrypeRepoScan` using its globally unique id. */
   deleteGrypeRepoScanByNodeId?: Maybe<DeleteGrypeRepoScanPayload>;
-  /** Deletes a single `Job` using a unique key. */
-  deleteJob?: Maybe<DeleteJobPayload>;
-  /** Deletes a single `Job` using its globally unique id. */
-  deleteJobByNodeId?: Maybe<DeleteJobPayload>;
-  /** Deletes a single `JobLog` using a unique key. */
-  deleteJobLog?: Maybe<DeleteJobLogPayload>;
-  /** Deletes a single `JobLog` using its globally unique id. */
-  deleteJobLogByNodeId?: Maybe<DeleteJobLogPayload>;
   /** Deletes a single `Label` using a unique key. */
   deleteLabel?: Maybe<DeleteLabelPayload>;
   /** Deletes a single `LabelAssociation` using a unique key. */
@@ -10930,10 +10528,6 @@ export type Mutation = {
   deleteQueryHistory?: Maybe<DeleteQueryHistoryPayload>;
   /** Deletes a single `QueryHistory` using its globally unique id. */
   deleteQueryHistoryByNodeId?: Maybe<DeleteQueryHistoryPayload>;
-  /** Deletes a single `Queue` using a unique key. */
-  deleteQueue?: Maybe<DeleteQueuePayload>;
-  /** Deletes a single `Queue` using its globally unique id. */
-  deleteQueueByNodeId?: Maybe<DeleteQueuePayload>;
   /** Deletes a single `Repo` using a unique key. */
   deleteRepo?: Maybe<DeleteRepoPayload>;
   /** Deletes a single `Repo` using its globally unique id. */
@@ -11022,12 +10616,8 @@ export type Mutation = {
   deleteYelpDetectSecretsRepoScan?: Maybe<DeleteYelpDetectSecretsRepoScanPayload>;
   /** Deletes a single `YelpDetectSecretsRepoScan` using its globally unique id. */
   deleteYelpDetectSecretsRepoScanByNodeId?: Maybe<DeleteYelpDetectSecretsRepoScanPayload>;
-  dequeueJob?: Maybe<DequeueJobPayload>;
   fetchServiceAuthCredential?: Maybe<FetchServiceAuthCredentialPayload>;
   jsonbRecursiveMerge?: Maybe<JsonbRecursiveMergePayload>;
-  markFailed?: Maybe<MarkFailedPayload>;
-  markSuccess?: Maybe<MarkSuccessPayload>;
-  reap?: Maybe<ReapPayload>;
   setSyncJobStatus?: Maybe<SetSyncJobStatusPayload>;
   simpleRepoSyncQueueCleanup?: Maybe<SimpleRepoSyncQueueCleanupPayload>;
   syncNow?: Maybe<Scalars['Boolean']>;
@@ -11127,14 +10717,6 @@ export type Mutation = {
   updateGrypeRepoScan?: Maybe<UpdateGrypeRepoScanPayload>;
   /** Updates a single `GrypeRepoScan` using its globally unique id and a patch. */
   updateGrypeRepoScanByNodeId?: Maybe<UpdateGrypeRepoScanPayload>;
-  /** Updates a single `Job` using a unique key and a patch. */
-  updateJob?: Maybe<UpdateJobPayload>;
-  /** Updates a single `Job` using its globally unique id and a patch. */
-  updateJobByNodeId?: Maybe<UpdateJobPayload>;
-  /** Updates a single `JobLog` using a unique key and a patch. */
-  updateJobLog?: Maybe<UpdateJobLogPayload>;
-  /** Updates a single `JobLog` using its globally unique id and a patch. */
-  updateJobLogByNodeId?: Maybe<UpdateJobLogPayload>;
   /** Updates a single `Label` using a unique key and a patch. */
   updateLabel?: Maybe<UpdateLabelPayload>;
   /** Updates a single `LabelAssociation` using a unique key and a patch. */
@@ -11155,10 +10737,6 @@ export type Mutation = {
   updateQueryHistory?: Maybe<UpdateQueryHistoryPayload>;
   /** Updates a single `QueryHistory` using its globally unique id and a patch. */
   updateQueryHistoryByNodeId?: Maybe<UpdateQueryHistoryPayload>;
-  /** Updates a single `Queue` using a unique key and a patch. */
-  updateQueue?: Maybe<UpdateQueuePayload>;
-  /** Updates a single `Queue` using its globally unique id and a patch. */
-  updateQueueByNodeId?: Maybe<UpdateQueuePayload>;
   /** Updates a single `Repo` using a unique key and a patch. */
   updateRepo?: Maybe<UpdateRepoPayload>;
   /** Updates a single `Repo` using its globally unique id and a patch. */
@@ -11260,18 +10838,6 @@ export type MutationAddTokenArgs = {
   token: Scalars['String'];
   type: Scalars['String'];
   username?: InputMaybe<Scalars['String']>;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCancellingJobArgs = {
-  input: CancellingJobInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCheckJobStatusArgs = {
-  input: CheckJobStatusInput;
 };
 
 
@@ -11426,18 +10992,6 @@ export type MutationCreateGrypeRepoScanArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateJobArgs = {
-  input: CreateJobInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateJobLogArgs = {
-  input: CreateJobLogInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateLabelArgs = {
   input: CreateLabelInput;
 };
@@ -11470,12 +11024,6 @@ export type MutationCreateProviderArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateQueryHistoryArgs = {
   input: CreateQueryHistoryInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateQueueArgs = {
-  input: CreateQueueInput;
 };
 
 
@@ -11894,30 +11442,6 @@ export type MutationDeleteGrypeRepoScanByNodeIdArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteJobArgs = {
-  input: DeleteJobInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteJobByNodeIdArgs = {
-  input: DeleteJobByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteJobLogArgs = {
-  input: DeleteJobLogInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteJobLogByNodeIdArgs = {
-  input: DeleteJobLogByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteLabelArgs = {
   input: DeleteLabelInput;
 };
@@ -11974,18 +11498,6 @@ export type MutationDeleteQueryHistoryArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteQueryHistoryByNodeIdArgs = {
   input: DeleteQueryHistoryByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteQueueArgs = {
-  input: DeleteQueueInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteQueueByNodeIdArgs = {
-  input: DeleteQueueByNodeIdInput;
 };
 
 
@@ -12254,12 +11766,6 @@ export type MutationDeleteYelpDetectSecretsRepoScanByNodeIdArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDequeueJobArgs = {
-  input: DequeueJobInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationFetchServiceAuthCredentialArgs = {
   input: FetchServiceAuthCredentialInput;
 };
@@ -12268,24 +11774,6 @@ export type MutationFetchServiceAuthCredentialArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationJsonbRecursiveMergeArgs = {
   input: JsonbRecursiveMergeInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationMarkFailedArgs = {
-  input: MarkFailedInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationMarkSuccessArgs = {
-  input: MarkSuccessInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationReapArgs = {
-  input: ReapInput;
 };
 
 
@@ -12597,30 +12085,6 @@ export type MutationUpdateGrypeRepoScanByNodeIdArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateJobArgs = {
-  input: UpdateJobInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateJobByNodeIdArgs = {
-  input: UpdateJobByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateJobLogArgs = {
-  input: UpdateJobLogInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateJobLogByNodeIdArgs = {
-  input: UpdateJobLogByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateLabelArgs = {
   input: UpdateLabelInput;
 };
@@ -12677,18 +12141,6 @@ export type MutationUpdateQueryHistoryArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateQueryHistoryByNodeIdArgs = {
   input: UpdateQueryHistoryByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateQueueArgs = {
-  input: UpdateQueueInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateQueueByNodeIdArgs = {
-  input: UpdateQueueByNodeIdInput;
 };
 
 
@@ -13599,16 +13051,6 @@ export type Query = Node & {
   grypeRepoScans?: Maybe<GrypeRepoScansConnection>;
   /** Reads and enables pagination through a set of `GrypeRepoVulnerability`. */
   grypeRepoVulnerabilities?: Maybe<GrypeRepoVulnerabilitiesConnection>;
-  job?: Maybe<Job>;
-  /** Reads a single `Job` using its globally unique `ID`. */
-  jobByNodeId?: Maybe<Job>;
-  jobLog?: Maybe<JobLog>;
-  /** Reads a single `JobLog` using its globally unique `ID`. */
-  jobLogByNodeId?: Maybe<JobLog>;
-  /** Reads and enables pagination through a set of `JobLog`. */
-  jobLogs?: Maybe<JobLogsConnection>;
-  /** Reads and enables pagination through a set of `Job`. */
-  jobs?: Maybe<JobsConnection>;
   label?: Maybe<Label>;
   labelAssociationByLabelAndRepoSyncType?: Maybe<LabelAssociation>;
   /** Reads and enables pagination through a set of `LabelAssociation`. */
@@ -13620,7 +13062,7 @@ export type Query = Node & {
   /** Reads and enables pagination through a set of `LatestRepoSync`. */
   latestRepoSyncs?: Maybe<LatestRepoSyncsConnection>;
   /** Fetches an object given its globally unique `ID`. */
-  node?: Maybe<ContainerImage | ContainerImageType | ContainerSync | ContainerSyncSchedule | GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Job | JobLog | Label | OssfScorecardRepoScan | Provider | Query | QueryHistory | Queue | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | Vendor | VendorType | YelpDetectSecretsRepoScan>;
+  node?: Maybe<ContainerImage | ContainerImageType | ContainerSync | ContainerSyncSchedule | GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Label | OssfScorecardRepoScan | Provider | Query | QueryHistory | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | Vendor | VendorType | YelpDetectSecretsRepoScan>;
   /** The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`. */
   nodeId: Scalars['ID'];
   /** Reads and enables pagination through a set of `OssfScorecardRepoCheckResult`. */
@@ -13648,11 +13090,6 @@ export type Query = Node & {
   queryHistory?: Maybe<QueryHistory>;
   /** Reads a single `QueryHistory` using its globally unique `ID`. */
   queryHistoryByNodeId?: Maybe<QueryHistory>;
-  queue?: Maybe<Queue>;
-  /** Reads a single `Queue` using its globally unique `ID`. */
-  queueByNodeId?: Maybe<Queue>;
-  /** Reads and enables pagination through a set of `Queue`. */
-  queues?: Maybe<QueuesConnection>;
   repo?: Maybe<Repo>;
   /** Reads a single `Repo` using its globally unique `ID`. */
   repoByNodeId?: Maybe<Repo>;
@@ -14450,56 +13887,6 @@ export type QueryGrypeRepoVulnerabilitiesArgs = {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryJobArgs = {
-  id: Scalars['UUID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryJobByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryJobLogArgs = {
-  id: Scalars['UUID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryJobLogByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryJobLogsArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  condition?: InputMaybe<JobLogCondition>;
-  filter?: InputMaybe<JobLogFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<JobLogsOrderBy>>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryJobsArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  condition?: InputMaybe<JobCondition>;
-  filter?: InputMaybe<JobFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<JobsOrderBy>>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
 export type QueryLabelArgs = {
   label: Scalars['String'];
 };
@@ -14667,31 +14054,6 @@ export type QueryQueryHistoryArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryQueryHistoryByNodeIdArgs = {
   nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryQueueArgs = {
-  name: Scalars['String'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryQueueByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryQueuesArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  condition?: InputMaybe<QueueCondition>;
-  filter?: InputMaybe<QueueFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<QueuesOrderBy>>;
 };
 
 
@@ -15388,141 +14750,6 @@ export type QueryHistoryPatch = {
   query?: InputMaybe<Scalars['String']>;
   runAt?: InputMaybe<Scalars['Datetime']>;
   runBy?: InputMaybe<Scalars['String']>;
-};
-
-export type Queue = Node & {
-  concurrency?: Maybe<Scalars['Int']>;
-  createdAt: Scalars['Datetime'];
-  description?: Maybe<Scalars['String']>;
-  /** Reads and enables pagination through a set of `Job`. */
-  jobsByQueue: JobsConnection;
-  name: Scalars['String'];
-  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
-  nodeId: Scalars['ID'];
-  priority: Scalars['Int'];
-};
-
-
-export type QueueJobsByQueueArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  condition?: InputMaybe<JobCondition>;
-  filter?: InputMaybe<JobFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<JobsOrderBy>>;
-};
-
-/** A condition to be used against `Queue` object types. All fields are tested for equality and combined with a logical ‘and.’ */
-export type QueueCondition = {
-  /** Checks for equality with the object’s `concurrency` field. */
-  concurrency?: InputMaybe<Scalars['Int']>;
-  /** Checks for equality with the object’s `createdAt` field. */
-  createdAt?: InputMaybe<Scalars['Datetime']>;
-  /** Checks for equality with the object’s `description` field. */
-  description?: InputMaybe<Scalars['String']>;
-  /** Checks for equality with the object’s `name` field. */
-  name?: InputMaybe<Scalars['String']>;
-  /** Checks for equality with the object’s `priority` field. */
-  priority?: InputMaybe<Scalars['Int']>;
-};
-
-/** A filter to be used against `Queue` object types. All fields are combined with a logical ‘and.’ */
-export type QueueFilter = {
-  /** Checks for all expressions in this list. */
-  and?: InputMaybe<Array<QueueFilter>>;
-  /** Filter by the object’s `concurrency` field. */
-  concurrency?: InputMaybe<IntFilter>;
-  /** Filter by the object’s `createdAt` field. */
-  createdAt?: InputMaybe<DatetimeFilter>;
-  /** Filter by the object’s `description` field. */
-  description?: InputMaybe<StringFilter>;
-  /** Filter by the object’s `name` field. */
-  name?: InputMaybe<StringFilter>;
-  /** Negates the expression. */
-  not?: InputMaybe<QueueFilter>;
-  /** Checks for any expressions in this list. */
-  or?: InputMaybe<Array<QueueFilter>>;
-  /** Filter by the object’s `priority` field. */
-  priority?: InputMaybe<IntFilter>;
-};
-
-/** An input for mutations affecting `Queue` */
-export type QueueInput = {
-  concurrency?: InputMaybe<Scalars['Int']>;
-  createdAt?: InputMaybe<Scalars['Datetime']>;
-  description?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  priority?: InputMaybe<Scalars['Int']>;
-};
-
-/** Represents an update to a `Queue`. Fields that are set will be updated. */
-export type QueuePatch = {
-  concurrency?: InputMaybe<Scalars['Int']>;
-  createdAt?: InputMaybe<Scalars['Datetime']>;
-  description?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  priority?: InputMaybe<Scalars['Int']>;
-};
-
-/** A connection to a list of `Queue` values. */
-export type QueuesConnection = {
-  /** A list of edges which contains the `Queue` and cursor to aid in pagination. */
-  edges: Array<QueuesEdge>;
-  /** A list of `Queue` objects. */
-  nodes: Array<Queue>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `Queue` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `Queue` edge in the connection. */
-export type QueuesEdge = {
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `Queue` at the end of the edge. */
-  node: Queue;
-};
-
-/** Methods to use when ordering `Queue`. */
-export enum QueuesOrderBy {
-  ConcurrencyAsc = 'CONCURRENCY_ASC',
-  ConcurrencyDesc = 'CONCURRENCY_DESC',
-  CreatedAtAsc = 'CREATED_AT_ASC',
-  CreatedAtDesc = 'CREATED_AT_DESC',
-  DescriptionAsc = 'DESCRIPTION_ASC',
-  DescriptionDesc = 'DESCRIPTION_DESC',
-  NameAsc = 'NAME_ASC',
-  NameDesc = 'NAME_DESC',
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  PriorityAsc = 'PRIORITY_ASC',
-  PriorityDesc = 'PRIORITY_DESC'
-}
-
-/** All input for the `reap` mutation. */
-export type ReapInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  queues?: InputMaybe<Array<InputMaybe<Scalars['String']>>>;
-};
-
-/** The output of our `reap` mutation. */
-export type ReapPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  integer?: Maybe<Scalars['Int']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
 };
 
 /** git repositories to track */
@@ -19609,102 +18836,6 @@ export type UpdateGrypeRepoScanPayloadGrypeRepoScanEdgeArgs = {
   orderBy?: InputMaybe<Array<GrypeRepoScansOrderBy>>;
 };
 
-/** All input for the `updateJobByNodeId` mutation. */
-export type UpdateJobByNodeIdInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `Job` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `Job` being updated. */
-  patch: JobPatch;
-};
-
-/** All input for the `updateJob` mutation. */
-export type UpdateJobInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  id: Scalars['UUID'];
-  /** An object where the defined keys will be set on the `Job` being updated. */
-  patch: JobPatch;
-};
-
-/** All input for the `updateJobLogByNodeId` mutation. */
-export type UpdateJobLogByNodeIdInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `JobLog` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `JobLog` being updated. */
-  patch: JobLogPatch;
-};
-
-/** All input for the `updateJobLog` mutation. */
-export type UpdateJobLogInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  id: Scalars['UUID'];
-  /** An object where the defined keys will be set on the `JobLog` being updated. */
-  patch: JobLogPatch;
-};
-
-/** The output of our update `JobLog` mutation. */
-export type UpdateJobLogPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** Reads a single `Job` that is related to this `JobLog`. */
-  jobByJob?: Maybe<Job>;
-  /** The `JobLog` that was updated by this mutation. */
-  jobLog?: Maybe<JobLog>;
-  /** An edge for our `JobLog`. May be used by Relay 1. */
-  jobLogEdge?: Maybe<JobLogsEdge>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-};
-
-
-/** The output of our update `JobLog` mutation. */
-export type UpdateJobLogPayloadJobLogEdgeArgs = {
-  orderBy?: InputMaybe<Array<JobLogsOrderBy>>;
-};
-
-/** The output of our update `Job` mutation. */
-export type UpdateJobPayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** The `Job` that was updated by this mutation. */
-  job?: Maybe<Job>;
-  /** An edge for our `Job`. May be used by Relay 1. */
-  jobEdge?: Maybe<JobsEdge>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Queue` that is related to this `Job`. */
-  queueByQueue?: Maybe<Queue>;
-};
-
-
-/** The output of our update `Job` mutation. */
-export type UpdateJobPayloadJobEdgeArgs = {
-  orderBy?: InputMaybe<Array<JobsOrderBy>>;
-};
-
 /** All input for the `updateLabelAssociationByLabelAndRepoSyncType` mutation. */
 export type UpdateLabelAssociationByLabelAndRepoSyncTypeInput = {
   /**
@@ -19942,52 +19073,6 @@ export type UpdateQueryHistoryPayload = {
 /** The output of our update `QueryHistory` mutation. */
 export type UpdateQueryHistoryPayloadQueryHistoryEdgeArgs = {
   orderBy?: InputMaybe<Array<QueryHistoriesOrderBy>>;
-};
-
-/** All input for the `updateQueueByNodeId` mutation. */
-export type UpdateQueueByNodeIdInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `Queue` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `Queue` being updated. */
-  patch: QueuePatch;
-};
-
-/** All input for the `updateQueue` mutation. */
-export type UpdateQueueInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  /** An object where the defined keys will be set on the `Queue` being updated. */
-  patch: QueuePatch;
-};
-
-/** The output of our update `Queue` mutation. */
-export type UpdateQueuePayload = {
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** The `Queue` that was updated by this mutation. */
-  queue?: Maybe<Queue>;
-  /** An edge for our `Queue`. May be used by Relay 1. */
-  queueEdge?: Maybe<QueuesEdge>;
-};
-
-
-/** The output of our update `Queue` mutation. */
-export type UpdateQueuePayloadQueueEdgeArgs = {
-  orderBy?: InputMaybe<Array<QueuesOrderBy>>;
 };
 
 /** All input for the `updateRepoByNodeId` mutation. */

--- a/ui/src/api-logic/graphql/queries/get-query-history.ts
+++ b/ui/src/api-logic/graphql/queries/get-query-history.ts
@@ -1,0 +1,16 @@
+import { gql } from '@apollo/client'
+
+const GET_QUERY_HISTORY = gql`
+  query getQueryHistory {
+    queryHistories(orderBy: RUN_AT_DESC) {
+      nodes {
+        id
+        runAt
+        runBy
+        query
+      }
+    }
+  }
+`
+
+export { GET_QUERY_HISTORY }

--- a/ui/src/api-logic/mappers/history.ts
+++ b/ui/src/api-logic/mappers/history.ts
@@ -1,0 +1,21 @@
+import { QueryHistoryData } from 'src/@types'
+import { GetQueryHistoryQuery } from '../graphql/generated/schema'
+
+const mapToQueryHistoryData = (data: GetQueryHistoryQuery | undefined): Array<QueryHistoryData> => {
+  const queryHistory: Array<QueryHistoryData> = []
+
+  data?.queryHistories?.nodes.forEach((r) => {
+    const info: QueryHistoryData = {
+      id: r?.id,
+      query: r?.query,
+      runAt: new Date(r?.runAt),
+      runBy: r?.runBy
+    }
+
+    queryHistory.push(info)
+  })
+
+  return queryHistory
+}
+
+export { mapToQueryHistoryData }

--- a/ui/src/state/contexts/query.context.tsx
+++ b/ui/src/state/contexts/query.context.tsx
@@ -16,6 +16,7 @@ type QueryContextT = {
   dataQuery: QueryResultProps
   projection: string[]
   showSettingsModal: boolean
+  showQueryHistoryModal: boolean
 }
 
 type UseQueryContextT = [
@@ -31,7 +32,8 @@ const initialState: QueryContextT = {
   tabs: [],
   dataQuery: {},
   projection: [],
-  showSettingsModal: false
+  showSettingsModal: false,
+  showQueryHistoryModal: false
 }
 
 function useQueryEditor(): UseQueryContextT {
@@ -112,6 +114,13 @@ function useQuerySetState() {
     }))
   }
 
+  const setShowQueryHistoryModal = (showQueryHistoryModal: boolean) => {
+    setState(prev => ({
+      ...prev,
+      showQueryHistoryModal
+    }))
+  }
+
   return {
     _,
     setQuery,
@@ -121,7 +130,8 @@ function useQuerySetState() {
     setTabs,
     setDataQuery,
     setProjection,
-    setShowSettingsModal
+    setShowSettingsModal,
+    setShowQueryHistoryModal,
   }
 }
 

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -58,6 +58,15 @@
            cursor-pointer;
 }
 
+.t-vertical-nav-item-active {
+  @apply border-l-4
+         border-blue-500
+}
+
+.t-vertical-nav-item-active > a > span > div > p {
+  @apply text-blue-500
+}
+
 .t-table-bordered tr:last-child td {
   @apply  border-r
           border-l

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -40,7 +40,7 @@
   @apply font-medium
          text-gray-600
          text-sm
-         mb-1;
+         mb-2;
 }
 
 .t-master-detail-item-preview {

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -20,12 +20,18 @@
 }
 */
 
+.t-master-detail-list {
+  @apply bg-gray-50;
+}
+
 .t-master-detail-item {
   @apply px-6
          text-left
          bg-white
          text-gray-900
          py-4
+         border-b
+         border-gray-150
          w-full
          hover_bg-gray-50;
 }

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -20,109 +20,59 @@
 }
 */
 
-
-/* TODO(emily): fix override max-h-full class in t-modal styles in blocks */
-.t-modal {
-  max-height: calc(100vh - 4.8rem);
+.t-master-detail-list {
+  @apply bg-gray-50;
+}
+.t-master-detail-item {
+  @apply px-6
+         text-left
+         border-b
+         border-gray-150
+         bg-white
+         text-gray-900
+         py-4
+         w-full
+         hover_bg-gray-50;
 }
 
-/* TODO(emily): add button styles to blocks */
-.t-nav {
-  @apply h-auto;
+.t-master-detail-item-active {
+  @apply relative
+         bg-gray-50
+         py-4;
 }
 
-.t-nav-item {
-  @apply h-11;
+.t-master-detail-item-title {
+  @apply font-medium
+         text-gray-900
+         text-sm
+         mb-1;
 }
 
-.t-nav > * + * {
-  @apply ml-3
+.t-master-detail-item-preview {
+  @apply font-mono
+         text-xs
+         text-gray-450;
 }
 
-.t-nav-item > a,
-.t-nav-item > button {
-    @apply px-3
-           border-0
-           rounded-md
-           bg-transparent
-           gap-3
-           font-medium
-           inline-flex
-           items-center
-           h-full
-           focus_outline-none
-           focus_ring-2
-           ring-inset
-           focus_ring-blue-500
-           hover_bg-gray-600
-           cursor-pointer;
+.t-master-detail-item-active .t-master-detail-item-title {
+  @apply text-blue-600;
 }
 
-.t-vertical-nav-item-active {
-  @apply border-l-4
-         border-blue-500
+.t-master-detail-item-active:after {
+  content: "";
+  @apply left-0
+         top-0
+         w-1
+         h-full
+         absolute
+         bg-blue-500;
 }
 
-.t-vertical-nav-item-active > a > span > div > p {
-  @apply text-blue-500
-}
-
-.t-table-bordered tr:last-child td {
-  @apply  border-r
-          border-l
-          border-b;
-}
-
-/* TODO(emily) re-add missing resizer styles to blocks */
-.t-resizer {
-  cursor: row-resize;
-  @apply w-full;
-}
-
-
-/* TODO(emily) adjust styles in blocks */
-.t-button-toolbar {
-  @apply space-x-3;
-}
-
-/* TODO(emily) update classname */
-.t-radio-card.t-radio-card-selected {
-  @apply bg-blue-50
-         text-blue-600
-         ring-1
-         ring-inset
-         ring-blue-500
-         border-blue-500
-         hover_from-blue-100
-         hover_to-blue-100;
-}
-
-/* TODO(emily) review avatar setup */
-.t-avatar {
-  @apply bg-gray-100;
-}
-
-.t-avatar-dark {
-  @apply bg-gray-500;
-}
-
-.t-avatar-primary {
-  @apply bg-blue-600;
-}
-
-.t-avatar-xl .t-icon {
-    @apply w-6
-           h-6;
-}
-
-/* TODO(emily) fix modal position jump on smaller screens */
-.t-modal {
-  @apply align-middle;
-}
-
-/* TODO(emily) fix tabs spacing in blocks */
-.t-tab {
-  @apply mb-0;
+pre[class*="language-"]::selection,
+pre[class*="language-"] ::selection,
+code[class*="language-"]::selection,
+code[class*="language-"] ::selection {
+  @apply bg-gray-200;
 }
 
 .apexcharts-tooltip {

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -20,55 +20,6 @@
 }
 */
 
-.t-master-detail-list {
-  @apply bg-gray-50;
-}
-
-.t-master-detail-item {
-  @apply px-6
-         text-left
-         bg-white
-         text-gray-900
-         py-4
-         border-b
-         border-gray-150
-         w-full
-         hover_bg-gray-50;
-}
-
-.t-master-detail-item-active {
-  @apply relative
-         bg-gray-50
-         py-4;
-}
-
-.t-master-detail-item-title {
-  @apply font-medium
-         text-gray-600
-         text-sm
-         mb-2;
-}
-
-.t-master-detail-item-preview {
-  @apply font-mono
-         text-xs
-         text-gray-450;
-}
-
-.t-master-detail-item-active .t-master-detail-item-title {
-  @apply text-blue-600;
-}
-
-.t-master-detail-item-active:after {
-  content: "";
-  @apply left-0
-         top-0
-         w-1
-         h-full
-         absolute
-         bg-blue-500;
-}
-
 pre[class*="language-"]::selection,
 pre[class*="language-"] ::selection,
 code[class*="language-"]::selection,

--- a/ui/src/styles/globals.css
+++ b/ui/src/styles/globals.css
@@ -20,14 +20,9 @@
 }
 */
 
-.t-master-detail-list {
-  @apply bg-gray-50;
-}
 .t-master-detail-item {
   @apply px-6
          text-left
-         border-b
-         border-gray-150
          bg-white
          text-gray-900
          py-4
@@ -43,7 +38,7 @@
 
 .t-master-detail-item-title {
   @apply font-medium
-         text-gray-900
+         text-gray-600
          text-sm
          mb-1;
 }

--- a/ui/src/views/hooks/useQueryEditor.ts
+++ b/ui/src/views/hooks/useQueryEditor.ts
@@ -9,8 +9,8 @@ import { formatTimeExecution } from 'src/utils'
 import { States } from 'src/utils/constants'
 
 const useQueryEditor = (rowsLimit: number) => {
-  const [{ query, readOnly, expanded, dataQuery, projection, showSettingsModal }] = useQueryContext()
-  const { setQuery, setDataQuery, setProjection, setTabs, setActiveTab, setShowSettingsModal } = useQuerySetState()
+  const [{ query, readOnly, expanded, dataQuery, projection, showSettingsModal, showQueryHistoryModal }] = useQueryContext()
+  const { setQuery, setDataQuery, setProjection, setTabs, setActiveTab, setShowSettingsModal, setShowQueryHistoryModal } = useQuerySetState()
   const dispatch = useQueryTabsDispatch()
 
   const [state, setState] = useState<States>(States.Empty)
@@ -92,6 +92,7 @@ const useQueryEditor = (rowsLimit: number) => {
   return {
     setQuery,
     setShowSettingsModal,
+    setShowQueryHistoryModal,
     setTitle,
     setDesc,
     executeSQLQuery,
@@ -99,6 +100,7 @@ const useQueryEditor = (rowsLimit: number) => {
     expanded,
     dataQuery,
     showSettingsModal,
+    showQueryHistoryModal,
     state,
     rowLimitReached,
     executed,

--- a/ui/src/views/hooks/useQueryHistory.ts
+++ b/ui/src/views/hooks/useQueryHistory.ts
@@ -1,0 +1,15 @@
+
+import { GET_QUERY_HISTORY } from 'src/api-logic/graphql/queries/get-query-history'
+import { useQuery } from '@apollo/client'
+import { GetQueryHistoryQuery } from 'src/api-logic/graphql/generated/schema'
+
+const useQueryHistory = () => {
+  const { loading, data } = useQuery<GetQueryHistoryQuery>(GET_QUERY_HISTORY, {
+    fetchPolicy: 'no-cache',
+    pollInterval: 5000,
+  })
+
+  return { loading, data }
+}
+
+export default useQueryHistory

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -12,6 +12,7 @@ import QueryEditorFilled from './components/state-filled'
 import QueryEditorLoading from './components/state-loading'
 import QueryEditorRowsImpacted from './components/state-rows-affected'
 import { QuerySettingsModal } from './modals/query-setting'
+import { QueryHistoryModal } from './modals/query-history'
 
 type QueryEditorProps = {
   savedQueryId?: string | string[]
@@ -21,8 +22,8 @@ type QueryEditorProps = {
 const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorProps) => {
   const ROWS_LIMIT = 1000
   const {
-    setQuery, setShowSettingsModal, setTitle, setDesc, executeSQLQuery, cancelSQLQuery,
-    expanded, showSettingsModal, state, rowLimitReached, executed, readOnly,
+    setQuery, setShowSettingsModal, setShowQueryHistoryModal, setTitle, setDesc, executeSQLQuery, cancelSQLQuery,
+    expanded, showSettingsModal, showQueryHistoryModal, state, rowLimitReached, executed, readOnly,
     loading, error, query, data, time, title, desc
   } = useQueryEditor(ROWS_LIMIT)
 
@@ -77,13 +78,11 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
               onClick={() => setShowSettingsModal(true)}
             />
 
-            <Tooltip content='Query history coming soon' placement='bottom' offset={[0, 10]}>
-              <Button isIconOnly disabled
-                skin='borderless-muted'
-                startIcon={<ClockHistoryIcon className='t-icon' />}
-                onClick={() => null}
-              />
-            </Tooltip>
+            <Button isIconOnly
+              skin='borderless-muted'
+              startIcon={<ClockHistoryIcon className='t-icon' />}
+              onClick={() => setShowQueryHistoryModal(true)}
+            />
 
             <div className='flex gap-x-2'>
               {savedQueryId
@@ -148,6 +147,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
       </div>
 
       {showSettingsModal && <QuerySettingsModal />}
+      {showQueryHistoryModal && <QueryHistoryModal />}
     </>
   )
 }

--- a/ui/src/views/sql-query-editor/modals/query-history.tsx
+++ b/ui/src/views/sql-query-editor/modals/query-history.tsx
@@ -1,0 +1,123 @@
+import { Button, Modal, Toolbar, VerticalNav } from '@mergestat/blocks'
+import React, { useCallback, useEffect, useState } from 'react'
+import { ClockHistoryIcon, XIcon } from '@mergestat/icons'
+import { useQuerySetState } from 'src/state/contexts'
+import useQueryHistory from 'src/views/hooks/useQueryHistory'
+import { mapToQueryHistoryData } from 'src/api-logic/mappers/history'
+import { QueryHistoryData } from 'src/@types'
+import Loading from 'src/components/Loading'
+import Editor from '@monaco-editor/react'
+
+export const QueryHistoryModal: React.FC = () => {
+  const { setShowQueryHistoryModal, setQuery } = useQuerySetState()
+  const { loading, data } = useQueryHistory()
+  const [active, setActive] = useState<QueryHistoryData>()
+  const [queryHistory, setQueryHistory] = useState<Array<QueryHistoryData>>()
+
+  const close = useCallback(() => {
+    setShowQueryHistoryModal(false)
+  }, [setShowQueryHistoryModal])
+
+  const onUseQueryClick = () => {
+    if (active) {
+      setQuery(active.query)
+      close()
+    }
+  }
+
+  useEffect(() => {
+    setQueryHistory(mapToQueryHistoryData(data))
+  }, [data])
+
+  return (
+    <Modal open onClose={close} size="lg">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>View query history</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body className='overflow-hidden'>
+        {
+          loading
+            ? <div className='h-720'><Loading /></div>
+            : <div className='flex overflow-hidden'>
+            <div className='w-1/3 border-r h-720 overflow-y-scroll'>
+              <VerticalNav>
+                {queryHistory?.map((history) => (
+                  <VerticalNav.Item
+                    key={`vertical-nav-item-${history.id}`}
+                    active={active?.id === history.id}
+                    onClick={() => setActive(history)}
+                    className="border-b mt-0 h-65"
+                    text={
+                      <div className="flex flex-col items-start mx-2">
+                        <p className='font-medium text-sm text-gray-700'>
+                          {history.runAt?.toDateString() || ''}
+                        </p>
+                        <div className='text-xs font-mono text-gray-400'>
+                          {history.query.length > 40 ? `${history.query.substring(0, 40)} ...` : history.query}
+                        </div>
+                      </div>
+                    }
+                  />
+                ))}
+              </VerticalNav>
+            </div>
+            <div className='w-2/3'>
+              <div className='overflow-hidden flex justify-between items-center h-14 w-full border-b px-8'>
+                <div className='flex justify-between items-center'>
+                  <Button
+                    isIconOnly
+                    className='bg-gray-100 py-2 px-3'
+                    skin='borderless-muted'
+                    startIcon={<ClockHistoryIcon className='t-icon' />}
+                  />
+                  <p className='font-semibold text-gray-900 px-3'>
+                    {active?.runAt?.toDateString() || ''}
+                  </p>
+                </div>
+                <Button
+                  className='whitespace-nowrap justify-center ml-0 w-32'
+                  label='Use Query'
+                  disabled={!active}
+                  onClick={onUseQueryClick}
+                />
+              </div>
+              <div className='bg-gray-50 p-3 h-full'>
+                <Editor
+                  className='text-sm font-mono'
+                  value={active?.query}
+                  language='sql'
+                  options={
+                    {
+                      minimap: { enabled: false },
+                      fontSize: 14,
+                      scrollbar: {
+                        vertical: 'auto',
+                      },
+                      readOnly: true,
+                      domReadOnly: true,
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        }
+      </Modal.Body>
+    </Modal>
+  )
+}

--- a/ui/src/views/sql-query-editor/modals/query-history.tsx
+++ b/ui/src/views/sql-query-editor/modals/query-history.tsx
@@ -69,7 +69,7 @@ export const QueryHistoryModal: React.FC = () => {
                   </p>
                 </div>
               : <>
-              <div className='w-1/3 border-r flex flex-col overflow-hidden'>
+              <div className='w-1/3 border-r flex flex-col overflow-hidden h-720'>
                 <div className='t-master-detail-list flex-1 overflow-auto'>
                   {queryHistory?.map((history) => (
                   <button

--- a/ui/src/views/sql-query-editor/modals/query-history.tsx
+++ b/ui/src/views/sql-query-editor/modals/query-history.tsx
@@ -1,18 +1,20 @@
-import { Button, Modal, Toolbar, VerticalNav } from '@mergestat/blocks'
 import React, { useCallback, useEffect, useState } from 'react'
+import cx from 'classnames'
+import { Avatar, Button, ColoredBox, Modal, Toolbar } from '@mergestat/blocks'
 import { ClockHistoryIcon, XIcon } from '@mergestat/icons'
 import { useQuerySetState } from 'src/state/contexts'
 import useQueryHistory from 'src/views/hooks/useQueryHistory'
 import { mapToQueryHistoryData } from 'src/api-logic/mappers/history'
 import { QueryHistoryData } from 'src/@types'
 import Loading from 'src/components/Loading'
-import Editor from '@monaco-editor/react'
+import SyntaxHighlighter from 'react-syntax-highlighter'
+import { a11yLight } from 'react-syntax-highlighter/dist/cjs/styles/hljs'
 
 export const QueryHistoryModal: React.FC = () => {
   const { setShowQueryHistoryModal, setQuery } = useQuerySetState()
   const { loading, data } = useQueryHistory()
-  const [active, setActive] = useState<QueryHistoryData>()
   const [queryHistory, setQueryHistory] = useState<Array<QueryHistoryData>>()
+  const [active, setActive] = useState<QueryHistoryData>()
 
   const close = useCallback(() => {
     setShowQueryHistoryModal(false)
@@ -29,8 +31,14 @@ export const QueryHistoryModal: React.FC = () => {
     setQueryHistory(mapToQueryHistoryData(data))
   }, [data])
 
+  useEffect(() => {
+    if (queryHistory && queryHistory.length > 0) {
+      setActive(queryHistory[0])
+    }
+  }, [queryHistory])
+
   return (
-    <Modal open onClose={close} size="lg">
+    <Modal open onClose={close} size="lg" className='h-full'>
       <Modal.Header>
         <Toolbar className="h-16 px-6">
           <Toolbar.Left>
@@ -49,72 +57,69 @@ export const QueryHistoryModal: React.FC = () => {
           </Toolbar.Right>
         </Toolbar>
       </Modal.Header>
-      <Modal.Body className='overflow-hidden'>
-        {
-          loading
-            ? <div className='h-720'><Loading /></div>
-            : <div className='flex overflow-hidden'>
-            <div className='w-1/3 border-r h-720 overflow-y-scroll'>
-              <VerticalNav>
-                {queryHistory?.map((history) => (
-                  <VerticalNav.Item
-                    key={`vertical-nav-item-${history.id}`}
-                    active={active?.id === history.id}
+      <Modal.Body className='overflow-hidden text-left flex flex-col h-full'>
+        { loading
+          ? <div className='h-720'><Loading /></div>
+          : <div className='flex overflow-hidden'>
+            { queryHistory && queryHistory.length < 1
+              ? <div className='flex flex-col items-center w-full justify-center px-6 py-12'>
+                  <Avatar icon={<ClockHistoryIcon className='t-icon' />} />
+                  <p className='t-text-muted mt-6'>
+                    No queries ran yet.
+                  </p>
+                </div>
+              : <>
+              <div className='w-1/3 border-r flex flex-col overflow-hidden'>
+                <div className='t-master-detail-list flex-1 overflow-auto'>
+                  {queryHistory?.map((history) => (
+                  <button
+                    className={cx('t-master-detail-item', { 't-master-detail-item-active': active?.id === history.id })}
+                    key={`master-detail-item-${history.id}`}
                     onClick={() => setActive(history)}
-                    className="border-b mt-0 h-65"
-                    text={
-                      <div className="flex flex-col items-start mx-2">
-                        <p className='font-medium text-sm text-gray-700'>
-                          {history.runAt?.toDateString() || ''}
-                        </p>
-                        <div className='text-xs font-mono text-gray-400'>
-                          {history.query.length > 40 ? `${history.query.substring(0, 40)} ...` : history.query}
-                        </div>
+                    >
+                      <div className='t-master-detail-item-title'>
+                        {history.runAt?.toDateString() || ''}
                       </div>
-                    }
-                  />
-                ))}
-              </VerticalNav>
+                      <div className='t-master-detail-item-preview'>
+                          {history.query.length > 36 ? `${history.query.substring(0, 36)} ...` : history.query}
+                      </div>
+                  </button>
+                  ))}
+                </div>
             </div>
-            <div className='w-2/3'>
-              <div className='overflow-hidden flex justify-between items-center h-14 w-full border-b px-8'>
-                <div className='flex justify-between items-center'>
-                  <Button
-                    isIconOnly
-                    className='bg-gray-100 py-2 px-3'
-                    skin='borderless-muted'
-                    startIcon={<ClockHistoryIcon className='t-icon' />}
-                  />
-                  <p className='font-semibold text-gray-900 px-3'>
+            <div className='w-2/3 flex flex-col overflow-hidden h-720'>
+              <div className='flex-none flex justify-between items-center h-14 w-full border-b px-8'>
+                <div className='flex items-center space-x-3'>
+                  <ColoredBox size='8'><ClockHistoryIcon className='t-icon'/></ColoredBox>
+                  <p className='t-h4 mb-0'>
                     {active?.runAt?.toDateString() || ''}
                   </p>
                 </div>
                 <Button
-                  className='whitespace-nowrap justify-center ml-0 w-32'
+                  className='whitespace-nowrap'
                   label='Use Query'
                   disabled={!active}
                   onClick={onUseQueryClick}
                 />
               </div>
-              <div className='bg-gray-50 p-3 h-full'>
-                <Editor
-                  className='text-sm font-mono'
-                  value={active?.query}
-                  language='sql'
-                  options={
-                    {
-                      minimap: { enabled: false },
-                      fontSize: 14,
-                      scrollbar: {
-                        vertical: 'auto',
-                      },
-                      readOnly: true,
-                      domReadOnly: true,
-                    }
-                  }
-                />
+              <div className='bg-gray-50 p-3 flex-1 overflow-auto'>
+              <SyntaxHighlighter
+                language='sql'
+                style={a11yLight}
+                showLineNumbers={true}
+                customStyle={{
+                  backgroundColor: undefined,
+                  userSelect: undefined,
+                  lineHeight: '20px',
+                  fontSize: 14
+                }}>
+                {active?.query as string}
+              </SyntaxHighlighter>
               </div>
             </div>
+            </>
+            }
+
           </div>
         }
       </Modal.Body>

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -47,7 +47,9 @@ module.exports = {
         1.5: '6px',
         3.5: '14px',
         4.5: '18px',
+        64: '4rem',
         84: '21rem',
+        720: '45rem',
       },
       margin: {
         0.5: '2px',

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -24,6 +24,7 @@ module.exports = {
       },
       fontFamily: {
         sans: ['"Inter UI"', 'ui-sans-serif', 'system-ui'],
+        display: ['"Cal Sans"'],
         mono: ['Monaco', 'ui-monospace', 'SFMono-Regular'],
       },
       gridTemplateRows: {
@@ -66,8 +67,12 @@ module.exports = {
       lime: colors.lime,
       red: colors.red,
       blue: colors.sky,
+      indigo: colors.indigo,
       yellow: colors.amber,
       white: colors.white,
+      purple: colors.purple,
+      teal: colors.teal,
+      pink: colors.pink
     },
   },
   variants: {


### PR DESCRIPTION
- Added empty state
- Used `react-syntax-highlighter` instead of the Monaco editor to show the query preview
- Added `t-master-detail` styles instead of the `VerticalNav` component for the list (needs to be synced to `blocks`)
- Cleaned up `global.css` by removing duplicate styles that are already in `blocks`

A possible future improvement would be to install `@headlessui` and use the `Tabs` component (`vertical` variant) to make it keyboard accessible (use up/down arrow keys to move through the list)

<img width="1722" alt="Screenshot 2023-03-24 at 00 22 30" src="https://user-images.githubusercontent.com/36261498/227491984-9f521dd4-17d3-45a1-9e06-dac366e5c9da.png">

<img width="1719" alt="image" src="https://user-images.githubusercontent.com/36261498/227536268-fe1ac676-0f42-44d6-9e07-d152c10d5545.png">
