### PR TITLE
chore: allow overrides of secrets in `docker-compose` setup

### DIFF
--- a/docker-compose.ui-dev.yaml
+++ b/docker-compose.ui-dev.yaml
@@ -9,7 +9,7 @@ services:
       - 5433:5433
     command:
       - "--connection"
-      - "postgres://postgres:password@postgres:5432/postgres?sslmode=disable"
+      - "postgres://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgres?sslmode=disable"
       - "--port"
       - "5433"
       - "--schema"
@@ -28,10 +28,10 @@ services:
       - "--allow-explain"
       - "--enable-query-batching"
       - "--legacy-relations=omit"
-      - "--jwt-secret=secret"
+      - "--jwt-secret=${JWT_SECRET:-secret}"
       - "--default-role=mergestat_anonymous"
     environment:
-      ENCRYPTION_SECRET: password
+      ENCRYPTION_SECRET: ${ENCRYPTION_SECRET:-password}
       DISPLAY_PG_HOSTNAME: localhost
       DISPLAY_PG_PORT: 5432
       DISPLAY_PG_DATABASE: postgres

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
       timeout: 5s
       retries: 5
     environment:
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
 
   worker:
     # NOTE: to opt out of basic image pull tracking, comment out the current image
@@ -32,10 +32,10 @@ services:
       timeout: 5s
       retries: 5
     environment:
-      POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres?sslmode=disable
+      POSTGRES_CONNECTION: postgres://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgres?sslmode=disable
       CONCURRENCY: 5
       GITHUB_RATE_LIMIT: 1/2
-      ENCRYPTION_SECRET: password
+      ENCRYPTION_SECRET: ${ENCRYPTION_SECRET:-password}
       LOG_LEVEL: debug
       DEBUG: 1
       PRETTY_LOGS: 1
@@ -66,7 +66,7 @@ services:
       - 5433:5433
     command:
       - "--connection"
-      - "postgres://postgres:password@postgres:5432/postgres?sslmode=disable"
+      - "postgres://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgres?sslmode=disable"
       - "--port"
       - "5433"
       - "--schema"
@@ -84,10 +84,10 @@ services:
       - "--enable-query-batching"
       - "--disable-query-log"
       - "--legacy-relations=omit"
-      - "--jwt-secret=secret"
+      - "--jwt-secret=${JWT_SECRET:-secret}"
       - "--default-role=mergestat_anonymous"
     environment:
-      ENCRYPTION_SECRET: password
+      ENCRYPTION_SECRET: ${ENCRYPTION_SECRET:-password}
       DISPLAY_PG_HOSTNAME: localhost
       DISPLAY_PG_PORT: 5432
       DISPLAY_PG_DATABASE: postgres
@@ -104,8 +104,8 @@ services:
       - 3300:3000
     environment:
       POSTGRAPHILE_API: http://graphql:5433/graphql
-      POSTGRES_CONNECTION: postgres://postgres:password@postgres:5432/postgres?sslmode=disable
-      JWT_SECRET: secret # should match - "--jwt-secret=secret" flag in graphql service
+      POSTGRES_CONNECTION: postgres://postgres:${POSTGRES_PASSWORD:-password}@postgres:5432/postgres?sslmode=disable
+      JWT_SECRET: ${JWT_SECRET:-secret} # should match - "--jwt-secret=secret" flag in graphql service
       INSECURE_SESSION_COOKIE: 1
     labels:
       shipyard.route: '/'
@@ -116,7 +116,7 @@ services:
     environment:
       PGHOST: postgres
       PGUSER: postgres
-      PGPASSWORD: password
+      PGPASSWORD: ${POSTGRES_PASSWORD:-password}
       PGDATABASE: postgres
     ports:
       - 3000:3000


### PR DESCRIPTION
- `POSTGRES_PASSWORD`
- `JWT_SECRET`
- `ENCRYPTION_SECRET`

The can now be set as env vars when running `docker-compose up` (or `make dev`). The current "hardcoded" values will be the defaults for consistency.

This allows a user wanting to run an instance via `docker-compose` to more easily inject their own secrets via env vars.

Closes #976 