### PR TITLE
fix: add a PK to `mergestat.container_sync_executions`

### DIFF
--- a/migrations/900000000000054_missing_pkey.sql
+++ b/migrations/900000000000054_missing_pkey.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE mergestat.container_sync_executions
+ADD PRIMARY KEY(sync_id, job_id);
+
+COMMIT;


### PR DESCRIPTION
This one slipped thru the cracks