### PR TITLE
feat: use vendor+provider specific queues for repo import jobs

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/mergestat/mergestat/internal/syncer"
 	"github.com/mergestat/mergestat/internal/timeout"
 	"github.com/mergestat/mergestat/queries"
-	"github.com/mergestat/sqlq"
 	"github.com/mergestat/sqlq/runtime/embed"
 	"github.com/mergestat/sqlq/schema"
 
@@ -275,11 +274,7 @@ func main() {
 
 	// run a basic cron every minute to schedule a repos/auto-import job
 	// these jobs are idempotent, and so, multiple instances can run at same time without conflict
-	go cron.Basic(ctx, 1*time.Minute, func() {
-		if _, err := sqlq.Enqueue(upstream, "default", sqlq.NewJobDesc("repos/auto-import")); err != nil {
-			logger.Err(err).Msg("failed to enqueue repo sync job")
-		}
-	})
+	go cron.AutoImport(ctx, 15*time.Second, upstream)
 
 	// run container sync scheduler every minute
 	go cron.ContainerSync(ctx, 1*time.Minute, upstream)

--- a/internal/cron/auto_import_schedule.go
+++ b/internal/cron/auto_import_schedule.go
@@ -1,0 +1,93 @@
+package cron
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/mergestat/sqlq"
+	"github.com/rs/zerolog"
+	"time"
+)
+
+// AutoImport provides a cron function that periodically schedules execution
+// auto import jobs across the different providers.
+func AutoImport(ctx context.Context, dur time.Duration, upstream *sql.DB) {
+	type ImportJob = struct {
+		ID         uuid.UUID
+		Provider   uuid.UUID
+		VendorName string
+	}
+
+	const query = `
+WITH dequeued AS (
+    UPDATE mergestat.repo_imports SET last_import_started_at = now()
+    WHERE id IN (
+        SELECT id FROM mergestat.repo_imports AS t
+        WHERE
+            (now() - t.last_import > t.import_interval OR t.last_import IS NULL)
+            AND
+            (now() - t.last_import_started_at > t.import_interval OR t.last_import_started_at IS NULL)
+        ORDER BY last_import ASC
+        FOR UPDATE SKIP LOCKED
+    ) RETURNING id, created_at, updated_at, settings, last_import, import_interval, last_import_started_at, import_status, import_error, provider
+)
+SELECT dq.id, dq.provider, vd.name
+FROM dequeued dq
+    INNER JOIN mergestat.providers pr ON pr.id = dq.provider
+    INNER JOIN mergestat.vendors vd ON vd.name = pr.vendor
+`
+
+	var log = zerolog.Ctx(ctx)
+	var fn = func(ctx context.Context) (err error) {
+		var tx *sql.Tx
+		if tx, err = upstream.BeginTx(ctx, &sql.TxOptions{}); err != nil {
+			return err
+		}
+		defer tx.Rollback()
+
+		// fetch a list of all configured imports that are due now
+		var rows *sql.Rows
+		if rows, err = tx.QueryContext(ctx, query); err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		var imports []ImportJob
+		for rows.Next() {
+			var job ImportJob
+			if err = rows.Scan(&job.ID, &job.Provider, &job.VendorName); err != nil {
+				return err
+			}
+			imports = append(imports, job)
+		}
+
+		if err = rows.Close(); err != nil {
+			return err
+		}
+
+		for _, job := range imports {
+			var queue = sqlq.Queue(fmt.Sprintf("%s-%s", job.VendorName, job.Provider))
+			if _, err = sqlq.Enqueue(tx, queue, newAutoImportJob(job.ID)); err != nil {
+				return err
+			}
+		}
+
+		return tx.Commit()
+	}
+
+	// reuse existing loop-select functionality in Basic()
+	Basic(ctx, dur, func() {
+		if err := fn(context.Background()); err != nil {
+			log.Err(err).Msg("failed to enqueue auto imports")
+		}
+	})
+}
+
+func newAutoImportJob(id uuid.UUID) *sqlq.JobDescription {
+	var p = struct{ ID uuid.UUID }{ID: id}
+	var params, _ = json.Marshal(p)
+
+	return sqlq.NewJobDesc("repos/auto-import", sqlq.WithParameters(params))
+}

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -665,6 +665,7 @@ type MergestatContainerImage struct {
 	Version     string
 	Parameters  pgtype.JSONB
 	Description sql.NullString
+	Queue       string
 }
 
 type MergestatContainerImageType struct {

--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -22,6 +22,7 @@ type Querier interface {
 	EnqueueAllSyncs(ctx context.Context) error
 	FetchContainerSync(ctx context.Context, id uuid.UUID) (FetchContainerSyncRow, error)
 	FetchGitHubToken(ctx context.Context, pgpSymDecrypt string) (string, error)
+	FetchImportJob(ctx context.Context, id uuid.UUID) (FetchImportJobRow, error)
 	GetRepoById(ctx context.Context, id uuid.UUID) (Repo, error)
 	GetRepoIDsFromRepoImport(ctx context.Context, arg GetRepoIDsFromRepoImportParams) ([]uuid.UUID, error)
 	GetRepoImportByID(ctx context.Context, id uuid.UUID) (MergestatRepoImport, error)

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -402,3 +402,10 @@ SELECT sync.id, sync.repo_id,
     jsonb_recursive_merge(image.parameters, sync.parameters) AS params
 FROM mergestat.container_syncs sync, mergestat.container_images image, public.repos repo
     WHERE image.id = sync.image_id AND repo.id = sync.repo_id AND sync.id = @id;
+
+-- name: FetchImportJob :one
+SELECT dq.id, dq.created_at, dq.updated_at, dq.settings, dq.provider, pr.settings AS provider_settings, vd.name AS vendor_name
+FROM mergestat.repo_imports AS dq
+    INNER JOIN mergestat.providers pr ON pr.id = dq.provider
+    INNER JOIN mergestat.vendors vd ON vd.name = pr.vendor
+WHERE dq.id = @id;

--- a/internal/jobs/repo/import.go
+++ b/internal/jobs/repo/import.go
@@ -2,6 +2,8 @@ package repo
 
 import (
 	"context"
+	"encoding/json"
+	"github.com/google/uuid"
 	"time"
 
 	"github.com/jackc/pgx/v4"
@@ -9,7 +11,6 @@ import (
 	"github.com/mergestat/mergestat/internal/db"
 	"github.com/mergestat/sqlq"
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
 )
 
 // AutoImport implements the githubRepository auto-import job to automatically
@@ -18,82 +19,74 @@ func AutoImport(pool *pgxpool.Pool) sqlq.HandlerFunc {
 	var queries = db.New(pool)
 
 	return func(ctx context.Context, job *sqlq.Job) (err error) {
-		var l = zerolog.Ctx(ctx)
-		var logger = job.Logger()
-		var jobErrors error
-
 		// start sending periodic keep-alive pings!
 		go job.SendKeepAlive(ctx, job.KeepAlive-(5*time.Second)) //nolint:errcheck
 
+		var logger = job.Logger()
+		var jobErrors error
+
+		var params = struct{ ID uuid.UUID }{}
+		if err = json.Unmarshal(job.Parameters, &params); err != nil {
+			return err
+		}
+
 		// fetch a list of all configured imports that are due now
-		var imports []db.ListRepoImportsDueForImportRow
-		if imports, err = queries.ListRepoImportsDueForImport(ctx); err != nil {
-			logger.Errorf("failed to list repo import job: %v", err)
-			l.Error().Msgf("failed to list repo import job: %v", err)
-			return errors.Wrapf(sqlq.ErrSkipRetry, "failed to list repo import job: %v", err)
+		var imp db.FetchImportJobRow
+		if imp, err = queries.FetchImportJob(ctx, params.ID); err != nil {
+			logger.Errorf("failed to fetch import job with id: %s", params.ID)
 		}
 
-		logger.Infof("handling %d import(s)", len(imports))
-		l.Info().Msgf("handling %d import(s)", len(imports))
-		for _, imp := range imports {
-			logger.Infof("executing import %s", imp.ID)
-			l.Info().Msgf("executing import %s", imp.ID)
-			var tx pgx.Tx // each import is executed within its own transaction
-			if tx, err = pool.Begin(ctx); err != nil {
-				return errors.Wrapf(err, "failed to start new database transaction")
-			}
-			var importStatus = db.UpdateImportStatusParams{Status: "RUNNING", ID: imp.ID}
-			if err = queries.UpdateImportStatus(ctx, importStatus); err != nil {
-				return errors.Wrapf(sqlq.ErrSkipRetry, "failed to update import status: %v", err)
-			}
-			// execute the import
-			// if the execution fails for some reason, only that import is marked as failed
-			// the job still continues executing.
-			var importError error
-			if imp.VendorName == "github" {
-				importError = handleGithubImport(ctx, queries.WithTx(tx), imp)
-			} else if imp.VendorName == "bitbucket" {
-				importError = handleBitbucketImport(ctx, queries.WithTx(tx), imp)
-			} else if imp.VendorName == "gitlab" {
-				importError = handleGitlabImport(ctx, queries.WithTx(tx), imp)
-			} else {
-				importError = errors.Errorf("unknown vendor: %s", imp.VendorName)
-			}
+		logger.Infof("executing import %s", imp.ID)
 
-			if importError != nil {
-				logger.Warnf("import(%s) failed: %v", imp.ID, importError.Error())
-				l.Warn().Msgf("import(%s) failed: %v", imp.ID, importError.Error())
-
-				if err = tx.Rollback(ctx); err != nil {
-					jobErrors = errors.Wrap(err, "failed to rollback transaction")
-					return jobErrors
-				}
-
-				jobErrors = errors.Wrap(importError, "failed to handle import")
-
-			} else {
-				// if the import was successful, commit the changes
-				if err = tx.Commit(ctx); err != nil {
-					jobErrors = errors.Wrapf(err, "failed to commit database transaction")
-					return jobErrors
-				}
-				logger.Infof("import(%s) was successful", imp.ID)
-				l.Info().Msgf("import(%s) was successful", imp.ID)
-			}
-
-			importStatus = db.UpdateImportStatusParams{Status: "SUCCESS", ID: imp.ID}
-			if importError != nil {
-				importStatus.Status, importStatus.Error = "FAILURE", importError.Error()
-			}
-
-			// import status updates happen outside the transaction in which the import was processed.
-			// this is so that even if the transaction is marked as errored, we could still go ahead and update
-			// the job status.
-			if err = queries.UpdateImportStatus(ctx, importStatus); err != nil {
-				jobErrors = errors.Wrapf(sqlq.ErrSkipRetry, "failed to update import status: %v", err)
-				return jobErrors
-			}
+		var tx pgx.Tx // each import is executed within its own transaction
+		if tx, err = pool.Begin(ctx); err != nil {
+			return errors.Wrapf(err, "failed to start new database transaction")
 		}
+
+		var importStatus = db.UpdateImportStatusParams{Status: "RUNNING", ID: imp.ID}
+		if err = queries.UpdateImportStatus(ctx, importStatus); err != nil {
+			return errors.Wrapf(sqlq.ErrSkipRetry, "failed to update import status: %v", err)
+		}
+
+		var importError error
+		if imp.VendorName == "github" {
+			importError = handleGithubImport(ctx, queries.WithTx(tx), imp)
+		} else if imp.VendorName == "bitbucket" {
+			importError = handleBitbucketImport(ctx, queries.WithTx(tx), imp)
+		} else if imp.VendorName == "gitlab" {
+			importError = handleGitlabImport(ctx, queries.WithTx(tx), imp)
+		} else {
+			importError = errors.Errorf("unknown vendor: %s", imp.VendorName)
+		}
+
+		if importError != nil {
+			logger.Warnf("import(%s) failed: %v", imp.ID, importError.Error())
+
+			if err = tx.Rollback(ctx); err != nil {
+				return errors.Wrap(err, "failed to rollback transaction")
+			}
+
+			jobErrors = errors.Wrap(importError, "failed to handle import")
+		} else {
+			// if the import was successful, commit the changes
+			if err = tx.Commit(ctx); err != nil {
+				return errors.Wrapf(err, "failed to commit database transaction")
+			}
+			logger.Infof("import(%s) was successful", imp.ID)
+		}
+
+		importStatus = db.UpdateImportStatusParams{Status: "SUCCESS", ID: imp.ID}
+		if importError != nil {
+			importStatus.Status, importStatus.Error = "FAILURE", importError.Error()
+		}
+
+		// import status updates happen outside the transaction in which the import was processed.
+		// this is so that even if the transaction is marked as errored, we could still go ahead and update
+		// the job status.
+		if err = queries.UpdateImportStatus(ctx, importStatus); err != nil {
+			return errors.Wrapf(sqlq.ErrSkipRetry, "failed to update import status: %v", err)
+		}
+
 		return jobErrors
 	}
 }

--- a/internal/jobs/repo/vendor_bitbucket.go
+++ b/internal/jobs/repo/vendor_bitbucket.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 )
 
-func handleBitbucketImport(ctx context.Context, qry *db.Queries, imp db.ListRepoImportsDueForImportRow) (err error) {
+func handleBitbucketImport(ctx context.Context, qry *db.Queries, imp db.FetchImportJobRow) (err error) {
 	var emptyTags = []byte("[]") // bitbucket doesn't support tags
 
 	var username, password string

--- a/internal/jobs/repo/vendor_github.go
+++ b/internal/jobs/repo/vendor_github.go
@@ -16,7 +16,7 @@ import (
 
 type fetchFunc func(ctx context.Context, page int) ([]*github.Repository, *github.Response, error)
 
-func handleGithubImport(ctx context.Context, qry *db.Queries, imp db.ListRepoImportsDueForImportRow) (err error) {
+func handleGithubImport(ctx context.Context, qry *db.Queries, imp db.FetchImportJobRow) (err error) {
 	var token string
 	if _, token, err = qry.FetchCredential(ctx, imp.Provider); err != nil {
 		return err

--- a/internal/jobs/repo/vendor_gitlab.go
+++ b/internal/jobs/repo/vendor_gitlab.go
@@ -13,7 +13,7 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-func handleGitlabImport(ctx context.Context, qry *db.Queries, imp db.ListRepoImportsDueForImportRow) (err error) {
+func handleGitlabImport(ctx context.Context, qry *db.Queries, imp db.FetchImportJobRow) (err error) {
 	var token string
 	if _, token, err = qry.FetchCredential(ctx, imp.Provider); err != nil {
 		return err

--- a/internal/mocks/mock_queries.go
+++ b/internal/mocks/mock_queries.go
@@ -154,6 +154,21 @@ func (mr *MockQuerierMockRecorder) FetchGitHubToken(ctx, pgpSymDecrypt interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchGitHubToken", reflect.TypeOf((*MockQuerier)(nil).FetchGitHubToken), ctx, pgpSymDecrypt)
 }
 
+// FetchImportJob mocks base method.
+func (m *MockQuerier) FetchImportJob(ctx context.Context, id uuid.UUID) (db.FetchImportJobRow, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FetchImportJob", ctx, id)
+	ret0, _ := ret[0].(db.FetchImportJobRow)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FetchImportJob indicates an expected call of FetchImportJob.
+func (mr *MockQuerierMockRecorder) FetchImportJob(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchImportJob", reflect.TypeOf((*MockQuerier)(nil).FetchImportJob), ctx, id)
+}
+
 // GetRepoById mocks base method.
 func (m *MockQuerier) GetRepoById(ctx context.Context, id uuid.UUID) (db.Repo, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR updates the repo auto-import process to use `{vendor}-{provider}`-specific queues to better manage concurrency and api usage. Closes mergestat/mergestat#969