### PR TITLE
chore: bump to `1.22.3-beta`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,8 @@ services:
   worker:
     # NOTE: to opt out of basic image pull tracking, comment out the current image
     # and uncomment the next line (which will pull from Docker Hub directly).
-    # image: mergestat/worker:1.22.2-beta
-    image: images.mergestat.com/mergestat/worker:1.22.2-beta
+    # image: mergestat/worker:1.22.3-beta
+    image: images.mergestat.com/mergestat/worker:1.22.3-beta
     privileged: true
     stop_grace_period: 10m
     restart: always
@@ -51,8 +51,8 @@ services:
 
   graphql:
     # See NOTE above in worker service.
-    # image: mergestat/graphql:1.22.2-beta
-    image: images.mergestat.com/mergestat/graphql:1.22.2-beta
+    # image: mergestat/graphql:1.22.3-beta
+    image: images.mergestat.com/mergestat/graphql:1.22.3-beta
     restart: always
     depends_on:
       postgres:
@@ -95,8 +95,8 @@ services:
 
   ui:
     # See NOTE above in worker service.
-    # image: mergestat/console:1.22.2-beta
-    image: images.mergestat.com/mergestat/console:1.22.2-beta
+    # image: mergestat/console:1.22.3-beta
+    image: images.mergestat.com/mergestat/console:1.22.3-beta
     restart: always
     depends_on:
       - graphql


### PR DESCRIPTION
Bump version in  `docker-compose` to `1.22.3-beta`