### PR TITLE
fix(query-editor) Solving loading state when it is retrieving saved q…

### DIFF
--- a/ui/src/views/hooks/useSavedQuery.ts
+++ b/ui/src/views/hooks/useSavedQuery.ts
@@ -19,7 +19,7 @@ const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps)
   const { data: userData } = useCurrentUser()
   const [titleError, setTitleError] = useState<boolean>(false)
 
-  const [getSavedQuery, { data }] = useLazyQuery<GetSavedQueryQuery>(GET_SAVED_QUERY, { fetchPolicy: 'no-cache' })
+  const [getSavedQuery, { loading, data }] = useLazyQuery<GetSavedQueryQuery>(GET_SAVED_QUERY, { fetchPolicy: 'no-cache' })
 
   useEffect(() => {
     savedQueryId && getSavedQuery({ variables: { id: savedQueryId } })
@@ -71,7 +71,14 @@ const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps)
     }
   }
 
-  return { savedQuery: data?.savedQuery, titleError, setTitleError, addSavedQueryHandler, updateSavedQueryHandler }
+  return {
+    loadingSQ: loading,
+    savedQuery: data?.savedQuery,
+    titleError,
+    setTitleError,
+    addSavedQueryHandler,
+    updateSavedQueryHandler
+  }
 }
 
 export default useSavedQuery

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -26,7 +26,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
     loading, error, query, data, time, title, desc
   } = useQueryEditor(ROWS_LIMIT)
 
-  const { savedQuery, titleError, setTitleError, addSavedQueryHandler, updateSavedQueryHandler } = useSavedQuery({ savedQueryId, title, desc, query })
+  const { loadingSQ, savedQuery, titleError, setTitleError, addSavedQueryHandler, updateSavedQueryHandler } = useSavedQuery({ savedQueryId, title, desc, query })
 
   useEffect(() => {
     setTitle(savedQuery?.name || '')
@@ -49,13 +49,13 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
             className='flex-grow mr-5'
             icon={<TerminalIcon className="t-icon" />}
             title={{
-              placeholder: `${!query ? 'Loading...' : 'Untitled Saved Query'}`,
+              placeholder: `${loadingSQ ? 'Loading...' : 'Untitled Saved Query'}`,
               value: title,
               required: titleError,
               onChange: (e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)
             }}
             desc={{
-              placeholder: `${!query ? 'Loading...' : 'Enter a short description for this query (optional)'}`,
+              placeholder: `${loadingSQ ? 'Loading...' : 'Enter a short description for this query (optional)'}`,
               value: desc,
               onChange: (e: ChangeEvent<HTMLInputElement>) => setDesc(e.target.value)
             }}


### PR DESCRIPTION
Solving `loading` state when it is retrieving `saved query` info. (Resolves #942)

![no-loading-state](https://user-images.githubusercontent.com/109089565/229925195-50c918ee-ea4a-4d48-af1f-72dc3352c4e3.png)

