### PR TITLE
Adding auto imports for container sync

### DIFF
--- a/internal/db/querier.go
+++ b/internal/db/querier.go
@@ -17,6 +17,7 @@ type Querier interface {
 	DeleteGitHubRepoInfo(ctx context.Context, repoID uuid.UUID) error
 	DeleteRemovedRepos(ctx context.Context, arg DeleteRemovedReposParams) error
 	DequeueSyncJob(ctx context.Context) (DequeueSyncJobRow, error)
+	EnableContainerSync(ctx context.Context, arg EnableContainerSyncParams) error
 	// We use a CTE here to retrieve all the repo_sync_jobs that were previously enqueued, to make sure that we *do not* re-enqueue anything new until the previously enqueued jobs are *completed*.
 	// This allows us to make sure all repo syncs complete before we reschedule a new batch.
 	// We have now also added a concept of type groups which allows us to apply this same logic but by each group type which is where the PARTITION BY clause comes into play

--- a/internal/db/queries.sql
+++ b/internal/db/queries.sql
@@ -412,3 +412,6 @@ FROM mergestat.repo_imports AS dq
     INNER JOIN mergestat.providers pr ON pr.id = dq.provider
     INNER JOIN mergestat.vendors vd ON vd.name = pr.vendor
 WHERE dq.id = @id;
+
+-- name: EnableContainerSync :exec
+SELECT mergestat.enable_container_sync(@RepoID::UUID, @ContainerImageID::UUID);

--- a/internal/db/queries.sql.go
+++ b/internal/db/queries.sql.go
@@ -137,6 +137,20 @@ func (q *Queries) DequeueSyncJob(ctx context.Context) (DequeueSyncJobRow, error)
 	return i, err
 }
 
+const enableContainerSync = `-- name: EnableContainerSync :exec
+SELECT mergestat.enable_container_sync($1::UUID, $2::UUID)
+`
+
+type EnableContainerSyncParams struct {
+	Repoid           uuid.UUID
+	Containerimageid uuid.UUID
+}
+
+func (q *Queries) EnableContainerSync(ctx context.Context, arg EnableContainerSyncParams) error {
+	_, err := q.db.Exec(ctx, enableContainerSync, arg.Repoid, arg.Containerimageid)
+	return err
+}
+
 const enqueueAllSyncs = `-- name: EnqueueAllSyncs :exec
 WITH ranked_queue AS (
     SELECT

--- a/internal/jobs/repo/vendor_github.go
+++ b/internal/jobs/repo/vendor_github.go
@@ -33,10 +33,11 @@ func handleGithubImport(ctx context.Context, qry *db.Queries, imp db.FetchImport
 	}
 
 	var settings struct {
-		Type               string   `json:"type"`
-		Login              string   `json:"userOrOrg"`
-		RemoveDeletedRepos bool     `json:"removeDeletedRepos"`
-		DefaultSyncTypes   []string `json:"defaultSyncTypes"`
+		Type                   string      `json:"type"`
+		Login                  string      `json:"userOrOrg"`
+		RemoveDeletedRepos     bool        `json:"removeDeletedRepos"`
+		DefaultSyncTypes       []string    `json:"defaultSyncTypes"`
+		DefaultContainerImages []uuid.UUID `json:"defaultContainerImages"`
 	}
 
 	if err = json.Unmarshal(imp.Settings.Bytes, &settings); err != nil {
@@ -126,6 +127,28 @@ func handleGithubImport(ctx context.Context, qry *db.Queries, imp db.FetchImport
 		// enqueue all newly added syncs
 		if err = qry.EnqueueAllSyncs(ctx); err != nil {
 			return errors.Wrapf(err, "failed to enable default sync")
+		}
+	}
+
+	// (optional) configure default container images
+	if len(settings.DefaultContainerImages) > 0 {
+		// batch is a collection of newly added repositories
+		var batch = difference(existing, repoUrls)
+
+		// convert batch into a collection of repo ids
+		var ids []uuid.UUID
+		if ids, err = qry.GetRepoIDsFromRepoImport(ctx, db.GetRepoIDsFromRepoImportParams{Importid: imp.ID, Reposurls: batch}); err != nil {
+			return errors.Wrapf(err, "failed to enable default container sync")
+		}
+
+		// for each new repo, enable the provided container syncs
+		for _, id := range ids {
+			for _, containerImageID := range settings.DefaultContainerImages {
+				var params = db.EnableContainerSyncParams{Repoid: id, Containerimageid: containerImageID}
+				if err = qry.EnableContainerSync(ctx, params); err != nil {
+					return errors.Wrapf(err, "failed to enable default container sync")
+				}
+			}
 		}
 	}
 

--- a/internal/jobs/sync/podman/podman.go
+++ b/internal/jobs/sync/podman/podman.go
@@ -147,9 +147,10 @@ func ContainerSync(postgresUrl string, workerLogger *zerolog.Logger, querier *db
 
 			var args []string
 			args = append(args, "run", "--quiet", "--rm")
-			args = append(args, "--pull", "never")     // run never pulls an image!
-			args = append(args, "--env-file", envFile) // set environment variables from envFile
-			args = append(args, "--network", "host")   // use host networking
+			args = append(args, "--restart", "on-failure") // run never pulls an image!
+			args = append(args, "--pull", "never")         // run never pulls an image!
+			args = append(args, "--env-file", envFile)     // set environment variables from envFile
+			args = append(args, "--network", "host")       // use host networking
 
 			// if opted-in by setting com.mergestat.sync.clone to true, we perform a full clone
 			// of the repository to a temporary directory and mount that directory into the container

--- a/internal/mocks/mock_queries.go
+++ b/internal/mocks/mock_queries.go
@@ -124,6 +124,20 @@ func (mr *MockQuerierMockRecorder) DequeueSyncJob(ctx interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DequeueSyncJob", reflect.TypeOf((*MockQuerier)(nil).DequeueSyncJob), ctx)
 }
 
+// EnableContainerSync mocks base method.
+func (m *MockQuerier) EnableContainerSync(ctx context.Context, arg db.EnableContainerSyncParams) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnableContainerSync", ctx, arg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnableContainerSync indicates an expected call of EnableContainerSync.
+func (mr *MockQuerierMockRecorder) EnableContainerSync(ctx, arg interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnableContainerSync", reflect.TypeOf((*MockQuerier)(nil).EnableContainerSync), ctx, arg)
+}
+
 // EnqueueAllSyncs mocks base method.
 func (m *MockQuerier) EnqueueAllSyncs(ctx context.Context) error {
 	m.ctrl.T.Helper()

--- a/migrations/900000000000055_add_repos_stats_functions.up.sql
+++ b/migrations/900000000000055_add_repos_stats_functions.up.sql
@@ -171,6 +171,7 @@ BEGIN
             ci.name AS container_image_name,
             j.id AS job_id,
             j.status,
+            j.created_at,
             j.started_at,
             j.completed_at,
             (SELECT COUNT(1) FROM sqlq.job_logs WHERE sqlq.job_logs.job = j.id AND level = 'warn') warning_count,
@@ -180,14 +181,14 @@ BEGIN
         INNER JOIN mergestat.container_images ci ON cs.image_id = ci.id
         INNER JOIN sqlq.jobs j ON cse.job_id = j.id
         WHERE cs.id = container_syncs.id
-        ORDER BY cs.id, j.completed_at DESC
+        ORDER BY cs.id, j.created_at DESC
         LIMIT 15
     )
     SELECT 
         JSONB_OBJECT_AGG(job_id, TO_JSONB(t) - 'job_id')
     INTO response
     FROM (
-        SELECT job_id, started_at, completed_at, ((EXTRACT('epoch' FROM completed_at)-EXTRACT('epoch' FROM started_at))*1000)::INTEGER AS duration_ms, status FROM last_completed_syncs    
+        SELECT job_id, created_at, started_at, completed_at, ((EXTRACT('epoch' FROM completed_at)-EXTRACT('epoch' FROM started_at))*1000)::INTEGER AS duration_ms, status FROM last_completed_syncs    
     )t;
 
     RETURN response;

--- a/migrations/900000000000055_add_repos_stats_functions.up.sql
+++ b/migrations/900000000000055_add_repos_stats_functions.up.sql
@@ -171,7 +171,6 @@ BEGIN
             ci.name AS container_image_name,
             j.id AS job_id,
             j.status,
-            j.created_at,
             j.started_at,
             j.completed_at,
             (SELECT COUNT(1) FROM sqlq.job_logs WHERE sqlq.job_logs.job = j.id AND level = 'warn') warning_count,
@@ -181,14 +180,14 @@ BEGIN
         INNER JOIN mergestat.container_images ci ON cs.image_id = ci.id
         INNER JOIN sqlq.jobs j ON cse.job_id = j.id
         WHERE cs.id = container_syncs.id
-        ORDER BY cs.id, j.created_at DESC
+        ORDER BY cs.id, j.completed_at DESC
         LIMIT 15
     )
     SELECT 
         JSONB_OBJECT_AGG(job_id, TO_JSONB(t) - 'job_id')
     INTO response
     FROM (
-        SELECT job_id, created_at, started_at, completed_at, ((EXTRACT('epoch' FROM completed_at)-EXTRACT('epoch' FROM started_at))*1000)::INTEGER AS duration_ms, status FROM last_completed_syncs    
+        SELECT job_id, started_at, completed_at, ((EXTRACT('epoch' FROM completed_at)-EXTRACT('epoch' FROM started_at))*1000)::INTEGER AS duration_ms, status FROM last_completed_syncs    
     )t;
 
     RETURN response;

--- a/migrations/900000000000057_add_default_syncs_for_container_images.up.sql
+++ b/migrations/900000000000057_add_default_syncs_for_container_images.up.sql
@@ -63,4 +63,24 @@ BEGIN
     
 END; $$;
 
+CREATE OR REPLACE FUNCTION mergestat.enable_container_sync(repo_id_param UUID, container_image_id UUID)
+RETURNS BOOLEAN
+LANGUAGE PLPGSQL VOLATILE
+AS $$
+DECLARE
+    container_sync_id UUID;
+BEGIN
+
+    INSERT INTO mergestat.container_syncs (repo_id, image_id) VALUES (repo_id_param, container_image_id)
+        ON CONFLICT (repo_id, image_id) DO UPDATE SET repo_id = EXCLUDED.repo_id, image_id = EXCLUDED.image_id
+        RETURNING id INTO container_sync_id;
+    
+    INSERT INTO mergestat.container_sync_schedules (sync_id) VALUES (container_sync_id) ON CONFLICT DO NOTHING;
+    
+    PERFORM mergestat.sync_now(container_sync_id);
+    
+    RETURN TRUE;
+    
+END; $$;
+
 COMMIT;

--- a/migrations/900000000000057_add_default_syncs_for_container_images.up.sql
+++ b/migrations/900000000000057_add_default_syncs_for_container_images.up.sql
@@ -1,0 +1,66 @@
+BEGIN;
+
+--GitHub Org
+--Example: SELECT mergestat.add_repo_import('1f337c1a-702c-4411-ab03-25aa43f5a3c1', 'GITHUB_ORG', '{{orgname}}', (array['51c76dcf-05a4-4288-b796-50f74c25f479'])::UUID[])
+--GitHub User
+--Example: SELECT mergestat.add_repo_import('1f337c1a-702c-4411-ab03-25aa43f5a3c1', 'GITHUB_USER', '{{username}}', (array['51c76dcf-05a4-4288-b796-50f74c25f479'])::UUID[])
+--BitBucket owner
+--Example: SELECT mergestat.add_repo_import('714d5147-3b35-4dde-a75e-dab527006856', 'owner', '{{ownername}}', (array['51c76dcf-05a4-4288-b796-50f74c25f479'])::UUID[])
+--GitLab Groub
+--Example: SELECT mergestat.add_repo_import('fc7a3eb7-68b1-4282-a592-acdb1e0bbf91', 'GITLAB_GROUP', '{{groupname}}', (array['51c76dcf-05a4-4288-b796-50f74c25f479'])::UUID[])
+--GitLab User
+--Example: SELECT mergestat.add_repo_import('fc7a3eb7-68b1-4282-a592-acdb1e0bbf91', 'GITLAB_USER', '{{username}}', (array['51c76dcf-05a4-4288-b796-50f74c25f479'])::UUID[])
+CREATE OR REPLACE FUNCTION mergestat.add_repo_import(provider_id UUID, import_type TEXT, import_type_name TEXT, default_container_image_ids UUID[])
+RETURNS BOOLEAN
+LANGUAGE PLPGSQL VOLATILE
+AS $$
+DECLARE 
+    vendor_type TEXT;
+    settings JSONB;
+BEGIN
+    
+    -- get the vendor type
+    SELECT vendor
+    INTO
+    vendor_type
+    FROM mergestat.providers
+    WHERE id = provider_id;
+    
+    -- set the settings by vendor
+    SELECT 
+        CASE
+            WHEN vendor_type = 'github'
+                THEN jsonb_build_object('type', import_type) || jsonb_build_object('userOrOrg', import_type_name) || jsonb_build_object('defaultContainerImages', default_container_image_ids)
+            WHEN vendor_type = 'gitlab'
+                THEN jsonb_build_object('type', import_type) || jsonb_build_object('userOrGroup', import_type_name) || jsonb_build_object('defaultContainerImages', default_container_image_ids)
+            WHEN vendor_type = 'bitbucket' 
+                THEN jsonb_build_object('owner', import_type_name) || jsonb_build_object('defaultContainerImages', default_container_image_ids)
+            ELSE '{}'::JSONB
+        END 
+    INTO
+    settings;
+
+    -- add the repo import
+    INSERT INTO mergestat.repo_imports (settings, provider) values (settings, provider_id);
+    
+    RETURN TRUE;
+    
+END; $$;
+
+--Replace repo import default container images
+--Example: SELECT mergestat.update_repo_import_default_container_images('fdebb5e3-17aa-4725-b7c2-b8e47e54df30', (array['51c76dcf-05a4-4288-b796-50f74c25f479', '1dc4ae75-9c93-4f21-8f64-90228b6486e8'])::UUID[])
+CREATE OR REPLACE FUNCTION mergestat.update_repo_import_default_container_images(repo_import_id UUID, default_container_image_ids UUID[])
+RETURNS BOOLEAN
+LANGUAGE PLPGSQL VOLATILE
+AS $$
+BEGIN
+    
+    -- update the repo import by replacing the defaultContainerImages element from the settings object
+    UPDATE mergestat.repo_imports SET settings = settings - 'defaultContainerImages' || jsonb_build_object('defaultContainerImages', default_container_image_ids)
+    WHERE id = repo_import_id;
+    
+    RETURN TRUE;
+    
+END; $$;
+
+COMMIT;

--- a/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
+++ b/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
@@ -186,4 +186,40 @@ BEGIN
 END
 $$;
 
+--https://www.graphile.org/postgraphile/computed-columns/
+CREATE OR REPLACE FUNCTION mergestat.container_syncs_latest_sync_runs(container_syncs mergestat.CONTAINER_SYNCS)
+RETURNS JSONB
+LANGUAGE PLPGSQL STABLE
+AS $$
+DECLARE
+   response JSONB;
+BEGIN
+    WITH last_completed_syncs AS(
+        SELECT
+            cs.id AS container_sync_id,
+            ci.name AS container_image_name,
+            j.id AS job_id,
+            j.status,
+            j.started_at,
+            j.completed_at,
+            (SELECT COUNT(1) FROM sqlq.job_logs WHERE sqlq.job_logs.job = j.id AND level = 'warn') warning_count,
+            (SELECT COUNT(1) FROM sqlq.job_logs WHERE sqlq.job_logs.job = j.id AND level = 'error') error_count
+        FROM mergestat.container_syncs cs
+        INNER JOIN mergestat.container_sync_executions cse ON cs.id = cse.sync_id
+        INNER JOIN mergestat.container_images ci ON cs.image_id = ci.id
+        INNER JOIN sqlq.jobs j ON cse.job_id = j.id
+        WHERE cs.id = container_syncs.id
+        ORDER BY cs.id, j.completed_at DESC
+        LIMIT 15
+    )
+    SELECT 
+        JSONB_OBJECT_AGG(job_id, TO_JSONB(t) - 'job_id')
+    INTO response
+    FROM (
+        SELECT job_id, started_at, completed_at, ((EXTRACT('epoch' FROM completed_at)-EXTRACT('epoch' FROM started_at))*1000)::INTEGER AS duration_ms, status FROM last_completed_syncs    
+    )t;
+
+    RETURN response;
+END; $$;
+
 COMMIT;

--- a/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
+++ b/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
@@ -83,4 +83,62 @@ BEGIN
     
 END; $$;
 
+CREATE OR REPLACE FUNCTION mergestat.sync_now(container_sync_id UUID)
+RETURNS BOOLEAN
+LANGUAGE PLPGSQL VOLATILE
+AS $$
+DECLARE 
+    queue_name TEXT;
+    queue_concurrency INTEGER;
+    job_id UUID;
+    is_sync_already_running BOOLEAN;
+BEGIN
+    --Check if a sync run is already queued
+    WITH sync_running(id, queue, job, status) AS (
+        SELECT DISTINCT ON (syncs.id) syncs.id, (image.queue || '-' || repo.provider) AS queue, exec.job_id, job.status,
+            CASE WHEN image.queue = 'github' THEN 1 ELSE 0 END AS concurrency
+            FROM mergestat.container_syncs syncs
+                INNER JOIN mergestat.container_images image ON image.id = syncs.image_id
+                INNER JOIN public.repos repo ON repo.id = syncs.repo_id
+                LEFT OUTER JOIN mergestat.container_sync_executions exec ON exec.sync_id = syncs.id
+                LEFT OUTER JOIN sqlq.jobs job ON job.id = exec.job_id
+        WHERE syncs.id = container_sync_id
+        ORDER BY syncs.id, exec.created_at DESC
+    )
+    SELECT CASE WHEN (SELECT COUNT(*) FROM sync_running WHERE status IN ('pending','running')) > 0 THEN TRUE ELSE FALSE END
+    INTO is_sync_already_running;
+    
+    
+    IF is_sync_already_running = FALSE
+    THEN    
+        --Get the queue name
+        SELECT DISTINCT (ci.queue || '-' || r.provider)
+        INTO queue_name
+        FROM mergestat.container_syncs cs
+        INNER JOIN mergestat.container_images ci ON ci.id = cs.image_id
+        INNER JOIN public.repos r ON r.id = cs.repo_id
+        WHERE cs.id = container_sync_id;
+        
+        --Get the queue concurrency
+        SELECT DISTINCT CASE WHEN ci.queue = 'github' THEN 1 ELSE NULL END
+        INTO queue_concurrency
+        FROM mergestat.container_syncs cs
+        INNER JOIN mergestat.container_images ci ON ci.id = cs.image_id
+        INNER JOIN public.repos r ON r.id = cs.repo_id
+        WHERE cs.id = container_sync_id;
+        
+        --Add the queue if missing
+        INSERT INTO sqlq.queues (name, concurrency) VALUES (queue_name, queue_concurrency) ON CONFLICT (name) DO UPDATE SET concurrency = excluded.concurrency;
+        
+        --Add the job
+        INSERT INTO sqlq.jobs (queue, typename, parameters, priority) VALUES (queue_name, 'container/sync', jsonb_build_object('ID', container_sync_id), 0) RETURNING id INTO job_id;
+        
+        --Add the container sync execution
+        INSERT INTO mergestat.container_sync_executions (sync_id, job_id) VALUES (container_sync_id, job_id);
+    END IF;
+    
+    RETURN TRUE;
+    
+END; $$;
+
 COMMIT;

--- a/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
+++ b/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
@@ -189,7 +189,7 @@ BEGIN
         INNER JOIN mergestat.container_images ci ON cs.image_id = ci.id
         INNER JOIN sqlq.jobs j ON cse.job_id = j.id
         WHERE cs.id = container_syncs.id
-        ORDER BY cs.id, j.completed_at DESC
+        ORDER BY cs.id, j.created_at DESC
         LIMIT 15
     )
     SELECT 

--- a/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
+++ b/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
@@ -244,4 +244,64 @@ BEGIN
 END
 $$;
 
+--Removing reference to schedules
+----https://www.graphile.org/postgraphile/custom-queries/
+CREATE OR REPLACE FUNCTION mergestat.get_repos_syncs_by_status(repo_id_param UUID, status_param TEXT)
+RETURNS JSONB
+LANGUAGE PLPGSQL STABLE
+AS $$
+DECLARE
+   response JSONB;
+BEGIN
+    WITH last_completed_syncs AS(
+        SELECT DISTINCT ON (cs.id) 
+            cs.id AS container_sync_id,
+            ci.name AS container_image_name,
+            j.id AS job_id,
+            j.status,
+            j.completed_at AS sync_last_completed_at,
+            (SELECT COUNT(1) FROM sqlq.job_logs WHERE sqlq.job_logs.job = j.id AND level = 'warn') warning_count,
+            (SELECT COUNT(1) FROM sqlq.job_logs WHERE sqlq.job_logs.job = j.id AND level = 'error') error_count
+        FROM mergestat.container_syncs cs
+        INNER JOIN mergestat.container_sync_executions cse ON cs.id = cse.sync_id
+        INNER JOIN mergestat.container_images ci ON cs.image_id = ci.id
+        INNER JOIN sqlq.jobs j ON cse.job_id = j.id
+        WHERE cs.repo_id = repo_id_param AND j.status NOT IN ('pending','running')
+        ORDER BY cs.id, j.created_at DESC
+    ),
+    current_syncs AS(
+        SELECT DISTINCT ON (cs.id)
+            cs.id AS container_sync_id,
+            ci.name AS container_image_name,
+            j.id AS job_id,
+            j.status,
+            j.completed_at AS sync_last_completed_at
+        FROM mergestat.container_syncs cs
+        LEFT JOIN mergestat.container_sync_executions cse ON cs.id = cse.sync_id
+        LEFT JOIN mergestat.container_images ci ON cs.image_id = ci.id
+        LEFT JOIN sqlq.jobs j ON cse.job_id = j.id
+        WHERE cs.repo_id = repo_id_param AND j.status IN ('pending','running')
+        ORDER BY cs.id, j.created_at DESC
+    ),
+    selected_sync AS(
+        SELECT container_sync_id, job_id, container_image_name, sync_last_completed_at, 'running' AS selection FROM current_syncs WHERE status = 'running'
+        UNION
+        SELECT container_sync_id, job_id, container_image_name, sync_last_completed_at, 'pending' AS selection FROM current_syncs WHERE status = 'pending'
+        UNION
+        SELECT container_sync_id, job_id, container_image_name, sync_last_completed_at, 'success' AS selection FROM last_completed_syncs WHERE status = 'success'
+        UNION
+        SELECT container_sync_id, job_id, container_image_name, sync_last_completed_at, 'warning' AS selection FROM last_completed_syncs WHERE warning_count > 0
+        UNION
+        SELECT container_sync_id, job_id, container_image_name, sync_last_completed_at, 'errored' AS selection FROM last_completed_syncs WHERE status = 'errored' OR error_count > 0
+    )
+    SELECT 
+        JSONB_OBJECT_AGG(job_id, TO_JSONB(t) - 'job_id')
+    INTO response
+    FROM (
+        SELECT container_sync_id, job_id, container_image_name, sync_last_completed_at FROM selected_sync WHERE selection = status_param
+    )t;
+
+    RETURN response;
+END; $$;
+
 COMMIT;

--- a/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
+++ b/migrations/900000000000058_add_default_syncs_for_container_images.up.sql
@@ -151,26 +151,37 @@ BEGIN
     
 END; $$;
 
+--Delete duplicate container images and add unique constraint
+DELETE FROM
+    mergestat.container_images a
+    USING mergestat.container_images b
+WHERE
+    a.id < b.id
+    AND a.name = b.name;
+
+ALTER TABLE mergestat.container_images DROP CONSTRAINT IF EXISTS unique_container_images_name;
+ALTER TABLE mergestat.container_images ADD CONSTRAINT unique_container_images_name UNIQUE (name);
+
 --Seeding container images
 INSERT INTO mergestat.container_images(name, description, type, url, version, queue)
 VALUES
-('git-blame', 'Retrieves the git blame of all lines in all files of a git repository', 'docker', 'ghcr.io/mergestat/sync-git-blame', 'latest', 'default'),
-('git-commit-stats', 'Retrieves commit stats for a repo', 'docker', 'ghcr.io/mergestat/sync-git-commit-stats', 'latest', 'default'),
-('git-commits', 'Retrieves the commit history of a repo', 'docker', 'ghcr.io/mergestat/sync-git-commits', 'latest', 'default'),
-('git-files', 'Retrieves files (content and paths) of a git repo', 'docker', 'ghcr.io/mergestat/sync-git-files', 'latest', 'default'),
-('git-refs', 'Retrieves all the refs of a git repo', 'docker', 'ghcr.io/mergestat/sync-git-refs', 'latest', 'default'),
-('github-issues', 'Retrieves all the issues of a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-issues', 'latest', 'github'),
-('github-pull-request-commits', 'Retrieves commits for all pull requests in a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-pull-request-commits', 'latest', 'github'),
-('github-pull-request-reviews', 'Retrieves the reviews of all pull requests in a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-pull-request-reviews', 'latest', 'github'),
-('github-pull-requests', 'Retrieves all the pull requests of a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-pull-requests', 'latest', 'github'),
-('github-repo-info', 'Retrieves info/metadata about a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-repo-info', 'latest', 'github'),
-('github-repo-stargazers', 'Retrieves all stargazers of a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-repo-stargazers', 'latest', 'github'),
-('scan-gitleaks', 'Executes a gitleaks scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-gitleaks', 'latest', 'default'),
-('scan-gosec', 'Executes a gosec scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-gosec', 'latest', 'default'),
-('scan-grype', 'Executes a grype scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-grype', 'latest', 'default'),
-('scan-syft', 'Executes a syft scan on a git repository to generate an SBOM', 'docker', 'ghcr.io/mergestat/sync-scan-syft', 'latest', 'default'),
-('scan-trivy', 'Executes a trivy scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-trivy', 'latest', 'default'),
-('scan-yelp-detect-secrets', 'Executes a Yelp detect-secrets scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-yelp-detect-secrets', 'latest', 'default')
+('Git Blame', 'Retrieves the git blame of all lines in all files of a git repository', 'docker', 'ghcr.io/mergestat/sync-git-blame', 'latest', 'default'),
+('Git Commit Stats', 'Retrieves commit stats for a repo', 'docker', 'ghcr.io/mergestat/sync-git-commit-stats', 'latest', 'default'),
+('Git Commits', 'Retrieves the commit history of a repo', 'docker', 'ghcr.io/mergestat/sync-git-commits', 'latest', 'default'),
+('Git Files', 'Retrieves files (content and paths) of a git repo', 'docker', 'ghcr.io/mergestat/sync-git-files', 'latest', 'default'),
+('Git Refs', 'Retrieves all the refs of a git repo', 'docker', 'ghcr.io/mergestat/sync-git-refs', 'latest', 'default'),
+('GitHub Issues', 'Retrieves all the issues of a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-issues', 'latest', 'github'),
+('GitHub PR Commits', 'Retrieves commits for all pull requests in a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-pull-request-commits', 'latest', 'github'),
+('GitHub PR Reviews', 'Retrieves the reviews of all pull requests in a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-pull-request-reviews', 'latest', 'github'),
+('GitHub Pull Requests', 'Retrieves all the pull requests of a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-pull-requests', 'latest', 'github'),
+('GitHub Repo Info', 'Retrieves info/metadata of a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-repo-info', 'latest', 'github'),
+('GitHub Stargazers', 'Retrieves all stargazers of a GitHub repo', 'docker', 'ghcr.io/mergestat/sync-github-repo-stargazers', 'latest', 'github'),
+('Scan Gitleaks', 'Executes a gitleaks scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-gitleaks', 'latest', 'default'),
+('Scan Gosec', 'Executes a gosec scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-gosec', 'latest', 'default'),
+('Scan Grype', 'Executes a grype scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-grype', 'latest', 'default'),
+('Scan Syft', 'Executes a syft scan on a git repository to generate an SBOM', 'docker', 'ghcr.io/mergestat/sync-scan-syft', 'latest', 'default'),
+('Scan Trivy', 'Executes a trivy scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-trivy', 'latest', 'default'),
+('Scan Yelp Detect Secrets', 'Executes a Yelp detect-secrets scan on a git repository', 'docker', 'ghcr.io/mergestat/sync-scan-yelp-detect-secrets', 'latest', 'default')
 ON CONFLICT DO NOTHING;
 
 --Adding more columns to the response of the function

--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -434,12 +434,14 @@ export type JobData = {
   runningTime: number
   runningTimeReadable?: string
   status: string
+  createdAt?: Date
   doneAt?: Date
 }
 
 export interface JobSyncRun {
   [key: string]: {
     status: string,
+    created_at: string,
     started_at: string,
     duration_ms: number,
     completed_at: string

--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -430,6 +430,7 @@ export type JobData = {
   id: string
   repoId: string
   syncId: string
+  durationMs: number
   runningTime: number
   runningTimeReadable?: string
   status: string

--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -199,6 +199,20 @@ export type SyncType = {
   checked: boolean
 }
 
+export type ContainerImage = {
+  id: string
+  description: string | null | undefined
+  name: string
+  checked: boolean
+}
+
+export type ImportContainerImage = {
+  name: string
+  type: string
+  opened?: boolean
+  defaultSyncs: Array<ContainerImage>
+}
+
 export type ImportSync = {
   name: string
   type: string

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -22192,6 +22192,11 @@ export type GetDefaultRepoSyncsQueryVariables = Exact<{
 
 export type GetDefaultRepoSyncsQuery = { all?: { totalCount: number } | null, containerImages?: { totalCount: number, nodes: Array<{ id: any, name: string, description?: string | null, containerSyncs: { nodes: Array<{ repo?: { provider: any } | null, scheduled?: { id: any } | null }> } }> } | null };
 
+export type GetAllContainerImagesQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetAllContainerImagesQuery = { containerImages?: { totalCount: number, nodes: Array<{ id: any, name: string, description?: string | null }> } | null };
+
 export type GetQueryHistoryQueryVariables = Exact<{ [key: string]: never; }>;
 
 

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -21,6 +21,127 @@ export type Scalars = {
   YesOrNo: any;
 };
 
+/** All input for the `addRepoImport` mutation. */
+export type AddRepoImportInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  defaultContainerImageIds?: InputMaybe<Array<InputMaybe<Scalars['UUID']>>>;
+  importType?: InputMaybe<Scalars['String']>;
+  importTypeName?: InputMaybe<Scalars['String']>;
+  providerId?: InputMaybe<Scalars['UUID']>;
+};
+
+/** The output of our `addRepoImport` mutation. */
+export type AddRepoImportPayload = {
+  boolean?: Maybe<Scalars['Boolean']>;
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+};
+
+/** Bearer repo scans */
+export type BearerRepoScan = Node & {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt: Scalars['Datetime'];
+  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
+  nodeId: Scalars['ID'];
+  /** Reads a single `Repo` that is related to this `BearerRepoScan`. */
+  repo?: Maybe<Repo>;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+  /** JSON results from Bearer repo scan */
+  results: Scalars['JSON'];
+};
+
+/**
+ * A condition to be used against `BearerRepoScan` object types. All fields are
+ * tested for equality and combined with a logical ‘and.’
+ */
+export type BearerRepoScanCondition = {
+  /** Checks for equality with the object’s `_mergestatSyncedAt` field. */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** Checks for equality with the object’s `repoId` field. */
+  repoId?: InputMaybe<Scalars['UUID']>;
+  /** Checks for equality with the object’s `results` field. */
+  results?: InputMaybe<Scalars['JSON']>;
+};
+
+/** A filter to be used against `BearerRepoScan` object types. All fields are combined with a logical ‘and.’ */
+export type BearerRepoScanFilter = {
+  /** Filter by the object’s `_mergestatSyncedAt` field. */
+  _mergestatSyncedAt?: InputMaybe<DatetimeFilter>;
+  /** Checks for all expressions in this list. */
+  and?: InputMaybe<Array<BearerRepoScanFilter>>;
+  /** Negates the expression. */
+  not?: InputMaybe<BearerRepoScanFilter>;
+  /** Checks for any expressions in this list. */
+  or?: InputMaybe<Array<BearerRepoScanFilter>>;
+  /** Filter by the object’s `repoId` field. */
+  repoId?: InputMaybe<UuidFilter>;
+  /** Filter by the object’s `results` field. */
+  results?: InputMaybe<JsonFilter>;
+};
+
+/** An input for mutations affecting `BearerRepoScan` */
+export type BearerRepoScanInput = {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+  /** JSON results from Bearer repo scan */
+  results: Scalars['JSON'];
+};
+
+/** Represents an update to a `BearerRepoScan`. Fields that are set will be updated. */
+export type BearerRepoScanPatch = {
+  /** timestamp when record was synced into the MergeStat database */
+  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
+  /** foreign key for public.repos.id */
+  repoId?: InputMaybe<Scalars['UUID']>;
+  /** JSON results from Bearer repo scan */
+  results?: InputMaybe<Scalars['JSON']>;
+};
+
+/** A connection to a list of `BearerRepoScan` values. */
+export type BearerRepoScansConnection = {
+  /** A list of edges which contains the `BearerRepoScan` and cursor to aid in pagination. */
+  edges: Array<BearerRepoScansEdge>;
+  /** A list of `BearerRepoScan` objects. */
+  nodes: Array<BearerRepoScan>;
+  /** Information to aid in pagination. */
+  pageInfo: PageInfo;
+  /** The count of *all* `BearerRepoScan` you could get from the connection. */
+  totalCount: Scalars['Int'];
+};
+
+/** A `BearerRepoScan` edge in the connection. */
+export type BearerRepoScansEdge = {
+  /** A cursor for use in pagination. */
+  cursor?: Maybe<Scalars['Cursor']>;
+  /** The `BearerRepoScan` at the end of the edge. */
+  node: BearerRepoScan;
+};
+
+/** Methods to use when ordering `BearerRepoScan`. */
+export enum BearerRepoScansOrderBy {
+  Natural = 'NATURAL',
+  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
+  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
+  RepoIdAsc = 'REPO_ID_ASC',
+  RepoIdDesc = 'REPO_ID_DESC',
+  ResultsAsc = 'RESULTS_ASC',
+  ResultsDesc = 'RESULTS_DESC',
+  MergestatSyncedAtAsc = '_MERGESTAT_SYNCED_AT_ASC',
+  MergestatSyncedAtDesc = '_MERGESTAT_SYNCED_AT_DESC'
+}
+
 /** A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’ */
 export type BigIntFilter = {
   /** Not equal to the specified value, treating null like an ordinary value. */
@@ -743,6 +864,40 @@ export enum ContainerSyncsOrderBy {
   RepoIdAsc = 'REPO_ID_ASC',
   RepoIdDesc = 'REPO_ID_DESC'
 }
+
+/** All input for the create `BearerRepoScan` mutation. */
+export type CreateBearerRepoScanInput = {
+  /** The `BearerRepoScan` to be created by this mutation. */
+  bearerRepoScan: BearerRepoScanInput;
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+};
+
+/** The output of our create `BearerRepoScan` mutation. */
+export type CreateBearerRepoScanPayload = {
+  /** The `BearerRepoScan` that was created by this mutation. */
+  bearerRepoScan?: Maybe<BearerRepoScan>;
+  /** An edge for our `BearerRepoScan`. May be used by Relay 1. */
+  bearerRepoScanEdge?: Maybe<BearerRepoScansEdge>;
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Repo` that is related to this `BearerRepoScan`. */
+  repo?: Maybe<Repo>;
+};
+
+
+/** The output of our create `BearerRepoScan` mutation. */
+export type CreateBearerRepoScanPayloadBearerRepoScanEdgeArgs = {
+  orderBy?: InputMaybe<Array<BearerRepoScansOrderBy>>;
+};
 
 /** All input for the create `ContainerImage` mutation. */
 export type CreateContainerImageInput = {
@@ -2624,6 +2779,52 @@ export type DatetimeFilter = {
   notEqualTo?: InputMaybe<Scalars['Datetime']>;
   /** Not included in the specified list. */
   notIn?: InputMaybe<Array<Scalars['Datetime']>>;
+};
+
+/** All input for the `deleteBearerRepoScanByNodeId` mutation. */
+export type DeleteBearerRepoScanByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `BearerRepoScan` to be deleted. */
+  nodeId: Scalars['ID'];
+};
+
+/** All input for the `deleteBearerRepoScan` mutation. */
+export type DeleteBearerRepoScanInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+};
+
+/** The output of our delete `BearerRepoScan` mutation. */
+export type DeleteBearerRepoScanPayload = {
+  /** The `BearerRepoScan` that was deleted by this mutation. */
+  bearerRepoScan?: Maybe<BearerRepoScan>;
+  /** An edge for our `BearerRepoScan`. May be used by Relay 1. */
+  bearerRepoScanEdge?: Maybe<BearerRepoScansEdge>;
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  deletedBearerRepoScanNodeId?: Maybe<Scalars['ID']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Repo` that is related to this `BearerRepoScan`. */
+  repo?: Maybe<Repo>;
+};
+
+
+/** The output of our delete `BearerRepoScan` mutation. */
+export type DeleteBearerRepoScanPayloadBearerRepoScanEdgeArgs = {
+  orderBy?: InputMaybe<Array<BearerRepoScansOrderBy>>;
 };
 
 /** All input for the `deleteContainerImageByNodeId` mutation. */
@@ -5074,6 +5275,29 @@ export type DisplayDatabaseConnection = {
   host?: Maybe<Scalars['String']>;
   port?: Maybe<Scalars['Int']>;
   user?: Maybe<Scalars['String']>;
+};
+
+/** All input for the `enableContainerSync` mutation. */
+export type EnableContainerSyncInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  containerImageId?: InputMaybe<Scalars['UUID']>;
+  repoIdParam?: InputMaybe<Scalars['UUID']>;
+};
+
+/** The output of our `enableContainerSync` mutation. */
+export type EnableContainerSyncPayload = {
+  boolean?: Maybe<Scalars['Boolean']>;
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
 };
 
 export type ExecSqlInput = {
@@ -10705,11 +10929,14 @@ export type MarkSuccessPayload = {
 
 /** The root mutation type which contains root level fields which mutate data. */
 export type Mutation = {
+  addRepoImport?: Maybe<AddRepoImportPayload>;
   addToken?: Maybe<Scalars['Boolean']>;
   bulkDisableSync?: Maybe<Scalars['Boolean']>;
   bulkEnableSync?: Maybe<Scalars['Boolean']>;
   cancellingJob?: Maybe<CancellingJobPayload>;
   checkJobStatus?: Maybe<CheckJobStatusPayload>;
+  /** Creates a single `BearerRepoScan`. */
+  createBearerRepoScan?: Maybe<CreateBearerRepoScanPayload>;
   /** Creates a single `ContainerImage`. */
   createContainerImage?: Maybe<CreateContainerImagePayload>;
   /** Creates a single `ContainerImageType`. */
@@ -10820,6 +11047,10 @@ export type Mutation = {
   createVendorType?: Maybe<CreateVendorTypePayload>;
   /** Creates a single `YelpDetectSecretsRepoScan`. */
   createYelpDetectSecretsRepoScan?: Maybe<CreateYelpDetectSecretsRepoScanPayload>;
+  /** Deletes a single `BearerRepoScan` using a unique key. */
+  deleteBearerRepoScan?: Maybe<DeleteBearerRepoScanPayload>;
+  /** Deletes a single `BearerRepoScan` using its globally unique id. */
+  deleteBearerRepoScanByNodeId?: Maybe<DeleteBearerRepoScanPayload>;
   /** Deletes a single `ContainerImage` using a unique key. */
   deleteContainerImage?: Maybe<DeleteContainerImagePayload>;
   /** Deletes a single `ContainerImage` using its globally unique id. */
@@ -11041,6 +11272,7 @@ export type Mutation = {
   /** Deletes a single `YelpDetectSecretsRepoScan` using its globally unique id. */
   deleteYelpDetectSecretsRepoScanByNodeId?: Maybe<DeleteYelpDetectSecretsRepoScanPayload>;
   dequeueJob?: Maybe<DequeueJobPayload>;
+  enableContainerSync?: Maybe<EnableContainerSyncPayload>;
   fetchServiceAuthCredential?: Maybe<FetchServiceAuthCredentialPayload>;
   jsonbRecursiveMerge?: Maybe<JsonbRecursiveMergePayload>;
   markFailed?: Maybe<MarkFailedPayload>;
@@ -11050,6 +11282,10 @@ export type Mutation = {
   simpleRepoSyncQueueCleanup?: Maybe<SimpleRepoSyncQueueCleanupPayload>;
   simpleSqlqCleanup?: Maybe<SimpleSqlqCleanupPayload>;
   syncNow?: Maybe<SyncNowPayload>;
+  /** Updates a single `BearerRepoScan` using a unique key and a patch. */
+  updateBearerRepoScan?: Maybe<UpdateBearerRepoScanPayload>;
+  /** Updates a single `BearerRepoScan` using its globally unique id and a patch. */
+  updateBearerRepoScanByNodeId?: Maybe<UpdateBearerRepoScanPayload>;
   /** Updates a single `ContainerImage` using a unique key and a patch. */
   updateContainerImage?: Maybe<UpdateContainerImagePayload>;
   /** Updates a single `ContainerImage` using its globally unique id and a patch. */
@@ -11190,6 +11426,7 @@ export type Mutation = {
   updateRepoImport?: Maybe<UpdateRepoImportPayload>;
   /** Updates a single `RepoImport` using its globally unique id and a patch. */
   updateRepoImportByNodeId?: Maybe<UpdateRepoImportPayload>;
+  updateRepoImportDefaultContainerImages?: Maybe<UpdateRepoImportDefaultContainerImagesPayload>;
   /** Updates a single `RepoImportType` using a unique key and a patch. */
   updateRepoImportType?: Maybe<UpdateRepoImportTypePayload>;
   /** Updates a single `RepoImportType` using its globally unique id and a patch. */
@@ -11278,6 +11515,12 @@ export type Mutation = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationAddRepoImportArgs = {
+  input: AddRepoImportInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationAddTokenArgs = {
   provider: Scalars['UUID'];
   token: Scalars['String'];
@@ -11309,6 +11552,12 @@ export type MutationCancellingJobArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCheckJobStatusArgs = {
   input: CheckJobStatusInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationCreateBearerRepoScanArgs = {
+  input: CreateBearerRepoScanInput;
 };
 
 
@@ -11639,6 +11888,18 @@ export type MutationCreateVendorTypeArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCreateYelpDetectSecretsRepoScanArgs = {
   input: CreateYelpDetectSecretsRepoScanInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteBearerRepoScanArgs = {
+  input: DeleteBearerRepoScanInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteBearerRepoScanByNodeIdArgs = {
+  input: DeleteBearerRepoScanByNodeIdInput;
 };
 
 
@@ -12309,6 +12570,12 @@ export type MutationDequeueJobArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationEnableContainerSyncArgs = {
+  input: EnableContainerSyncInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationFetchServiceAuthCredentialArgs = {
   input: FetchServiceAuthCredentialInput;
 };
@@ -12359,6 +12626,18 @@ export type MutationSimpleSqlqCleanupArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationSyncNowArgs = {
   input: SyncNowInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateBearerRepoScanArgs = {
+  input: UpdateBearerRepoScanInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateBearerRepoScanByNodeIdArgs = {
+  input: UpdateBearerRepoScanByNodeIdInput;
 };
 
 
@@ -12779,6 +13058,12 @@ export type MutationUpdateRepoImportArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateRepoImportByNodeIdArgs = {
   input: UpdateRepoImportByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateRepoImportDefaultContainerImagesArgs = {
+  input: UpdateRepoImportDefaultContainerImagesInput;
 };
 
 
@@ -13536,6 +13821,11 @@ export enum ProvidersOrderBy {
 
 /** The root query type which gives access points into the data universe. */
 export type Query = Node & {
+  bearerRepoScan?: Maybe<BearerRepoScan>;
+  /** Reads a single `BearerRepoScan` using its globally unique `ID`. */
+  bearerRepoScanByNodeId?: Maybe<BearerRepoScan>;
+  /** Reads and enables pagination through a set of `BearerRepoScan`. */
+  bearerRepoScans?: Maybe<BearerRepoScansConnection>;
   containerImage?: Maybe<ContainerImage>;
   /** Reads a single `ContainerImage` using its globally unique `ID`. */
   containerImageByNodeId?: Maybe<ContainerImage>;
@@ -13690,7 +13980,7 @@ export type Query = Node & {
   /** Reads and enables pagination through a set of `LatestRepoSync`. */
   latestRepoSyncs?: Maybe<LatestRepoSyncsConnection>;
   /** Fetches an object given its globally unique `ID`. */
-  node?: Maybe<ContainerImage | ContainerImageType | ContainerSync | ContainerSyncSchedule | GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Job | JobLog | Label | OssfScorecardRepoScan | Provider | Query | QueryHistory | Queue | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | Vendor | VendorType | YelpDetectSecretsRepoScan>;
+  node?: Maybe<BearerRepoScan | ContainerImage | ContainerImageType | ContainerSync | ContainerSyncSchedule | GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Job | JobLog | Label | OssfScorecardRepoScan | Provider | Query | QueryHistory | Queue | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | Vendor | VendorType | YelpDetectSecretsRepoScan>;
   /** The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`. */
   nodeId: Scalars['ID'];
   /** Reads and enables pagination through a set of `OssfScorecardRepoCheckResult`. */
@@ -13840,6 +14130,31 @@ export type Query = Node & {
   yelpDetectSecretsRepoScanByNodeId?: Maybe<YelpDetectSecretsRepoScan>;
   /** Reads and enables pagination through a set of `YelpDetectSecretsRepoScan`. */
   yelpDetectSecretsRepoScans?: Maybe<YelpDetectSecretsRepoScansConnection>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryBearerRepoScanArgs = {
+  repoId: Scalars['UUID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryBearerRepoScanByNodeIdArgs = {
+  nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryBearerRepoScansArgs = {
+  after?: InputMaybe<Scalars['Cursor']>;
+  before?: InputMaybe<Scalars['Cursor']>;
+  condition?: InputMaybe<BearerRepoScanCondition>;
+  filter?: InputMaybe<BearerRepoScanFilter>;
+  first?: InputMaybe<Scalars['Int']>;
+  last?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+  orderBy?: InputMaybe<Array<BearerRepoScansOrderBy>>;
 };
 
 
@@ -15617,6 +15932,8 @@ export type ReapPayload = {
 
 /** git repositories to track */
 export type Repo = Node & {
+  /** Reads a single `BearerRepoScan` that is related to this `Repo`. */
+  bearerRepoScan?: Maybe<BearerRepoScan>;
   /** Reads and enables pagination through a set of `ContainerSync`. */
   containerSyncs: ContainerSyncsConnection;
   /** timestamp of when the MergeStat repo entry was created */
@@ -18594,6 +18911,55 @@ export type UuidFilter = {
   notIn?: InputMaybe<Array<Scalars['UUID']>>;
 };
 
+/** All input for the `updateBearerRepoScanByNodeId` mutation. */
+export type UpdateBearerRepoScanByNodeIdInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** The globally unique `ID` which will identify a single `BearerRepoScan` to be updated. */
+  nodeId: Scalars['ID'];
+  /** An object where the defined keys will be set on the `BearerRepoScan` being updated. */
+  patch: BearerRepoScanPatch;
+};
+
+/** All input for the `updateBearerRepoScan` mutation. */
+export type UpdateBearerRepoScanInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  /** An object where the defined keys will be set on the `BearerRepoScan` being updated. */
+  patch: BearerRepoScanPatch;
+  /** foreign key for public.repos.id */
+  repoId: Scalars['UUID'];
+};
+
+/** The output of our update `BearerRepoScan` mutation. */
+export type UpdateBearerRepoScanPayload = {
+  /** The `BearerRepoScan` that was updated by this mutation. */
+  bearerRepoScan?: Maybe<BearerRepoScan>;
+  /** An edge for our `BearerRepoScan`. May be used by Relay 1. */
+  bearerRepoScanEdge?: Maybe<BearerRepoScansEdge>;
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  /** Reads a single `Repo` that is related to this `BearerRepoScan`. */
+  repo?: Maybe<Repo>;
+};
+
+
+/** The output of our update `BearerRepoScan` mutation. */
+export type UpdateBearerRepoScanPayloadBearerRepoScanEdgeArgs = {
+  orderBy?: InputMaybe<Array<BearerRepoScansOrderBy>>;
+};
+
 /** All input for the `updateContainerImageByNodeId` mutation. */
 export type UpdateContainerImageByNodeIdInput = {
   /**
@@ -20176,6 +20542,29 @@ export type UpdateRepoImportByNodeIdInput = {
   nodeId: Scalars['ID'];
   /** An object where the defined keys will be set on the `RepoImport` being updated. */
   patch: RepoImportPatch;
+};
+
+/** All input for the `updateRepoImportDefaultContainerImages` mutation. */
+export type UpdateRepoImportDefaultContainerImagesInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  defaultContainerImageIds?: InputMaybe<Array<InputMaybe<Scalars['UUID']>>>;
+  repoImportId?: InputMaybe<Scalars['UUID']>;
+};
+
+/** The output of our `updateRepoImportDefaultContainerImages` mutation. */
+export type UpdateRepoImportDefaultContainerImagesPayload = {
+  boolean?: Maybe<Scalars['Boolean']>;
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
 };
 
 /** All input for the `updateRepoImport` mutation. */
@@ -21912,6 +22301,24 @@ export type UpdateRepoImportMutationVariables = Exact<{
 
 export type UpdateRepoImportMutation = { updateRepoImport?: { repoImport?: { id: any, settings: any } | null } | null };
 
+export type AddRepoImportContainerMutationVariables = Exact<{
+  providerId: Scalars['UUID'];
+  importType: Scalars['String'];
+  importTypeName: Scalars['String'];
+  defaultContainerImageIds: Array<InputMaybe<Scalars['UUID']>> | InputMaybe<Scalars['UUID']>;
+}>;
+
+
+export type AddRepoImportContainerMutation = { addRepoImport?: { boolean?: boolean | null } | null };
+
+export type UpdateRepoImportContainerMutationVariables = Exact<{
+  repoImportId: Scalars['UUID'];
+  defaultContainerImageIds: Array<InputMaybe<Scalars['UUID']>> | InputMaybe<Scalars['UUID']>;
+}>;
+
+
+export type UpdateRepoImportContainerMutation = { updateRepoImportDefaultContainerImages?: { boolean?: boolean | null } | null };
+
 export type AddTokenMutationVariables = Exact<{
   provider: Scalars['UUID'];
   token: Scalars['String'];
@@ -22232,6 +22639,13 @@ export type GetRepoImportQueryVariables = Exact<{
 
 
 export type GetRepoImportQuery = { repoImport?: { id: any, lastImport?: any | null, settings: any, provider?: { id: any, name: string, vendor: string, settings: any } | null } | null, repoSyncTypes?: { nodes: Array<{ type: string, description?: string | null, shortName: string }> } | null };
+
+export type GetRepoImportContainerQueryVariables = Exact<{
+  id: Scalars['UUID'];
+}>;
+
+
+export type GetRepoImportContainerQuery = { repoImport?: { id: any, lastImport?: any | null, settings: any, provider?: { id: any, name: string, vendor: string, settings: any } | null } | null, containerImages?: { totalCount: number, nodes: Array<{ id: any, name: string, description?: string | null }> } | null };
 
 export type GetRepoDataQueryVariables = Exact<{
   id: Scalars['UUID'];

--- a/ui/src/api-logic/graphql/generated/schema.ts
+++ b/ui/src/api-logic/graphql/generated/schema.ts
@@ -46,102 +46,6 @@ export type AddRepoImportPayload = {
   query?: Maybe<Query>;
 };
 
-/** Bearer repo scans */
-export type BearerRepoScan = Node & {
-  /** timestamp when record was synced into the MergeStat database */
-  _mergestatSyncedAt: Scalars['Datetime'];
-  /** A globally unique identifier. Can be used in various places throughout the system to identify this single value. */
-  nodeId: Scalars['ID'];
-  /** Reads a single `Repo` that is related to this `BearerRepoScan`. */
-  repo?: Maybe<Repo>;
-  /** foreign key for public.repos.id */
-  repoId: Scalars['UUID'];
-  /** JSON results from Bearer repo scan */
-  results: Scalars['JSON'];
-};
-
-/**
- * A condition to be used against `BearerRepoScan` object types. All fields are
- * tested for equality and combined with a logical ‘and.’
- */
-export type BearerRepoScanCondition = {
-  /** Checks for equality with the object’s `_mergestatSyncedAt` field. */
-  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
-  /** Checks for equality with the object’s `repoId` field. */
-  repoId?: InputMaybe<Scalars['UUID']>;
-  /** Checks for equality with the object’s `results` field. */
-  results?: InputMaybe<Scalars['JSON']>;
-};
-
-/** A filter to be used against `BearerRepoScan` object types. All fields are combined with a logical ‘and.’ */
-export type BearerRepoScanFilter = {
-  /** Filter by the object’s `_mergestatSyncedAt` field. */
-  _mergestatSyncedAt?: InputMaybe<DatetimeFilter>;
-  /** Checks for all expressions in this list. */
-  and?: InputMaybe<Array<BearerRepoScanFilter>>;
-  /** Negates the expression. */
-  not?: InputMaybe<BearerRepoScanFilter>;
-  /** Checks for any expressions in this list. */
-  or?: InputMaybe<Array<BearerRepoScanFilter>>;
-  /** Filter by the object’s `repoId` field. */
-  repoId?: InputMaybe<UuidFilter>;
-  /** Filter by the object’s `results` field. */
-  results?: InputMaybe<JsonFilter>;
-};
-
-/** An input for mutations affecting `BearerRepoScan` */
-export type BearerRepoScanInput = {
-  /** timestamp when record was synced into the MergeStat database */
-  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
-  /** foreign key for public.repos.id */
-  repoId: Scalars['UUID'];
-  /** JSON results from Bearer repo scan */
-  results: Scalars['JSON'];
-};
-
-/** Represents an update to a `BearerRepoScan`. Fields that are set will be updated. */
-export type BearerRepoScanPatch = {
-  /** timestamp when record was synced into the MergeStat database */
-  _mergestatSyncedAt?: InputMaybe<Scalars['Datetime']>;
-  /** foreign key for public.repos.id */
-  repoId?: InputMaybe<Scalars['UUID']>;
-  /** JSON results from Bearer repo scan */
-  results?: InputMaybe<Scalars['JSON']>;
-};
-
-/** A connection to a list of `BearerRepoScan` values. */
-export type BearerRepoScansConnection = {
-  /** A list of edges which contains the `BearerRepoScan` and cursor to aid in pagination. */
-  edges: Array<BearerRepoScansEdge>;
-  /** A list of `BearerRepoScan` objects. */
-  nodes: Array<BearerRepoScan>;
-  /** Information to aid in pagination. */
-  pageInfo: PageInfo;
-  /** The count of *all* `BearerRepoScan` you could get from the connection. */
-  totalCount: Scalars['Int'];
-};
-
-/** A `BearerRepoScan` edge in the connection. */
-export type BearerRepoScansEdge = {
-  /** A cursor for use in pagination. */
-  cursor?: Maybe<Scalars['Cursor']>;
-  /** The `BearerRepoScan` at the end of the edge. */
-  node: BearerRepoScan;
-};
-
-/** Methods to use when ordering `BearerRepoScan`. */
-export enum BearerRepoScansOrderBy {
-  Natural = 'NATURAL',
-  PrimaryKeyAsc = 'PRIMARY_KEY_ASC',
-  PrimaryKeyDesc = 'PRIMARY_KEY_DESC',
-  RepoIdAsc = 'REPO_ID_ASC',
-  RepoIdDesc = 'REPO_ID_DESC',
-  ResultsAsc = 'RESULTS_ASC',
-  ResultsDesc = 'RESULTS_DESC',
-  MergestatSyncedAtAsc = '_MERGESTAT_SYNCED_AT_ASC',
-  MergestatSyncedAtDesc = '_MERGESTAT_SYNCED_AT_DESC'
-}
-
 /** A filter to be used against BigInt fields. All fields are combined with a logical ‘and.’ */
 export type BigIntFilter = {
   /** Not equal to the specified value, treating null like an ordinary value. */
@@ -864,40 +768,6 @@ export enum ContainerSyncsOrderBy {
   RepoIdAsc = 'REPO_ID_ASC',
   RepoIdDesc = 'REPO_ID_DESC'
 }
-
-/** All input for the create `BearerRepoScan` mutation. */
-export type CreateBearerRepoScanInput = {
-  /** The `BearerRepoScan` to be created by this mutation. */
-  bearerRepoScan: BearerRepoScanInput;
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-};
-
-/** The output of our create `BearerRepoScan` mutation. */
-export type CreateBearerRepoScanPayload = {
-  /** The `BearerRepoScan` that was created by this mutation. */
-  bearerRepoScan?: Maybe<BearerRepoScan>;
-  /** An edge for our `BearerRepoScan`. May be used by Relay 1. */
-  bearerRepoScanEdge?: Maybe<BearerRepoScansEdge>;
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Repo` that is related to this `BearerRepoScan`. */
-  repo?: Maybe<Repo>;
-};
-
-
-/** The output of our create `BearerRepoScan` mutation. */
-export type CreateBearerRepoScanPayloadBearerRepoScanEdgeArgs = {
-  orderBy?: InputMaybe<Array<BearerRepoScansOrderBy>>;
-};
 
 /** All input for the create `ContainerImage` mutation. */
 export type CreateContainerImageInput = {
@@ -2781,50 +2651,14 @@ export type DatetimeFilter = {
   notIn?: InputMaybe<Array<Scalars['Datetime']>>;
 };
 
-/** All input for the `deleteBearerRepoScanByNodeId` mutation. */
-export type DeleteBearerRepoScanByNodeIdInput = {
+/** All input for the `deleteContainerImageByName` mutation. */
+export type DeleteContainerImageByNameInput = {
   /**
    * An arbitrary string value with no semantic meaning. Will be included in the
    * payload verbatim. May be used to track mutations by the client.
    */
   clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `BearerRepoScan` to be deleted. */
-  nodeId: Scalars['ID'];
-};
-
-/** All input for the `deleteBearerRepoScan` mutation. */
-export type DeleteBearerRepoScanInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** foreign key for public.repos.id */
-  repoId: Scalars['UUID'];
-};
-
-/** The output of our delete `BearerRepoScan` mutation. */
-export type DeleteBearerRepoScanPayload = {
-  /** The `BearerRepoScan` that was deleted by this mutation. */
-  bearerRepoScan?: Maybe<BearerRepoScan>;
-  /** An edge for our `BearerRepoScan`. May be used by Relay 1. */
-  bearerRepoScanEdge?: Maybe<BearerRepoScansEdge>;
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  deletedBearerRepoScanNodeId?: Maybe<Scalars['ID']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Repo` that is related to this `BearerRepoScan`. */
-  repo?: Maybe<Repo>;
-};
-
-
-/** The output of our delete `BearerRepoScan` mutation. */
-export type DeleteBearerRepoScanPayloadBearerRepoScanEdgeArgs = {
-  orderBy?: InputMaybe<Array<BearerRepoScansOrderBy>>;
+  name: Scalars['String'];
 };
 
 /** All input for the `deleteContainerImageByNodeId` mutation. */
@@ -5345,6 +5179,39 @@ export type FetchServiceAuthCredentialRecord = {
   id?: Maybe<Scalars['UUID']>;
   token?: Maybe<Scalars['String']>;
   username?: Maybe<Scalars['String']>;
+};
+
+/** All input for the `getfilesolderthan` mutation. */
+export type GetfilesolderthanInput = {
+  /**
+   * An arbitrary string value with no semantic meaning. Will be included in the
+   * payload verbatim. May be used to track mutations by the client.
+   */
+  clientMutationId?: InputMaybe<Scalars['String']>;
+  filePattern?: InputMaybe<Scalars['String']>;
+  olderThanDays?: InputMaybe<Scalars['Int']>;
+};
+
+/** The output of our `getfilesolderthan` mutation. */
+export type GetfilesolderthanPayload = {
+  /**
+   * The exact same `clientMutationId` that was provided in the mutation input,
+   * unchanged and unused. May be used by a client to track mutations.
+   */
+  clientMutationId?: Maybe<Scalars['String']>;
+  /** Our root query field type. Allows us to run any query from our mutation payload. */
+  query?: Maybe<Query>;
+  results?: Maybe<Array<Maybe<GetfilesolderthanRecord>>>;
+};
+
+/** The return type of our `getfilesolderthan` mutation. */
+export type GetfilesolderthanRecord = {
+  authorEmail?: Maybe<Scalars['String']>;
+  authorName?: Maybe<Scalars['String']>;
+  authorWhen?: Maybe<Scalars['Datetime']>;
+  filePath?: Maybe<Scalars['String']>;
+  hash?: Maybe<Scalars['String']>;
+  repo?: Maybe<Scalars['String']>;
 };
 
 /** git blame of all lines in all files of a repo */
@@ -10935,8 +10802,6 @@ export type Mutation = {
   bulkEnableSync?: Maybe<Scalars['Boolean']>;
   cancellingJob?: Maybe<CancellingJobPayload>;
   checkJobStatus?: Maybe<CheckJobStatusPayload>;
-  /** Creates a single `BearerRepoScan`. */
-  createBearerRepoScan?: Maybe<CreateBearerRepoScanPayload>;
   /** Creates a single `ContainerImage`. */
   createContainerImage?: Maybe<CreateContainerImagePayload>;
   /** Creates a single `ContainerImageType`. */
@@ -11047,12 +10912,10 @@ export type Mutation = {
   createVendorType?: Maybe<CreateVendorTypePayload>;
   /** Creates a single `YelpDetectSecretsRepoScan`. */
   createYelpDetectSecretsRepoScan?: Maybe<CreateYelpDetectSecretsRepoScanPayload>;
-  /** Deletes a single `BearerRepoScan` using a unique key. */
-  deleteBearerRepoScan?: Maybe<DeleteBearerRepoScanPayload>;
-  /** Deletes a single `BearerRepoScan` using its globally unique id. */
-  deleteBearerRepoScanByNodeId?: Maybe<DeleteBearerRepoScanPayload>;
   /** Deletes a single `ContainerImage` using a unique key. */
   deleteContainerImage?: Maybe<DeleteContainerImagePayload>;
+  /** Deletes a single `ContainerImage` using a unique key. */
+  deleteContainerImageByName?: Maybe<DeleteContainerImagePayload>;
   /** Deletes a single `ContainerImage` using its globally unique id. */
   deleteContainerImageByNodeId?: Maybe<DeleteContainerImagePayload>;
   /** Deletes a single `ContainerImageType` using a unique key. */
@@ -11274,6 +11137,7 @@ export type Mutation = {
   dequeueJob?: Maybe<DequeueJobPayload>;
   enableContainerSync?: Maybe<EnableContainerSyncPayload>;
   fetchServiceAuthCredential?: Maybe<FetchServiceAuthCredentialPayload>;
+  getfilesolderthan?: Maybe<GetfilesolderthanPayload>;
   jsonbRecursiveMerge?: Maybe<JsonbRecursiveMergePayload>;
   markFailed?: Maybe<MarkFailedPayload>;
   markSuccess?: Maybe<MarkSuccessPayload>;
@@ -11282,12 +11146,10 @@ export type Mutation = {
   simpleRepoSyncQueueCleanup?: Maybe<SimpleRepoSyncQueueCleanupPayload>;
   simpleSqlqCleanup?: Maybe<SimpleSqlqCleanupPayload>;
   syncNow?: Maybe<SyncNowPayload>;
-  /** Updates a single `BearerRepoScan` using a unique key and a patch. */
-  updateBearerRepoScan?: Maybe<UpdateBearerRepoScanPayload>;
-  /** Updates a single `BearerRepoScan` using its globally unique id and a patch. */
-  updateBearerRepoScanByNodeId?: Maybe<UpdateBearerRepoScanPayload>;
   /** Updates a single `ContainerImage` using a unique key and a patch. */
   updateContainerImage?: Maybe<UpdateContainerImagePayload>;
+  /** Updates a single `ContainerImage` using a unique key and a patch. */
+  updateContainerImageByName?: Maybe<UpdateContainerImagePayload>;
   /** Updates a single `ContainerImage` using its globally unique id and a patch. */
   updateContainerImageByNodeId?: Maybe<UpdateContainerImagePayload>;
   /** Updates a single `ContainerImageType` using a unique key and a patch. */
@@ -11552,12 +11414,6 @@ export type MutationCancellingJobArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationCheckJobStatusArgs = {
   input: CheckJobStatusInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationCreateBearerRepoScanArgs = {
-  input: CreateBearerRepoScanInput;
 };
 
 
@@ -11892,20 +11748,14 @@ export type MutationCreateYelpDetectSecretsRepoScanArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteBearerRepoScanArgs = {
-  input: DeleteBearerRepoScanInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationDeleteBearerRepoScanByNodeIdArgs = {
-  input: DeleteBearerRepoScanByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteContainerImageArgs = {
   input: DeleteContainerImageInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteContainerImageByNameArgs = {
+  input: DeleteContainerImageByNameInput;
 };
 
 
@@ -12582,6 +12432,12 @@ export type MutationFetchServiceAuthCredentialArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
+export type MutationGetfilesolderthanArgs = {
+  input: GetfilesolderthanInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
 export type MutationJsonbRecursiveMergeArgs = {
   input: JsonbRecursiveMergeInput;
 };
@@ -12630,20 +12486,14 @@ export type MutationSyncNowArgs = {
 
 
 /** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateBearerRepoScanArgs = {
-  input: UpdateBearerRepoScanInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
-export type MutationUpdateBearerRepoScanByNodeIdArgs = {
-  input: UpdateBearerRepoScanByNodeIdInput;
-};
-
-
-/** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateContainerImageArgs = {
   input: UpdateContainerImageInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateContainerImageByNameArgs = {
+  input: UpdateContainerImageByNameInput;
 };
 
 
@@ -13821,12 +13671,8 @@ export enum ProvidersOrderBy {
 
 /** The root query type which gives access points into the data universe. */
 export type Query = Node & {
-  bearerRepoScan?: Maybe<BearerRepoScan>;
-  /** Reads a single `BearerRepoScan` using its globally unique `ID`. */
-  bearerRepoScanByNodeId?: Maybe<BearerRepoScan>;
-  /** Reads and enables pagination through a set of `BearerRepoScan`. */
-  bearerRepoScans?: Maybe<BearerRepoScansConnection>;
   containerImage?: Maybe<ContainerImage>;
+  containerImageByName?: Maybe<ContainerImage>;
   /** Reads a single `ContainerImage` using its globally unique `ID`. */
   containerImageByNodeId?: Maybe<ContainerImage>;
   containerImageType?: Maybe<ContainerImageType>;
@@ -13980,7 +13826,7 @@ export type Query = Node & {
   /** Reads and enables pagination through a set of `LatestRepoSync`. */
   latestRepoSyncs?: Maybe<LatestRepoSyncsConnection>;
   /** Fetches an object given its globally unique `ID`. */
-  node?: Maybe<BearerRepoScan | ContainerImage | ContainerImageType | ContainerSync | ContainerSyncSchedule | GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Job | JobLog | Label | OssfScorecardRepoScan | Provider | Query | QueryHistory | Queue | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | Vendor | VendorType | YelpDetectSecretsRepoScan>;
+  node?: Maybe<ContainerImage | ContainerImageType | ContainerSync | ContainerSyncSchedule | GitBlame | GitCommit | GitCommitStat | GitFile | GitRef | GitRemote | GithubActionsWorkflow | GithubActionsWorkflowRun | GithubActionsWorkflowRunJob | GithubIssue | GithubPullRequest | GithubPullRequestCommit | GithubPullRequestReview | GithubRepoInfo | GithubStargazer | GitleaksRepoScan | GosecRepoScan | GrypeRepoScan | Job | JobLog | Label | OssfScorecardRepoScan | Provider | Query | QueryHistory | Queue | Repo | RepoImport | RepoImportType | RepoSync | RepoSyncLog | RepoSyncLogType | RepoSyncQueue | RepoSyncQueueStatusType | RepoSyncType | RepoSyncTypeGroup | SavedQuery | SchemaMigration | SchemaMigrationsHistory | ServiceAuthCredential | ServiceAuthCredentialType | SqlqMigration | SyftRepoScan | TrivyRepoScan | Vendor | VendorType | YelpDetectSecretsRepoScan>;
   /** The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`. */
   nodeId: Scalars['ID'];
   /** Reads and enables pagination through a set of `OssfScorecardRepoCheckResult`. */
@@ -14134,33 +13980,14 @@ export type Query = Node & {
 
 
 /** The root query type which gives access points into the data universe. */
-export type QueryBearerRepoScanArgs = {
-  repoId: Scalars['UUID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryBearerRepoScanByNodeIdArgs = {
-  nodeId: Scalars['ID'];
-};
-
-
-/** The root query type which gives access points into the data universe. */
-export type QueryBearerRepoScansArgs = {
-  after?: InputMaybe<Scalars['Cursor']>;
-  before?: InputMaybe<Scalars['Cursor']>;
-  condition?: InputMaybe<BearerRepoScanCondition>;
-  filter?: InputMaybe<BearerRepoScanFilter>;
-  first?: InputMaybe<Scalars['Int']>;
-  last?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  orderBy?: InputMaybe<Array<BearerRepoScansOrderBy>>;
-};
-
-
-/** The root query type which gives access points into the data universe. */
 export type QueryContainerImageArgs = {
   id: Scalars['UUID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryContainerImageByNameArgs = {
+  name: Scalars['String'];
 };
 
 
@@ -15932,8 +15759,6 @@ export type ReapPayload = {
 
 /** git repositories to track */
 export type Repo = Node & {
-  /** Reads a single `BearerRepoScan` that is related to this `Repo`. */
-  bearerRepoScan?: Maybe<BearerRepoScan>;
   /** Reads and enables pagination through a set of `ContainerSync`. */
   containerSyncs: ContainerSyncsConnection;
   /** timestamp of when the MergeStat repo entry was created */
@@ -18911,53 +18736,16 @@ export type UuidFilter = {
   notIn?: InputMaybe<Array<Scalars['UUID']>>;
 };
 
-/** All input for the `updateBearerRepoScanByNodeId` mutation. */
-export type UpdateBearerRepoScanByNodeIdInput = {
+/** All input for the `updateContainerImageByName` mutation. */
+export type UpdateContainerImageByNameInput = {
   /**
    * An arbitrary string value with no semantic meaning. Will be included in the
    * payload verbatim. May be used to track mutations by the client.
    */
   clientMutationId?: InputMaybe<Scalars['String']>;
-  /** The globally unique `ID` which will identify a single `BearerRepoScan` to be updated. */
-  nodeId: Scalars['ID'];
-  /** An object where the defined keys will be set on the `BearerRepoScan` being updated. */
-  patch: BearerRepoScanPatch;
-};
-
-/** All input for the `updateBearerRepoScan` mutation. */
-export type UpdateBearerRepoScanInput = {
-  /**
-   * An arbitrary string value with no semantic meaning. Will be included in the
-   * payload verbatim. May be used to track mutations by the client.
-   */
-  clientMutationId?: InputMaybe<Scalars['String']>;
-  /** An object where the defined keys will be set on the `BearerRepoScan` being updated. */
-  patch: BearerRepoScanPatch;
-  /** foreign key for public.repos.id */
-  repoId: Scalars['UUID'];
-};
-
-/** The output of our update `BearerRepoScan` mutation. */
-export type UpdateBearerRepoScanPayload = {
-  /** The `BearerRepoScan` that was updated by this mutation. */
-  bearerRepoScan?: Maybe<BearerRepoScan>;
-  /** An edge for our `BearerRepoScan`. May be used by Relay 1. */
-  bearerRepoScanEdge?: Maybe<BearerRepoScansEdge>;
-  /**
-   * The exact same `clientMutationId` that was provided in the mutation input,
-   * unchanged and unused. May be used by a client to track mutations.
-   */
-  clientMutationId?: Maybe<Scalars['String']>;
-  /** Our root query field type. Allows us to run any query from our mutation payload. */
-  query?: Maybe<Query>;
-  /** Reads a single `Repo` that is related to this `BearerRepoScan`. */
-  repo?: Maybe<Repo>;
-};
-
-
-/** The output of our update `BearerRepoScan` mutation. */
-export type UpdateBearerRepoScanPayloadBearerRepoScanEdgeArgs = {
-  orderBy?: InputMaybe<Array<BearerRepoScansOrderBy>>;
+  name: Scalars['String'];
+  /** An object where the defined keys will be set on the `ContainerImage` being updated. */
+  patch: ContainerImagePatch;
 };
 
 /** All input for the `updateContainerImageByNodeId` mutation. */

--- a/ui/src/api-logic/graphql/mutations/add-repo.ts
+++ b/ui/src/api-logic/graphql/mutations/add-repo.ts
@@ -32,4 +32,29 @@ const UPDATE_AUTO_IMPORT_REPOS = gql`
   }
 `
 
-export { ADD_REPO, AUTO_IMPORT_REPOS, UPDATE_AUTO_IMPORT_REPOS }
+const AUTO_IMPORT_REPOS_CONTAINER = gql`
+  mutation addRepoImportContainer($providerId: UUID!, $importType: String!, $importTypeName: String!, $defaultContainerImageIds: [UUID]!) {
+    addRepoImport(
+      input: {providerId: $providerId, importType: $importType, importTypeName: $importTypeName, defaultContainerImageIds: $defaultContainerImageIds}
+    ) {
+      boolean
+    }
+  }
+`
+
+const UPDATE_AUTO_IMPORT_REPOS_CONTAINER = gql`
+  mutation updateRepoImportContainer($repoImportId: UUID!, $defaultContainerImageIds: [UUID]!) {
+    updateRepoImportDefaultContainerImages(
+      input: {repoImportId: $repoImportId, defaultContainerImageIds: $defaultContainerImageIds}
+    ) {
+      boolean
+    }
+  }
+`
+
+export {
+  ADD_REPO, AUTO_IMPORT_REPOS,
+  UPDATE_AUTO_IMPORT_REPOS,
+  AUTO_IMPORT_REPOS_CONTAINER,
+  UPDATE_AUTO_IMPORT_REPOS_CONTAINER
+}

--- a/ui/src/api-logic/graphql/queries/get-git-sources.ts
+++ b/ui/src/api-logic/graphql/queries/get-git-sources.ts
@@ -145,7 +145,7 @@ const GET_DEFAULT_REPO_SYNCS = gql`
 
 const GET_ALL_CONTAINER_IMAGES = gql`
   query getAllContainerImages {
-    containerImages {
+    containerImages(orderBy: NAME_ASC) {
       totalCount
       nodes {
         id

--- a/ui/src/api-logic/graphql/queries/get-git-sources.ts
+++ b/ui/src/api-logic/graphql/queries/get-git-sources.ts
@@ -143,10 +143,24 @@ const GET_DEFAULT_REPO_SYNCS = gql`
   }
 `
 
+const GET_ALL_CONTAINER_IMAGES = gql`
+  query getAllContainerImages {
+    containerImages {
+      totalCount
+      nodes {
+        id
+        name
+        description
+      }
+    }
+  }
+`
+
 export {
   GET_GIT_SOURCES_LIST,
   GET_GIT_SOURCES_LIST_CS,
   GET_GIT_SOURCES,
   GET_GIT_SOURCE,
-  GET_DEFAULT_REPO_SYNCS
+  GET_DEFAULT_REPO_SYNCS,
+  GET_ALL_CONTAINER_IMAGES
 }

--- a/ui/src/api-logic/graphql/queries/get-repo-imports.ts
+++ b/ui/src/api-logic/graphql/queries/get-repo-imports.ts
@@ -94,7 +94,7 @@ const GET_REPO_IMPORT_CONTAINER = gql`
         settings
       }
     }
-    containerImages {
+    containerImages(orderBy: NAME_ASC) {
       totalCount
       nodes {
         id

--- a/ui/src/api-logic/graphql/queries/get-repo-imports.ts
+++ b/ui/src/api-logic/graphql/queries/get-repo-imports.ts
@@ -81,4 +81,34 @@ const GET_REPO_IMPORT = gql`
   }
 `
 
-export { GET_REPO_AUTO_IMPORTS, GET_ALL_REPO_MANUAL_IMPORTS, GET_REPO_MANUAL_IMPORTS, GET_REPO_IMPORT }
+const GET_REPO_IMPORT_CONTAINER = gql`
+  query getRepoImportContainer($id: UUID!) {
+    repoImport(id: $id) {
+      id
+      lastImport
+      settings
+      provider: providerByProvider {
+        id
+        name
+        vendor
+        settings
+      }
+    }
+    containerImages {
+      totalCount
+      nodes {
+        id
+        name
+        description
+      }
+    }
+  }
+`
+
+export {
+  GET_REPO_AUTO_IMPORTS,
+  GET_ALL_REPO_MANUAL_IMPORTS,
+  GET_REPO_MANUAL_IMPORTS,
+  GET_REPO_IMPORT,
+  GET_REPO_IMPORT_CONTAINER
+}

--- a/ui/src/api-logic/graphql/queries/get-repo-syncs.ts
+++ b/ui/src/api-logic/graphql/queries/get-repo-syncs.ts
@@ -46,6 +46,7 @@ const GET_CONTAINER_IMAGES = gql`
       totalCount
     }
     containerImages(
+      orderBy: NAME_ASC
       filter: {
         or: [
           {name: {includesInsensitive: $search}}

--- a/ui/src/api-logic/mappers/repo-container/repo-container-syncs.ts
+++ b/ui/src/api-logic/mappers/repo-container/repo-container-syncs.ts
@@ -66,8 +66,6 @@ const mapToRepoContainerSyncsData = (data: GetContainerSyncsQuery | undefined, r
     syncsData.push(sync)
   })
 
-  console.log('Data: ', syncsData)
-
   return syncsData.sort((a, b) => a.image.name.localeCompare(b.image.name))
 }
 

--- a/ui/src/api-logic/mappers/repo-container/repo-container-syncs.ts
+++ b/ui/src/api-logic/mappers/repo-container/repo-container-syncs.ts
@@ -20,17 +20,18 @@ const mapToRepoContainerSyncsData = (data: GetContainerSyncsQuery | undefined, r
 
     // 2. Sort the syncs
     const sortedSyncs: JobData[] = latestRuns
-      ? getLatestRunOrdered(
-        Object.entries(latestRuns).map(([jobId, jobData]) => ({
-          id: jobId,
-          repoId,
-          syncId: syncData?.id,
-          durationMs: jobData.duration_ms,
-          runningTime: jobData.duration_ms,
-          status: jobData.status,
-          doneAt: jobData.completed_at ? new Date(jobData.completed_at) : undefined
-        }))
-      )
+      ? Object.entries(latestRuns).map(([jobId, jobData]) => ({
+        id: jobId,
+        repoId,
+        syncId: syncData?.id,
+        durationMs: jobData.duration_ms,
+        runningTime: jobData.duration_ms,
+        status: jobData.status,
+        createdAt: jobData.created_at ? new Date(jobData.created_at) : undefined,
+        doneAt: jobData.completed_at ? new Date(jobData.completed_at) : undefined
+      })).sort((a, b) => (
+        (b.createdAt ? b.createdAt.getTime() : new Date().getTime()) - (a.createdAt ? a.createdAt.getTime() : new Date().getTime())
+      ))
       : []
 
     // 3. Get sync info
@@ -65,13 +66,9 @@ const mapToRepoContainerSyncsData = (data: GetContainerSyncsQuery | undefined, r
     syncsData.push(sync)
   })
 
-  return syncsData.sort((a, b) => a.image.name.localeCompare(b.image.name))
-}
+  console.log('Data: ', syncsData)
 
-const getLatestRunOrdered = (latestRuns: JobData[]): JobData[] => {
-  const runningJob = latestRuns.find(job => !job.doneAt)
-  const completedJobs = latestRuns.filter(job => job.doneAt).sort((a, b) => ((b.doneAt ? b.doneAt.getTime() : new Date().getTime()) - (a.doneAt ? a.doneAt.getTime() : new Date().getTime())))
-  return runningJob ? [runningJob, ...completedJobs] : completedJobs
+  return syncsData.sort((a, b) => a.image.name.localeCompare(b.image.name))
 }
 
 export { mapToRepoContainerSyncsData }

--- a/ui/src/pages/repos-containers/git-sources/[gitSourceId].tsx
+++ b/ui/src/pages/repos-containers/git-sources/[gitSourceId].tsx
@@ -1,0 +1,27 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { Fragment } from 'react'
+import { GitSourceDetailProvider } from 'src/state/contexts/git-source-detail.context'
+import { MERGESTAT_TITLE } from 'src/utils/constants'
+import GitSourceDetailView from 'src/views/repo-containers-git-sources/git-source-detail'
+
+const GitSourceDetailPage: NextPage = () => {
+  const router = useRouter()
+  const { gitSourceId } = router.query
+
+  const title = `Git Source ${MERGESTAT_TITLE}`
+
+  return (
+    <Fragment>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <GitSourceDetailProvider>
+        <GitSourceDetailView gitSourceId={gitSourceId} />
+      </GitSourceDetailProvider>
+    </Fragment>
+  )
+}
+
+export default GitSourceDetailPage

--- a/ui/src/pages/repos-containers/git-sources/index.tsx
+++ b/ui/src/pages/repos-containers/git-sources/index.tsx
@@ -1,0 +1,23 @@
+import type { NextPage } from 'next'
+import Head from 'next/head'
+import { Fragment } from 'react'
+import { GitSourcesProvider } from 'src/state/contexts/git-sources.context'
+import { MERGESTAT_TITLE } from 'src/utils/constants'
+import GitSourcesView from 'src/views/repo-containers-git-sources/git-sources'
+
+const GitSourcePage: NextPage = () => {
+  const title = `Git Sources ${MERGESTAT_TITLE}`
+
+  return (
+    <Fragment>
+      <Head>
+        <title>{title}</title>
+      </Head>
+      <GitSourcesProvider>
+        <GitSourcesView />
+      </GitSourcesProvider>
+    </Fragment>
+  )
+}
+
+export default GitSourcePage

--- a/ui/src/state/contexts/git-source-detail.context.tsx
+++ b/ui/src/state/contexts/git-source-detail.context.tsx
@@ -1,6 +1,6 @@
 import { createGenericContext } from 'lib/createGenericContext'
 import React, { PropsWithChildren } from 'react'
-import { GitSourceDetail, ImportSync, RepoImportData, RepoManualImportData } from 'src/@types'
+import { GitSourceDetail, ImportContainerImage, ImportSync, RepoImportData, RepoManualImportData } from 'src/@types'
 
 type GitSourceDetailContext = {
   loading: boolean
@@ -9,6 +9,7 @@ type GitSourceDetailContext = {
   searchImport: string
   searchManualImport: string
   importAuto: ImportSync
+  importAutoContainer: ImportContainerImage
   showAddRepoModal: boolean
   showAutoImportModal: boolean
   showRemoveImportModal: boolean
@@ -34,6 +35,7 @@ const initialState: GitSourceDetailContext = {
   searchImport: '',
   searchManualImport: '',
   importAuto: {} as ImportSync,
+  importAutoContainer: {} as ImportContainerImage,
   showAddRepoModal: false,
   showAutoImportModal: false,
   showRemoveImportModal: false,
@@ -108,6 +110,13 @@ function useGitSourceDetailSetState() {
     setState(prev => ({
       ...prev,
       importAuto
+    }))
+  }
+
+  const setImportAutoContainer = (importAutoContainer: ImportContainerImage) => {
+    setState(prev => ({
+      ...prev,
+      importAutoContainer
     }))
   }
 
@@ -196,6 +205,7 @@ function useGitSourceDetailSetState() {
     setSearchImport,
     setSearchManualImport,
     setImportAuto,
+    setImportAutoContainer,
     setShowAddRepoModal,
     setShowAutoImportModal,
     setShowRemoveImportModal,

--- a/ui/src/views/hooks/gitSourcesContainers/useGitSourceCrumb.tsx
+++ b/ui/src/views/hooks/gitSourcesContainers/useGitSourceCrumb.tsx
@@ -1,0 +1,28 @@
+import { RepositoryIcon } from '@mergestat/icons'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { useGlobalSetState } from 'src/state/contexts'
+
+const useGitSourceCrumb = () => {
+  const router = useRouter()
+  const { setCrumbs } = useGlobalSetState()
+
+  useEffect(() => {
+    const crumbs = [
+      {
+        text: 'Repos',
+        startIcon: <RepositoryIcon className='t-icon t-icon-default' />,
+        onClick: () => router.push('/repos-containers'),
+      },
+      {
+        text: 'Git Sources',
+        onClick: () => router.push('/repos-containers/git-sources'),
+      },
+    ]
+
+    setCrumbs(crumbs)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+}
+
+export default useGitSourceCrumb

--- a/ui/src/views/hooks/gitSourcesContainers/useSyncTypes.ts
+++ b/ui/src/views/hooks/gitSourcesContainers/useSyncTypes.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@apollo/client'
+import { useEffect, useState } from 'react'
+import { ContainerImage } from 'src/@types'
+import { GetAllContainerImagesQuery } from 'src/api-logic/graphql/generated/schema'
+import { GET_ALL_CONTAINER_IMAGES } from 'src/api-logic/graphql/queries/get-git-sources'
+
+const useContainerImages = () => {
+  const [containerImages, setContainerImages] = useState<ContainerImage[]>([])
+
+  const { data } = useQuery<GetAllContainerImagesQuery>(GET_ALL_CONTAINER_IMAGES, {
+    fetchPolicy: 'no-cache',
+  })
+
+  useEffect(() => {
+    const list = data?.containerImages?.nodes.map(ci => ({ id: ci.id, description: ci.description, name: ci.name, checked: false }))
+    setContainerImages(list || [])
+  }, [data])
+
+  return { containerImages, setContainerImages }
+}
+
+export default useContainerImages

--- a/ui/src/views/repo-containers-git-sources/add-source/index.tsx
+++ b/ui/src/views/repo-containers-git-sources/add-source/index.tsx
@@ -1,0 +1,212 @@
+import { useMutation, useQuery } from '@apollo/client'
+import { Alert, Button, HelpText, Input, Label, ListItem, Panel, RadioCard, Toolbar } from '@mergestat/blocks'
+import { BitbucketIcon, BranchIcon, ChevronRightIcon, GithubIcon, GitlabIcon, RepositoryIcon } from '@mergestat/icons'
+import { useRouter } from 'next/router'
+import { ChangeEvent, useEffect, useState } from 'react'
+import { AddGitSourceMutation, GetGitSourcesQuery } from 'src/api-logic/graphql/generated/schema'
+import { ADD_GIT_SOURCE } from 'src/api-logic/graphql/mutations/git-sources'
+import { GET_GIT_SOURCES } from 'src/api-logic/graphql/queries/get-git-sources'
+import Loading from 'src/components/Loading'
+import { useGlobalSetState } from 'src/state/contexts'
+import { getGitSourceIcon } from 'src/utils'
+import { VENDOR_TYPE, VENDOR_URL } from 'src/utils/constants'
+
+const AddSourceView: React.FC = () => {
+  const router = useRouter()
+  const { setCrumbs } = useGlobalSetState()
+
+  const [name, setName] = useState('')
+  const [vendor, setVendor] = useState('')
+  const [errorName, setErrorName] = useState<boolean>(false)
+  const [errorVendor, setErrorVendor] = useState<boolean>(false)
+
+  const [addGitSource] = useMutation(ADD_GIT_SOURCE, {
+    onCompleted: (data: AddGitSourceMutation) => {
+      router.push(`/repos/git-sources/${data.createProvider?.provider?.id}`)
+    }
+  })
+
+  const { loading, data } = useQuery<GetGitSourcesQuery>(GET_GIT_SOURCES, {
+    fetchPolicy: 'no-cache',
+  })
+
+  useEffect(() => {
+    const crumbs = [
+      {
+        text: 'Repos',
+        startIcon: <RepositoryIcon className='t-icon t-icon-default' />,
+        onClick: () => router.push('/repos'),
+      },
+    ]
+
+    setCrumbs(crumbs)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    name && setErrorName(false)
+  }, [name])
+
+  useEffect(() => {
+    vendor && setErrorVendor(false)
+  }, [vendor])
+
+  const handleAddGitSource = () => {
+    if (!name) setErrorName(true)
+    if (!vendor) setErrorVendor(true)
+
+    if (name && vendor) {
+      const vendorUrl = vendor === VENDOR_TYPE.BITBUCKET
+        ? VENDOR_URL.BITBUCKET
+        : vendor === VENDOR_TYPE.GITHUB
+          ? VENDOR_URL.GITHUB
+          : vendor === VENDOR_TYPE.GITLAB ? VENDOR_URL.GITLAB : undefined
+
+      addGitSource({
+        variables: {
+          name,
+          vendor,
+          settings: {
+            url: vendorUrl
+          }
+        }
+      })
+    }
+  }
+
+  return (
+    <div className='flex flex-col flex-1 overflow-hidden'>
+      {/* Header */}
+      <div className='bg-white h-16 w-full border-b px-8'>
+        <Toolbar className='h-full'>
+          <Toolbar.Left>
+            <h2 className='t-h2 mb-0'>Add Repos</h2>
+          </Toolbar.Left>
+        </Toolbar>
+      </div>
+
+      {/* Content */}
+      <div className='p-8 overflow-auto'>
+        {/* Panel: Add git surce */}
+        <Panel className='rounded-md shadow-sm max-w-4xl m-auto'>
+          <Panel.Header>
+            <h4 className='t-panel-title w-full'>Add a Git Source</h4>
+          </Panel.Header>
+          <Panel.Body className='p-6'>
+            <div className=''>
+              <Label className='text-gray-500' aria-required>Git Source name</Label>
+              <Input
+                value={name}
+                variant={errorName ? 'error' : 'default'}
+                placeholder='e.g. My GitHub Repos'
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setName(e.target.value)}
+              />
+              {errorName && (
+                <HelpText variant="error">Name is required</HelpText>
+              )}
+            </div>
+            <div className='mt-6'>
+              <Label className='text-gray-500' aria-required>Choose provider</Label>
+              <div className='flex flex-wrap justify-between'>
+                <RadioCard
+                  isSelected={vendor === VENDOR_TYPE.GITHUB}
+                  label="GitHub"
+                  className='my-2 w-64'
+                  onChange={() => setVendor(VENDOR_TYPE.GITHUB)}
+                  startIcon={<GithubIcon className="t-icon" />}
+                  disabled={!!(data?.github && data?.github?.totalCount > 0)}
+                  tooltip={(data?.github && data?.github?.totalCount > 0)
+                    ? <div className='w-56 p-2'>Currently, only one GitHub Git Source is allowed at a time</div>
+                    : undefined}
+                />
+                <RadioCard
+                  isSelected={vendor === VENDOR_TYPE.BITBUCKET}
+                  label="Bitbucket"
+                  className='my-2 w-64'
+                  onChange={() => setVendor(VENDOR_TYPE.BITBUCKET)}
+                  startIcon={<BitbucketIcon className="t-icon" />}
+                />
+                <RadioCard
+                  isSelected={vendor === VENDOR_TYPE.GITLAB}
+                  label="GitLab"
+                  className='my-2 w-64'
+                  onChange={() => setVendor(VENDOR_TYPE.GITLAB)}
+                  startIcon={<GitlabIcon className="t-icon" />}
+                />
+                <RadioCard
+                  isSelected={vendor === VENDOR_TYPE.GIT}
+                  label="Generic Git"
+                  className='my-2 w-64'
+                  onChange={() => setVendor(VENDOR_TYPE.GIT)}
+                  startIcon={<BranchIcon className="t-icon" />}
+                />
+              </div>
+              {errorVendor && (
+                <HelpText variant="error">Provider is required</HelpText>
+              )}
+            </div>
+          </Panel.Body>
+          <Panel.Footer>
+            <Toolbar className="h-16">
+              <Toolbar.Right>
+                <Toolbar.Item>
+                  <Button skin="primary" onClick={handleAddGitSource} >
+                    Continue
+                  </Button>
+                </Toolbar.Item>
+              </Toolbar.Right>
+            </Toolbar>
+          </Panel.Footer>
+        </Panel>
+
+        {data?.providers && data?.providers.nodes.length > 0 &&
+          <>
+            {/* Divider */}
+            <div className='max-w-4xl m-auto'>
+              <div className='flex justify-center w-full my-6'>
+                <div className='h-0 border-gray-200 border-b-2 mt-3 flex-1'></div>
+                <span className='px-2'>Or</span>
+                <div className='h-0 border-gray-200 border-b-2 mt-3 flex-1'></div>
+              </div>
+            </div>
+
+            {/* Panel: List git surces */}
+            <Panel className='rounded-md shadow-sm max-w-4xl m-auto'>
+              <Panel.Header>
+                <h4 className='t-panel-title w-full'>Existing Git Sources</h4>
+              </Panel.Header>
+              <Panel.Body className='p-6'>
+                <Alert type='default' theme='light' className='mb-6'>
+                  <span>These Git Sources are already configured. Pick from these to add repos to an existing Git Source.</span>
+                </Alert>
+
+                <Panel className='rounded-md shadow-sm max-w-4xl m-auto'>
+                  <Panel.Body className='p-0'>
+                    {loading
+                      ? <Loading />
+                      : data?.providers && data?.providers.nodes.map((provider, index) =>
+                        <ListItem key={`git-source-${index}`}
+                          title={provider.name}
+                          className={'px-4 h-20 border-b'}
+                          startIcon={getGitSourceIcon(provider.vendor)}
+                          onClick={() => router.push(`/repos/git-sources/${provider.id}`)}
+                          action={
+                            <Button label='Go to Git Source' skin="borderless-muted"
+                              className='hover_text-blue-600 font-normal'
+                              endIcon={<ChevronRightIcon className="t-icon" />}
+                              onClick={() => router.push(`/repos/git-sources/${provider.id}`)}
+                            />
+                          }
+                        />
+                      )}
+                  </Panel.Body>
+                </Panel>
+              </Panel.Body>
+            </Panel>
+          </>}
+      </div>
+    </div>
+  )
+}
+
+export default AddSourceView

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/auth/bitbucket.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/auth/bitbucket.tsx
@@ -1,0 +1,99 @@
+import { Badge, Button, Input, Label, Panel } from '@mergestat/blocks'
+import { CheckIcon } from '@mergestat/icons'
+import { ChangeEvent, useState } from 'react'
+import { useGitSourceDetailContext } from 'src/state/contexts/git-source-detail.context'
+import { showSuccessAlert } from 'src/utils/alerts'
+import { LINKS_TO } from 'src/utils/constants'
+import useCredentials from 'src/views/hooks/useCredentials'
+import SettedAuth from './setted-auth'
+
+const BitbucketAuth: React.FC = () => {
+  const [{ gsDetail: { id, auth } }] = useGitSourceDetailContext()
+
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const { addCredential } = useCredentials(() => {
+    showSuccessAlert('Bitbucket access token saved')
+    setUsername('')
+    setPassword('')
+  })
+
+  return (
+    <Panel className='rounded-md shadow-sm m-auto'>
+      <Panel.Header>
+        <div className='w-full flex justify-between'>
+          <h4 className='t-panel-title'>Authentication</h4>
+          {auth?.credentials &&
+            <Badge
+              label='Authentication is set'
+              endIcon={<CheckIcon className="t-icon" />}
+              variant="success"
+            />}
+        </div>
+      </Panel.Header>
+
+      <Panel.Body className='p-6'>
+        {auth && <SettedAuth {...auth} />}
+
+        {!auth && <>
+          <p className='mb-6 t-text-muted'>
+            In order to access the Bitbucket API and any private Bitbucket repos,
+            we need to authenticate with an{' '}
+            <a
+              target='_blank'
+              href={LINKS_TO.createPASS}
+              className='t-link font-semibold'
+              rel='noopener noreferrer'
+            >
+              app password
+            </a>{' '}.
+            Other authentication methods may become available in the future.
+          </p>
+
+          <form className='mb-4'>
+            <Label>Bitbucket username</Label>
+            <Input
+              className='max-w-2xl'
+              type='text'
+              value={username}
+              placeholder="Enter your Bitbucket username"
+              autoComplete='off'
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setUsername(e.target.value)
+              }}
+            />
+
+            <Label className='mt-6'>Bitbucket password</Label>
+            <Input
+              className='max-w-2xl'
+              type='password'
+              value={password}
+              placeholder="Enter your Bitbucket app password"
+              autoComplete='off'
+              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                setPassword(e.target.value)
+              }}
+            />
+          </form>
+
+          <Button
+            label='Save'
+            className='mt-2'
+            disabled={username === '' || password === ''}
+            onClick={() => addCredential({
+              variables: {
+                provider: id,
+                token: password,
+                type: 'BITBUCKET_APP_PASSWORD',
+                username
+              }
+            })}
+          />
+        </>}
+      </Panel.Body>
+    </Panel>
+  )
+}
+
+export default BitbucketAuth

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/auth/git-hub-lab.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/auth/git-hub-lab.tsx
@@ -1,0 +1,124 @@
+import { Badge, Button, Input, Label, Panel } from '@mergestat/blocks'
+import { CheckIcon, CircleCheckFilledIcon, CircleWarningFilledIcon } from '@mergestat/icons'
+import { useGitSourceDetailContext } from 'src/state/contexts/git-source-detail.context'
+import { LINKS_TO, TEST_IDS, VENDOR_TYPE } from 'src/utils/constants'
+import useSetPat from 'src/views/hooks/useSetPat'
+import SettedAuth from './setted-auth'
+
+const GitHubOrLabAuth: React.FC = () => {
+  const [{ gsDetail: { id, auth, vendor } }] = useGitSourceDetailContext()
+
+  const {
+    pat,
+    showValidation,
+    isTokenValid,
+    validatePAT,
+    changeToken,
+    handleSavePAT,
+  } = useSetPat(id, auth, vendor === VENDOR_TYPE.GITHUB)
+
+  return (
+    <Panel className='rounded-md shadow-sm m-auto'>
+      <Panel.Header>
+        <div className='w-full flex justify-between'>
+          <h4 className='t-panel-title'>Authentication</h4>
+          {auth?.credentials &&
+            <Badge
+              label='Token is set'
+              endIcon={<CheckIcon className="t-icon" />}
+              variant="success"
+            />}
+        </div>
+      </Panel.Header>
+
+      <Panel.Body className='p-6'>
+        {auth && <SettedAuth {...auth} />}
+
+        {!auth && <>
+          {vendor === VENDOR_TYPE.GITHUB &&
+            <p className='mb-6 t-text-muted'>
+              In order to access the GitHub API and any private GitHub
+              repos, we need to authenticate with{' '}
+              <a
+                target='_blank'
+                href={LINKS_TO.createGithubPAT}
+                className='t-link font-semibold'
+                rel='noopener noreferrer'
+              >
+                a (classic) personal access token
+              </a>{' '}
+              (PAT). Other authentication methods (such as an OAuth based
+              flow) may become available in the future.
+            </p>}
+
+          {vendor === VENDOR_TYPE.GITLAB &&
+            <p className='mb-6 t-text-muted'>
+              In order to access the GitLab API and any private GitLab repositories,
+              we need to authenticate with an{' '}
+              <a
+                target='_blank'
+                href={LINKS_TO.createGitlabPAT}
+                className='t-link font-semibold'
+                rel='noopener noreferrer'
+              >
+                API Access Token
+              </a>.{' '}
+            </p>}
+
+          <form className='mb-4'>
+            <div className='flex flex-col mt-8 mb-5'>
+              {vendor === VENDOR_TYPE.GITHUB && <Label>GitHub personal access token</Label>}
+              {vendor === VENDOR_TYPE.GITLAB && <Label>API Access Token</Label>}
+              <div className='flex space-x-2'>
+                <Input
+                  className='max-w-lg'
+                  data-testid={TEST_IDS.patInputText}
+                  placeholder={vendor === VENDOR_TYPE.GITHUB ? 'ghp_s0mEsecReTt0k3n' : 'glpat-s0mEsecReTt0k3n'}
+                  type='password'
+                  autoComplete='off'
+                  value={pat}
+                  onChange={changeToken}
+                  onKeyPress={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault()
+                      handleSavePAT()
+                    }
+                  }}
+                />
+                <Button
+                  label='Validate'
+                  skin='secondary'
+                  disabled={pat === ''}
+                  data-testid={TEST_IDS.patValidateToken}
+                  onClick={validatePAT}
+                />
+
+                {showValidation && isTokenValid && (
+                  <div className='flex items-center'>
+                    <CircleCheckFilledIcon className='t-icon t-icon-success flex-shrink-0' />
+                    <p className='text-green-700 ml-1.5'>Token valid</p>
+                  </div>
+                )}
+                {showValidation && !isTokenValid && (
+                  <div className='flex items-center'>
+                    <CircleWarningFilledIcon className='t-icon t-icon-danger flex-shrink-0' />
+                    <p className='text-red-700 ml-1.5'>Token invalid</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </form>
+
+          <Button
+            label='Save'
+            disabled={pat === ''}
+            data-testid={TEST_IDS.patSetToken}
+            onClick={handleSavePAT}
+          />
+        </>}
+      </Panel.Body>
+    </Panel>
+  )
+}
+
+export default GitHubOrLabAuth

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/auth/setted-auth.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/auth/setted-auth.tsx
@@ -1,0 +1,28 @@
+import { ListItem, Panel } from '@mergestat/blocks'
+import { KeyIcon } from '@mergestat/icons'
+import { useState } from 'react'
+import { AuthDetail } from 'src/@types'
+import { RemoveAuthModal } from '../../modals/remove-auth-credential'
+
+const SettedAuth: React.FC<AuthDetail> = ({ id, createdAt }: AuthDetail) => {
+  const [showRemoveAuthModal, setShowRemoveAuthModal] = useState(false)
+
+  return (
+    <>
+      <Panel className='rounded-md shadow-sm m-auto'>
+        <Panel.Body className='p-4'>
+          <ListItem
+            title={`Authenticated on ${createdAt}`}
+            className={'p-2'}
+            startIcon={<KeyIcon className='t-icon t-icon-muted' />}
+            onTrashClick={() => setShowRemoveAuthModal(true)}
+          />
+        </Panel.Body>
+      </Panel>
+
+      {showRemoveAuthModal && <RemoveAuthModal id={id} setShowRemoveAuthModal={setShowRemoveAuthModal} />}
+    </>
+  )
+}
+
+export default SettedAuth

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/default-syncs-table.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/default-syncs-table.tsx
@@ -1,0 +1,57 @@
+import { ListItem, Toggle } from '@mergestat/blocks'
+import { TableIcon } from '@mergestat/icons'
+import { useRouter } from 'next/router'
+import React, { PropsWithChildren } from 'react'
+import { DefaultRepoSync } from 'src/@types'
+import { NoDataFound } from 'src/views/shared/no-data-found'
+
+type DefaultSyncsTableProps = PropsWithChildren<{
+  defaultSyncs: DefaultRepoSync[]
+}>
+
+export const DefaultSyncsTable: React.FC<DefaultSyncsTableProps> = ({ defaultSyncs }: DefaultSyncsTableProps) => {
+  const router = useRouter()
+
+  return (
+    <div className='flex flex-col flex-1 overflow-hidden'>
+      {defaultSyncs.length < 1
+        ? <NoDataFound message='Couldn&#39;t find any default repo sync.' />
+        : <div className='flex flex-col min-w-0 bg-white h-full'>
+          <div className='flex-1 overflow-x-auto overflow-y-hidden'>
+            <table className='t-table-default t-table-hover border-b'>
+              <thead>
+                <tr className='bg-white'>
+                  <th scope='col' key='data' className='whitespace-nowrap'>Name</th>
+                  <th scope='col' key='enabled' className='whitespace-nowrap'>Enabled by default</th>
+                </tr>
+              </thead>
+
+              <tbody className='bg-white'>
+                {defaultSyncs.map((sync, index) => (
+                  <tr key={sync.id ?? `${sync.id}-${index}`}>
+                    <td className='min-w-sm h-20'>
+                      <ListItem key={`container-sync-${index}`}
+                        title={sync.name}
+                        subline={sync.description || ''}
+                        className={'px-4 py-2'}
+                        startIcon={<TableIcon className='t-icon' />}
+                        onClick={() => router.push(`/repos/repo-syncs/${sync.id}`)}
+                      />
+                    </td>
+                    <td className='w-0'>
+                      <div className='flex items-center justify-center'>
+                        <Toggle
+                          isChecked={!!sync.enabled}
+                          onChange={() => null}
+                        />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>}
+    </div>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/components/auto-import-table.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/components/auto-import-table.tsx
@@ -1,0 +1,98 @@
+import { Button, ListItem, Tooltip } from '@mergestat/blocks'
+import { CircleCheckFilledIcon, CircleErrorFilledIcon, ClockIcon, TrashIcon } from '@mergestat/icons'
+import React from 'react'
+import { RepoImportData } from 'src/@types'
+import RepoImage from 'src/components/RepoImage'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { IMPORT_STATUS_TYPE } from 'src/utils/constants'
+import { NoDataFound } from 'src/views/shared/no-data-found'
+import { RemoveAutoImportModal } from '../../../modals/remove-auto-import'
+import { UpdateAutoImportModal } from '../../../modals/update-auto-import'
+
+type AutoImportTableProps = {
+  imports: RepoImportData[]
+}
+
+export const AutoImportTable: React.FC<AutoImportTableProps> = ({ imports }: AutoImportTableProps) => {
+  const { setShowRemoveImportModal, setShowAutoImportModal, setImportInfo } = useGitSourceDetailSetState()
+  const [{ showAutoImportModal, showRemoveImportModal }] = useGitSourceDetailContext()
+
+  const prepareToRemove = (importInfo: RepoImportData) => {
+    setImportInfo(importInfo)
+    setShowRemoveImportModal(true)
+  }
+
+  const prepareToEdit = (importInfo: RepoImportData) => {
+    setImportInfo(importInfo)
+    setShowAutoImportModal(true)
+  }
+
+  const getIconStatus = (status: string) => (
+    status === IMPORT_STATUS_TYPE.SUCCESS
+      ? <CircleCheckFilledIcon className="t-icon t-icon-success m-auto" />
+      : status === IMPORT_STATUS_TYPE.FAILURE
+        ? <CircleErrorFilledIcon className="t-icon t-icon-danger m-auto" />
+        : <ClockIcon className='t-icon t-icon-muted m-auto' />
+  )
+
+  return (
+    <>
+      <div className='flex flex-col flex-1'>
+        {imports?.length < 1
+          ? <NoDataFound message='Couldn&#39;t find any auto import.' />
+          : <>
+            <div className='flex flex-col min-w-0 bg-gray-50 h-full'>
+              <div className='flex-1 overflow-x-auto overflow-y-hidden'>
+                <table className='t-table-default t-table-hover border-b'>
+                  <thead>
+                    <tr className='bg-white'>
+                      <th scope='col' key='status' className='whitespace-nowrap'>Status</th>
+                      <th scope='col' key='auto-import' className='whitespace-nowrap'>Auto import</th>
+                      <th scope='col' key='repos' className='whitespace-nowrap'>Repos</th>
+                      <th scope='col' key='remove' className='whitespace-nowrap px-4'></th>
+                    </tr>
+                  </thead>
+
+                  <tbody className='bg-white'>
+                    {imports.map((imp, index) => (
+                      <tr key={imp.id}>
+                        <td className='w-0 h-20'>
+                          {imp.importError && <Tooltip content={imp.importError} placement='bottom'>
+                            {getIconStatus(imp.status)}
+                          </Tooltip>}
+                          {!imp.importError && getIconStatus(imp.status)}
+                        </td>
+                        <td>
+                          <ListItem key={`auto-import-${index}`}
+                            title={imp.name}
+                            subline={imp.type}
+                            startIcon={<RepoImage vendor={imp.vendor} vendorUrl={imp.vendorUrl} orgName={imp.name} size="10" />}
+                            onClick={() => prepareToEdit(imp)}
+                          />
+                        </td>
+                        <td className='t-text-muted'>
+                          {imp.totalRepos}
+                        </td>
+                        <td className='t-text-muted'>
+                          <div className='t-button-toolbar'>
+                            <Button isIconOnly
+                              skin="borderless-muted"
+                              startIcon={<TrashIcon className="t-icon" />}
+                              onClick={() => prepareToRemove(imp)} />
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        }
+      </div>
+
+      {showAutoImportModal && <UpdateAutoImportModal />}
+      {showRemoveImportModal && <RemoveAutoImportModal />}
+    </>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/components/manual-import-table.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/components/manual-import-table.tsx
@@ -1,0 +1,73 @@
+import { Button, ListItem } from '@mergestat/blocks'
+import { TrashIcon } from '@mergestat/icons'
+import React from 'react'
+import { RepoManualImportData } from 'src/@types'
+import RepoImage from 'src/components/RepoImage'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { NoDataFound } from 'src/views/shared/no-data-found'
+import { RemoveManualImportModal } from '../../../modals/remove-manual-import'
+import { useRouter } from 'next/router'
+
+type ManualImportTableProps = {
+  repos: RepoManualImportData[]
+}
+
+export const ManualImportTable: React.FC<ManualImportTableProps> = ({ repos }: ManualImportTableProps) => {
+  const router = useRouter()
+
+  const { setShowRemoveImportModal, setRepoInfo } = useGitSourceDetailSetState()
+  const [{ showRemoveImportModal }] = useGitSourceDetailContext()
+
+  const prepareToRemove = (repoInfo: RepoManualImportData) => {
+    setRepoInfo(repoInfo)
+    setShowRemoveImportModal(true)
+  }
+
+  return (
+    <>
+      <div className='flex flex-col flex-1'>
+        {repos?.length < 1
+          ? <NoDataFound message='Couldn&#39;t find any repos.' />
+          : <>
+            <div className='flex flex-col min-w-0 bg-gray-50 h-full'>
+              <div className='flex-1 overflow-x-auto overflow-y-hidden'>
+                <table className='t-table-default t-table-hover border-b'>
+                  <thead>
+                    <tr className='bg-white'>
+                      <th scope='col' key='repo' className='whitespace-nowrap'>Repo</th>
+                      <th scope='col' key='remove' className='whitespace-nowrap px-4'></th>
+                    </tr>
+                  </thead>
+
+                  <tbody className='bg-white'>
+                    {repos.map((repo, index) => (
+                      <tr key={repo.id}>
+                        <td className='p-3'>
+                          <ListItem key={`repo-manual-${index}`}
+                            title={repo.name}
+                            startIcon={<RepoImage vendor={repo.vendor} vendorUrl={repo.vendorUrl} orgName={repo.name.split('/')[0]} size="10" />}
+                            onClick={() => router.push(`/repos/${repo.id}`)}
+                          />
+                        </td>
+                        <td className='text-gray-500 p-3 pr-8'>
+                          <div className='t-button-toolbar'>
+                            <Button isIconOnly
+                              skin="borderless-muted"
+                              startIcon={<TrashIcon className="t-icon" />}
+                              onClick={() => prepareToRemove(repo)} />
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </>
+        }
+      </div>
+
+      {showRemoveImportModal && <RemoveManualImportModal />}
+    </>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/index.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/index.tsx
@@ -1,0 +1,40 @@
+import { Panel, Tabs } from '@mergestat/blocks'
+import { useGitSourceDetailContext } from 'src/state/contexts/git-source-detail.context'
+import { VENDOR_TYPE } from 'src/utils/constants'
+import ReposAuto from './tabs/repos-auto'
+import ReposManual from './tabs/repos-manual'
+
+const ReposAutoManual: React.FC = () => {
+  const [{ gsDetail: { auto, totalManual, vendor } }] = useGitSourceDetailContext()
+
+  return (
+    <Panel className='rounded-md shadow-sm m-auto mt-6'>
+      <Panel.Header className='border-b-0 h-14'>
+        <div className='w-full flex justify-between'>
+          <h4 className='t-panel-title'>Repos</h4>
+        </div>
+      </Panel.Header>
+
+      <Panel.Body className='p-0'>
+        <Tabs>
+          <Tabs.List className='border-b px-6'>
+            <>{vendor !== VENDOR_TYPE.GIT && <Tabs.Item>{`Auto (${auto?.length || 0})`}</Tabs.Item>}</>
+            <Tabs.Item>{`Manual (${totalManual})`}</Tabs.Item>
+          </Tabs.List>
+          <Tabs.Panels className="h-full bg-gray-50 overflow-auto">
+            <>{vendor !== VENDOR_TYPE.GIT &&
+              <Tabs.Panel>
+                <ReposAuto />
+              </Tabs.Panel>
+            }</>
+            <Tabs.Panel>
+              <ReposManual />
+            </Tabs.Panel>
+          </Tabs.Panels>
+        </Tabs>
+      </Panel.Body>
+    </Panel>
+  )
+}
+
+export default ReposAutoManual

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/tabs/repos-auto.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/tabs/repos-auto.tsx
@@ -1,0 +1,111 @@
+import { Alert, Button, Dropdown, Input, Label, Menu, Panel } from '@mergestat/blocks'
+import { CaretDownIcon, PlusIcon } from '@mergestat/icons'
+import cx from 'classnames'
+import { useEffect, useState } from 'react'
+import Loading from 'src/components/Loading'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { capitalize, getVendor, getVendorLabelType } from 'src/utils'
+import { SYNC_REPO_METHOD, VENDOR_TYPE } from 'src/utils/constants'
+import useRepoImports from 'src/views/hooks/gitSources/useRepoImports'
+import useContainerImages from 'src/views/hooks/gitSourcesContainers/useSyncTypes'
+import { FilterHeader } from 'src/views/shared/filter-header'
+import { AddRepoImportModal } from '../../../modals/add-repo-import'
+import { AutoImportTable } from '../components/auto-import-table'
+
+const ReposAuto: React.FC = () => {
+  const { containerImages } = useContainerImages()
+  const [{ showAddRepoModal, searchImport, gsDetail: { vendor } }] = useGitSourceDetailContext()
+  const { setImportAutoContainer, setShowAddRepoModal, setSearchImport } = useGitSourceDetailSetState()
+
+  const { loading, imports, records } = useRepoImports()
+
+  const [importType, setImportType] = useState('')
+  const [userOrOrg, setUserOrOrg] = useState('')
+
+  const addImport = () => {
+    setImportAutoContainer({ name: userOrOrg, type: importType, defaultSyncs: containerImages })
+    setImportType(vendor === VENDOR_TYPE.GITHUB ? SYNC_REPO_METHOD.GH_ORG : SYNC_REPO_METHOD.GL_GROUP)
+    setUserOrOrg('')
+    setShowAddRepoModal(true)
+  }
+
+  useEffect(() => {
+    setImportType(vendor === VENDOR_TYPE.GITHUB ? SYNC_REPO_METHOD.GH_ORG : SYNC_REPO_METHOD.GL_GROUP)
+  }, [vendor])
+
+  return (
+    <>
+      <div className='bg-white p-6'>
+        <Alert type="default" className="bg-gray-50 mb-6">
+          {`Auto imports run on a schedule and bring in all repos from a ${getVendor(vendor)} ${getVendorLabelType(vendor)} or user.`}
+        </Alert>
+
+        {vendor === VENDOR_TYPE.BITBUCKET && <Label className='text-gray-500'>Owner</Label>}
+        <div className='flex items-center gap-2 mb-2'>
+          <div className={cx('flex-1', { 't-input-with-prepend': vendor !== VENDOR_TYPE.BITBUCKET })}>
+            {vendor !== VENDOR_TYPE.BITBUCKET && <Dropdown
+              alignEnd
+              trigger={
+                <Button isBlockBetween
+                  label={(importType === SYNC_REPO_METHOD.GH_ORG || importType === SYNC_REPO_METHOD.GL_GROUP) ? capitalize(getVendorLabelType(vendor)) : 'User'}
+                  endIcon={<CaretDownIcon className='t-icon' />}
+                  className='w-40'
+                  skin='secondary'
+                />
+              }
+              overlay={(close) => (
+                <Menu className='whitespace-nowrap w-full'>
+                  <Menu.Item text={capitalize(getVendorLabelType(vendor))} onClick={() => {
+                    vendor === VENDOR_TYPE.GITHUB ? setImportType(SYNC_REPO_METHOD.GH_ORG) : setImportType(SYNC_REPO_METHOD.GL_GROUP)
+                    close()
+                  }} />
+                  <Menu.Item text='User' onClick={() => {
+                    vendor === VENDOR_TYPE.GITHUB ? setImportType(SYNC_REPO_METHOD.GH_USER) : setImportType(SYNC_REPO_METHOD.GL_USER)
+                    close()
+                  }} />
+                </Menu>
+              )}
+            />}
+            <Input
+              id='orgName'
+              type='text'
+              value={userOrOrg}
+              onChange={(e) => setUserOrOrg(e.target.value)}
+              placeholder={vendor !== VENDOR_TYPE.BITBUCKET ? ((importType === SYNC_REPO_METHOD.GH_ORG || importType === SYNC_REPO_METHOD.GL_GROUP) ? `${getVendorLabelType(vendor)}-name` : 'user-name') : 'user or organization'}
+              onKeyPress={(e) => (e.key === 'Enter' && addImport())}
+            />
+          </div>
+          <Button
+            label='Add'
+            disabled={!userOrOrg}
+            className='whitespace-nowrap'
+            startIcon={<PlusIcon className='t-icon' />}
+            onClick={addImport}
+          />
+        </div>
+      </div>
+
+      {/** Auto Import Table */}
+      {records && <FilterHeader initValue={searchImport} setSearch={setSearchImport} />}
+
+      {loading
+        ? <Loading />
+        : records
+          ? <AutoImportTable imports={imports} />
+          : <div className='bg-white p-6 pt-0'>
+            <Panel className='rounded-md shadow-sm'>
+              <Panel.Body className='p-12 m-auto'>
+                <span className='text-gray-500'>
+                  {`Enter ${getVendor(vendor)} organization or username`}
+                </span>
+              </Panel.Body>
+            </Panel>
+          </div>
+      }
+
+      {showAddRepoModal && <AddRepoImportModal />}
+    </>
+  )
+}
+
+export default ReposAuto

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/tabs/repos-manual.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/repos/tabs/repos-manual.tsx
@@ -1,0 +1,110 @@
+import { Alert, Button, Input, Label, Panel, Textarea } from '@mergestat/blocks'
+import { ChevronDownIcon, ChevronUpIcon, PlusIcon } from '@mergestat/icons'
+import { ChangeEvent, useState } from 'react'
+import Loading from 'src/components/Loading'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { getVendor } from 'src/utils'
+import { VENDOR_TYPE, VENDOR_URL } from 'src/utils/constants'
+import useAddRepos from 'src/views/hooks/gitSources/useAddRepos'
+import useRepoManualImports from 'src/views/hooks/gitSources/useRepoManualImports'
+import { FilterFooter } from 'src/views/shared/filter-footer'
+import { FilterHeader } from 'src/views/shared/filter-header'
+import { ManualImportTable } from '../components/manual-import-table'
+
+const ReposManual: React.FC = () => {
+  const [{ gsDetail: { vendor }, rowsManualRepos, pageManualRepos, totalManualRepos, searchManualImport, showBulk }] = useGitSourceDetailContext()
+  const { setSearchManualImport, setRowsManualRepos, setPageManualRepos, setShowBulk } = useGitSourceDetailSetState()
+  const { loading, repos, records } = useRepoManualImports()
+  const { addFromURL, addFromCSV } = useAddRepos()
+
+  const [url, setUrl] = useState('')
+  const [urls, setUrls] = useState('')
+
+  const addRepos = () => {
+    if (showBulk) {
+      addFromCSV(urls)
+      setUrls('')
+    } else {
+      addFromURL(url)
+      setUrl('')
+    }
+  }
+
+  const getVendorUrl = () => {
+    return vendor === VENDOR_TYPE.BITBUCKET
+      ? VENDOR_URL.BITBUCKET
+      : vendor === VENDOR_TYPE.GITHUB
+        ? VENDOR_URL.GITHUB
+        : vendor === VENDOR_TYPE.GITLAB ? VENDOR_URL.GITLAB : VENDOR_URL.GITHUB
+  }
+
+  return (
+    <>
+      <div className='bg-white p-6'>
+        <Alert type="default" className="bg-gray-50 mb-6">
+          Manual repos are added directly to this Git Source.
+        </Alert>
+
+        <Label>Repo url(s)</Label>
+        <div className='flex items-start gap-2 mb-2'>
+          <div className='flex-1'>
+            {showBulk
+              ? <Textarea className="h-60" value={urls}
+                onChange={(e: ChangeEvent<HTMLTextAreaElement>) => setUrls(e.target.value)}
+              />
+              : <Input
+                id='url'
+                type='text'
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder={`${getVendorUrl()}/owner/repo`}
+                onKeyPress={(e) => (e.key === 'Enter' && addFromURL(url))}
+              />}
+          </div>
+          <Button
+            label='Add'
+            disabled={showBulk ? !urls : !url}
+            className='whitespace-nowrap'
+            startIcon={<PlusIcon className='t-icon' />}
+            onClick={addRepos}
+          />
+        </div>
+        <Button
+          label={showBulk ? 'Hide bulk add' : 'Bulk add'}
+          skin='borderless'
+          size='small'
+          className='whitespace-nowrap text-blue-600'
+          endIcon={showBulk ? <ChevronUpIcon className='t-icon' /> : <ChevronDownIcon className='t-icon' />}
+          onClick={() => setShowBulk(!showBulk)}
+        />
+      </div>
+
+      {/** Manual Import Table */}
+      {records && <div className='border-t pt-2'>
+        <FilterHeader initValue={searchManualImport} setSearch={setSearchManualImport} />
+      </div>}
+
+      {loading
+        ? <div className='my-14'><Loading /></div>
+        : records
+          ? <ManualImportTable repos={repos} />
+          : <div className='bg-white p-6 pt-0'>
+            <Panel className='rounded-md shadow-sm'>
+              <Panel.Body className='p-12 m-auto'>
+                <span className='text-gray-500'>{`Enter ${getVendor(vendor)} repo url`}</span>
+              </Panel.Body>
+            </Panel>
+          </div>
+      }
+      {records && <FilterFooter
+        total={totalManualRepos}
+        rows={rowsManualRepos}
+        page={pageManualRepos}
+        setRows={setRowsManualRepos}
+        setPage={setPageManualRepos}
+      />}
+    </>
+  )
+}
+
+export default ReposManual

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/components/stats.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/components/stats.tsx
@@ -1,0 +1,52 @@
+import { ColoredBox, Stat } from '@mergestat/blocks'
+import { AutoImportIcon, RepositoryIcon } from '@mergestat/icons'
+import { MetricNumber } from 'src/views/shared/metric-number'
+
+type GitSourceStatsProps = {
+  loading: boolean
+  totalAuto: number
+  totalManual: number
+  totalRepos: number
+}
+
+const GitSourceStats: React.FC<GitSourceStatsProps> = ({ loading, totalAuto, totalManual, totalRepos }: GitSourceStatsProps) => {
+  return (
+    <div className='md_grid md_grid-cols-3 gap-6 space-y-4 md_space-y-0 mb-6'>
+      <Stat className='shadow-sm w-full'>
+        <Stat.Left>
+          <Stat.Label>Total repos</Stat.Label>
+          <Stat.Number>
+            <MetricNumber loading={loading} metric={totalRepos || 0} />
+          </Stat.Number>
+        </Stat.Left>
+        <Stat.Right>
+          <ColoredBox size='12'><RepositoryIcon className='t-icon t-icon-default' /></ColoredBox>
+        </Stat.Right>
+      </Stat>
+      <Stat className='shadow-sm w-full'>
+        <Stat.Left>
+          <Stat.Label>Repos from auto imports</Stat.Label>
+          <Stat.Number>
+            <MetricNumber loading={loading} metric={totalAuto || 0} />
+          </Stat.Number>
+        </Stat.Left>
+        <Stat.Right>
+          <ColoredBox size='12'><AutoImportIcon className='t-icon t-icon-default' /></ColoredBox>
+        </Stat.Right>
+      </Stat>
+      <Stat className='shadow-sm w-full'>
+        <Stat.Left>
+          <Stat.Label>Repos added manually</Stat.Label>
+          <Stat.Number>
+            <MetricNumber loading={loading} metric={totalManual || 0} />
+          </Stat.Number>
+        </Stat.Left>
+        <Stat.Right>
+          <ColoredBox size='12'><RepositoryIcon className='t-icon t-icon-default' /></ColoredBox>
+        </Stat.Right>
+      </Stat>
+    </div>
+  )
+}
+
+export default GitSourceStats

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/index.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/index.tsx
@@ -1,9 +1,9 @@
 import { Button, EditableText, Tabs, Toolbar } from '@mergestat/blocks'
 import { ChangeEvent } from 'react'
 import { getGitSourceIcon } from 'src/utils'
-import useGitSourceCrumb from 'src/views/hooks/gitSources/useGitSourceCrumb'
 import useGitSourceDetail from 'src/views/hooks/gitSources/useGitSourceDetail'
 import useGitSourceUpdate from 'src/views/hooks/gitSources/useGitSourceUpdate'
+import useGitSourceCrumb from 'src/views/hooks/gitSourcesContainers/useGitSourceCrumb'
 import GitSourceOverviewTab from './tabs/overview'
 import GitSourceSettingsTab from './tabs/settings'
 

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/index.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/index.tsx
@@ -1,0 +1,74 @@
+import { Button, EditableText, Tabs, Toolbar } from '@mergestat/blocks'
+import { ChangeEvent } from 'react'
+import { getGitSourceIcon } from 'src/utils'
+import useGitSourceCrumb from 'src/views/hooks/gitSources/useGitSourceCrumb'
+import useGitSourceDetail from 'src/views/hooks/gitSources/useGitSourceDetail'
+import useGitSourceUpdate from 'src/views/hooks/gitSources/useGitSourceUpdate'
+import GitSourceOverviewTab from './tabs/overview'
+import GitSourceSettingsTab from './tabs/settings'
+
+type GitSourceDetailView = {
+  gitSourceId?: string | string[]
+}
+
+const GitSourceDetailView: React.FC<GitSourceDetailView> = ({ gitSourceId }: GitSourceDetailView) => {
+  useGitSourceDetail(gitSourceId)
+  useGitSourceCrumb()
+
+  const { vendor, nameGS, descriptionGS, setNameGS, setDescriptionGS, updateGitSource } = useGitSourceUpdate()
+
+  return (
+    <div className='flex flex-col h-full overflow-hidden'>
+      <Toolbar className='bg-white px-8 pt-4'>
+        <Toolbar.Left className='flex-grow'>
+          <EditableText
+            className='flex-grow mr-5'
+            icon={getGitSourceIcon(vendor || '')}
+            title={{
+              value: nameGS || '',
+              onChange: (e: ChangeEvent<HTMLInputElement>) => setNameGS(e.target.value)
+            }}
+            desc={{
+              value: descriptionGS || '',
+              placeholder: 'This is a short description',
+              onChange: (e: ChangeEvent<HTMLInputElement>) => setDescriptionGS(e.target.value)
+            }}
+          />
+        </Toolbar.Left>
+        <Toolbar.Right className='flex-none'>
+          <Button
+            className='whitespace-nowrap justify-center'
+            label='Save'
+            skin="secondary"
+            onClick={updateGitSource}
+          />
+        </Toolbar.Right>
+      </Toolbar>
+
+      <div className='flex flex-col flex-1 overflow-hidden'>
+        <Tabs>
+          <Tabs.List className='border-b px-8 bg-white'>
+            <Tabs.Item>Overview</Tabs.Item>
+            {/* <Tabs.Item>Default Repo Syncs</Tabs.Item> */}
+            <Tabs.Item>Settings</Tabs.Item>
+          </Tabs.List>
+          <Tabs.Panels className="bg-gray-50 flex-1 overflow-auto">
+            <Tabs.Panel className='p-8'>
+              <GitSourceOverviewTab />
+            </Tabs.Panel>
+            {/* <Tabs.Panel className='p-0 h-full flex flex-col'>
+              <DefaultRepoSyncsProvider>
+                <DefaultRepoSyncs />
+              </DefaultRepoSyncsProvider>
+            </Tabs.Panel> */}
+            <Tabs.Panel className='p-8'>
+              <GitSourceSettingsTab />
+            </Tabs.Panel>
+          </Tabs.Panels>
+        </Tabs>
+      </div>
+    </div>
+  )
+}
+
+export default GitSourceDetailView

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/modals/add-repo-import.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/modals/add-repo-import.tsx
@@ -1,0 +1,99 @@
+import { useMutation } from '@apollo/client'
+import { Alert, Button, Checkbox, Modal, Toolbar } from '@mergestat/blocks'
+import { XIcon } from '@mergestat/icons'
+import React, { useCallback } from 'react'
+import { AUTO_IMPORT_REPOS } from 'src/api-logic/graphql/mutations/add-repo'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { showSuccessAlert } from 'src/utils/alerts'
+
+export const AddRepoImportModal: React.FC = () => {
+  const { setImportAutoContainer, setShowAddRepoModal } = useGitSourceDetailSetState()
+  const [{ gsDetail: { id, vendor }, importAutoContainer }] = useGitSourceDetailContext()
+
+  const close = useCallback(() => {
+    setShowAddRepoModal(false)
+  }, [setShowAddRepoModal])
+
+  const [autoImportRepos] = useMutation(AUTO_IMPORT_REPOS, {
+    onCompleted: () => {
+      showSuccessAlert('Repo auto import added')
+      close()
+    },
+    awaitRefetchQueries: true,
+    refetchQueries: () => ['getGitSource', 'getRepoImports']
+  })
+
+  const handleCheckBox = (id: string) => {
+    const newDefaults = importAutoContainer.defaultSyncs.map((ci) => {
+      if (ci.id === id) {
+        return { ...ci, checked: !ci.checked }
+      }
+      return ci
+    })
+    setImportAutoContainer({ ...importAutoContainer, defaultSyncs: newDefaults })
+  }
+
+  const addImport = () => {
+    const defaultSyncs = importAutoContainer.defaultSyncs.filter(ds => ds.checked).map(ds => ds.id)
+    let settings
+
+    autoImportRepos({ variables: { settings, provider: id } })
+  }
+
+  return (
+    <Modal open onClose={close} size="lg">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>Default syncs</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body>
+        <Alert type='info' className='m-6' title='Default syncs are enabled for repos this auto-import brings in.'>
+          These syncs are automatically enabled for all repos that are imported from this GitHub organization or user. <a className='font-medium cursor-pointer' target='_blank' rel='noreferrer' href='https://docs.mergestat.com/mergestat/setup/repo-auto-imports'>Learn more</a>.
+        </Alert>
+
+        <table className='t-table-default t-table-hover'>
+          <tbody className='bg-white'>
+            {importAutoContainer.defaultSyncs.map((ci, index) => (
+              <tr key={index} onClick={() => handleCheckBox(ci.id)}>
+                <td className='py-3 pl-8 pr-4 w-0'>
+                  <Checkbox
+                    checked={ci.checked}
+                    onChange={() => handleCheckBox(ci.id)}
+                  />
+                </td>
+                <td className='py-3 pl-4 pr-8'>
+                  <h4 className='font-medium mb-0.5'>{ci.name}</h4>
+                  <p className='t-text-muted text-sm'>{ci.description}</p>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button label='Cancel' className="my-3 mr-3" skin="secondary" onClick={close} />
+              <Button label='Add Auto Import' className="my-3" skin="primary" onClick={addImport} />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/modals/add-repo-import.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/modals/add-repo-import.tsx
@@ -1,20 +1,24 @@
 import { useMutation } from '@apollo/client'
 import { Alert, Button, Checkbox, Modal, Toolbar } from '@mergestat/blocks'
-import { XIcon } from '@mergestat/icons'
+import { CogIcon, TableIcon, XIcon } from '@mergestat/icons'
+import { useRouter } from 'next/router'
 import React, { useCallback } from 'react'
-import { AUTO_IMPORT_REPOS } from 'src/api-logic/graphql/mutations/add-repo'
+import { AUTO_IMPORT_REPOS_CONTAINER } from 'src/api-logic/graphql/mutations/add-repo'
 import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
 import { showSuccessAlert } from 'src/utils/alerts'
+import { EmptyData } from 'src/views/shared/empty-data'
 
 export const AddRepoImportModal: React.FC = () => {
+  const router = useRouter()
+
   const { setImportAutoContainer, setShowAddRepoModal } = useGitSourceDetailSetState()
-  const [{ gsDetail: { id, vendor }, importAutoContainer }] = useGitSourceDetailContext()
+  const [{ gsDetail: { id }, importAutoContainer }] = useGitSourceDetailContext()
 
   const close = useCallback(() => {
     setShowAddRepoModal(false)
   }, [setShowAddRepoModal])
 
-  const [autoImportRepos] = useMutation(AUTO_IMPORT_REPOS, {
+  const [autoImportRepos] = useMutation(AUTO_IMPORT_REPOS_CONTAINER, {
     onCompleted: () => {
       showSuccessAlert('Repo auto import added')
       close()
@@ -35,9 +39,15 @@ export const AddRepoImportModal: React.FC = () => {
 
   const addImport = () => {
     const defaultSyncs = importAutoContainer.defaultSyncs.filter(ds => ds.checked).map(ds => ds.id)
-    let settings
 
-    autoImportRepos({ variables: { settings, provider: id } })
+    autoImportRepos({
+      variables: {
+        providerId: id,
+        importType: importAutoContainer.type,
+        importTypeName: importAutoContainer.name,
+        defaultContainerImageIds: defaultSyncs
+      }
+    })
   }
 
   return (
@@ -61,28 +71,49 @@ export const AddRepoImportModal: React.FC = () => {
         </Toolbar>
       </Modal.Header>
       <Modal.Body>
-        <Alert type='info' className='m-6' title='Default syncs are enabled for repos this auto-import brings in.'>
-          These syncs are automatically enabled for all repos that are imported from this GitHub organization or user. <a className='font-medium cursor-pointer' target='_blank' rel='noreferrer' href='https://docs.mergestat.com/mergestat/setup/repo-auto-imports'>Learn more</a>.
-        </Alert>
+        {importAutoContainer.defaultSyncs.length > 0 &&
+          <>
+            <Alert type='info' className='m-6' title='Default syncs are enabled for repos this auto-import brings in.'>
+              These syncs are automatically enabled for all repos that are imported from this GitHub organization or user. <a className='font-medium cursor-pointer' target='_blank' rel='noreferrer' href='https://docs.mergestat.com/mergestat/setup/repo-auto-imports'>Learn more</a>.
+            </Alert>
 
-        <table className='t-table-default t-table-hover'>
-          <tbody className='bg-white'>
-            {importAutoContainer.defaultSyncs.map((ci, index) => (
-              <tr key={index} onClick={() => handleCheckBox(ci.id)}>
-                <td className='py-3 pl-8 pr-4 w-0'>
-                  <Checkbox
-                    checked={ci.checked}
-                    onChange={() => handleCheckBox(ci.id)}
-                  />
-                </td>
-                <td className='py-3 pl-4 pr-8'>
-                  <h4 className='font-medium mb-0.5'>{ci.name}</h4>
-                  <p className='t-text-muted text-sm'>{ci.description}</p>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+            <table className='t-table-default t-table-hover'>
+              <tbody className='bg-white'>
+                {importAutoContainer.defaultSyncs.map((ci, index) => (
+                  <tr key={index} onClick={() => handleCheckBox(ci.id)}>
+                    <td className='py-3 pl-8 pr-4 w-0'>
+                      <Checkbox
+                        checked={ci.checked}
+                        onChange={() => handleCheckBox(ci.id)}
+                      />
+                    </td>
+                    <td className='py-3 pl-4 pr-8'>
+                      <h4 className='font-medium mb-0.5'>{ci.name}</h4>
+                      <p className='t-text-muted text-sm'>{ci.description}</p>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </>
+        }
+
+        {importAutoContainer.defaultSyncs.length === 0 &&
+          <div className='my-12'>
+            <EmptyData
+              message='No repo syncs yet'
+              icon={<TableIcon className="t-icon" />}
+              bottomElements={
+                <Button
+                  skin="borderless"
+                  label='Manage Syncs'
+                  startIcon={<CogIcon className="t-icon" />}
+                  onClick={() => router.push('/repos/repo-syncs')}
+                />
+              }
+            />
+          </div>
+        }
       </Modal.Body>
       <Modal.Footer>
         <Toolbar className="h-16 px-6">

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/modals/remove-auth-credential.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/modals/remove-auth-credential.tsx
@@ -1,0 +1,81 @@
+import { useMutation } from '@apollo/client'
+import { Button, Modal, Toolbar } from '@mergestat/blocks'
+import { TrashIcon, XIcon } from '@mergestat/icons'
+import React, { useCallback } from 'react'
+import { REMOVE_CREDENTIAL } from 'src/api-logic/graphql/mutations/auth-credentials'
+import { showSuccessAlert } from 'src/utils/alerts'
+import { TEST_IDS } from 'src/utils/constants'
+
+type RemoveAuthModalProps = {
+  id?: string
+  setShowRemoveAuthModal: (e: boolean) => void
+}
+
+export const RemoveAuthModal: React.FC<RemoveAuthModalProps> = ({ id, setShowRemoveAuthModal }: RemoveAuthModalProps) => {
+  const close = useCallback(() => {
+    setShowRemoveAuthModal(false)
+  }, [setShowRemoveAuthModal])
+
+  const [removeCredential] = useMutation(REMOVE_CREDENTIAL, {
+    onCompleted: () => {
+      showSuccessAlert('Token removed')
+      close()
+    },
+    awaitRefetchQueries: true,
+    refetchQueries: () => ['getGitSource']
+  })
+
+  return (
+    <Modal open onClose={close} size="sm">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>Remove Token</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body>
+        <div className='px-6 py-6'>
+        Are you sure you want to remove this token?
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="secondary"
+                onClick={close}
+                className="my-3 mr-3"
+              >
+                Cancel
+              </Button>
+              <Button
+                skin="danger"
+                onClick={() => removeCredential({
+                  variables: { id }
+                })}
+                startIcon={<TrashIcon className="t-icon" />}
+                data-testid={TEST_IDS.removeRepoButtonModal}
+                className="my-3"
+              >
+                Remove Token
+              </Button>
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/modals/remove-auto-import.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/modals/remove-auto-import.tsx
@@ -1,0 +1,81 @@
+import { useMutation } from '@apollo/client'
+import { Button, Modal, Spinner, Toolbar } from '@mergestat/blocks'
+import { TrashIcon, XIcon } from '@mergestat/icons'
+import React, { useCallback } from 'react'
+import { REMOVE_IMPORT } from 'src/api-logic/graphql/mutations/repos'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { showSuccessAlert } from 'src/utils/alerts'
+import { TEST_IDS } from 'src/utils/constants'
+
+export const RemoveAutoImportModal: React.FC = () => {
+  const { setShowRemoveImportModal } = useGitSourceDetailSetState()
+  const [{ importInfo }] = useGitSourceDetailContext()
+
+  const close = useCallback(() => {
+    setShowRemoveImportModal(false)
+  }, [setShowRemoveImportModal])
+
+  const [removeImport, { loading }] = useMutation(REMOVE_IMPORT, {
+    onCompleted: () => {
+      showSuccessAlert('Repo auto import removed')
+      close()
+    },
+    awaitRefetchQueries: true,
+    refetchQueries: () => ['getGitSource', 'getRepoImports']
+  })
+
+  return (
+    <Modal open onClose={close} size="sm">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>Remove Auto Import</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body>
+        <div className='px-6 py-6'>
+          Are you sure you want to remove the repo auto import for the <strong className="font-semibold text-gray-800">{importInfo?.name}</strong> {importInfo?.type}?
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="secondary"
+                onClick={close}
+                className="my-3 mr-3"
+              >
+                Cancel
+              </Button>
+              <Button
+                skin="danger"
+                disabled={loading}
+                onClick={() => removeImport({
+                  variables: { id: importInfo?.id }
+                })}
+                startIcon={loading ? <Spinner size="sm" className='mr-2' /> : <TrashIcon className="t-icon" />}
+                data-testid={TEST_IDS.removeRepoButtonModal}
+                className="my-3"
+              >
+                { loading ? 'Removing...' : 'Remove Auto Import' }
+              </Button>
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/modals/remove-git-source.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/modals/remove-git-source.tsx
@@ -1,0 +1,81 @@
+import { useMutation } from '@apollo/client'
+import { Button, Modal, Toolbar } from '@mergestat/blocks'
+import { TrashIcon, XIcon } from '@mergestat/icons'
+import { useRouter } from 'next/router'
+import React, { useCallback } from 'react'
+import { REMOVE_GIT_SOURCE } from 'src/api-logic/graphql/mutations/git-sources'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { showSuccessAlert } from 'src/utils/alerts'
+import { TEST_IDS } from 'src/utils/constants'
+
+export const RemoveGitSourceModal: React.FC = () => {
+  const router = useRouter()
+  const { setShowRemoveGitSourceModal } = useGitSourceDetailSetState()
+  const [{ idProvider }] = useGitSourceDetailContext()
+
+  const close = useCallback(() => {
+    setShowRemoveGitSourceModal(false)
+  }, [setShowRemoveGitSourceModal])
+
+  const [removeGitSource] = useMutation(REMOVE_GIT_SOURCE, {
+    onCompleted: () => {
+      showSuccessAlert('Git Source removed')
+      close()
+      router.push('/repos/git-sources')
+    }
+  })
+
+  return (
+    <Modal open onClose={close} size="sm">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>Remove Git Source</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body>
+        <div className='px-6 py-6'>
+          Are you sure you want to remove this Git Source?
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="secondary"
+                onClick={close}
+                className="my-3 mr-3"
+              >
+                Cancel
+              </Button>
+              <Button
+                skin="danger"
+                onClick={() => removeGitSource({
+                  variables: { idProvider }
+                })}
+                startIcon={<TrashIcon className="t-icon" />}
+                data-testid={TEST_IDS.removeRepoButtonModal}
+                className="my-3"
+              >
+                Remove Git Source
+              </Button>
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/modals/remove-manual-import.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/modals/remove-manual-import.tsx
@@ -1,0 +1,78 @@
+import { useMutation } from '@apollo/client'
+import { Button, Modal, Toolbar } from '@mergestat/blocks'
+import { TrashIcon, XIcon } from '@mergestat/icons'
+import React, { useCallback } from 'react'
+import { REMOVE_REPO } from 'src/api-logic/graphql/mutations/repos'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { showSuccessAlert } from 'src/utils/alerts'
+
+export const RemoveManualImportModal: React.FC = () => {
+  const { setShowRemoveImportModal } = useGitSourceDetailSetState()
+  const [{ repoInfo }] = useGitSourceDetailContext()
+
+  const close = useCallback(() => {
+    setShowRemoveImportModal(false)
+  }, [setShowRemoveImportModal])
+
+  const [removeRepo] = useMutation(REMOVE_REPO, {
+    onCompleted: () => {
+      showSuccessAlert('Repo removed successfully')
+      close()
+    },
+    awaitRefetchQueries: true,
+    refetchQueries: () => ['getGitSource', 'getAllRepoManualImports', 'getRepoManualImports']
+  })
+
+  return (
+    <Modal open onClose={close} size="sm">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>Remove repo</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body>
+        <div className='px-6 py-6'>
+          Are you sure you want to remove the repo <strong className="font-semibold text-gray-800">{repoInfo?.name}</strong>?
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="secondary"
+                onClick={close}
+                className="my-3 mr-3"
+              >
+                Cancel
+              </Button>
+              <Button
+                skin="danger"
+                onClick={() => removeRepo({
+                  variables: { id: repoInfo?.id }
+                })}
+                startIcon={<TrashIcon className="t-icon" />}
+                className="my-3"
+              >
+                Remove Repo
+              </Button>
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/modals/update-auto-import.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/modals/update-auto-import.tsx
@@ -1,0 +1,116 @@
+import { useMutation, useQuery } from '@apollo/client'
+import { Button, Checkbox, Modal, Toolbar } from '@mergestat/blocks'
+import { XIcon } from '@mergestat/icons'
+import React, { useCallback, useEffect, useState } from 'react'
+import { SyncType } from 'src/@types'
+import { GetRepoImportQuery } from 'src/api-logic/graphql/generated/schema'
+import { UPDATE_AUTO_IMPORT_REPOS } from 'src/api-logic/graphql/mutations/add-repo'
+import { GET_REPO_IMPORT } from 'src/api-logic/graphql/queries/get-repo-imports'
+import Loading from 'src/components/Loading'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { getVendorProp } from 'src/utils'
+import { showSuccessAlert } from 'src/utils/alerts'
+
+export const UpdateAutoImportModal: React.FC = () => {
+  const { setShowAutoImportModal } = useGitSourceDetailSetState()
+  const [{ importInfo }] = useGitSourceDetailContext()
+
+  const close = useCallback(() => {
+    setShowAutoImportModal(false)
+  }, [setShowAutoImportModal])
+
+  const [syncsTypesArray, setSyncsTypesArray] = useState<SyncType[]>([])
+
+  const { loading, data } = useQuery<GetRepoImportQuery>(GET_REPO_IMPORT, {
+    variables: { id: importInfo.id },
+    fetchPolicy: 'no-cache'
+  })
+
+  const [updateAutoImport] = useMutation(UPDATE_AUTO_IMPORT_REPOS, {
+    onCompleted: () => {
+      showSuccessAlert('Default syncs saved')
+      close()
+    }
+  })
+
+  useEffect(() => {
+    const defaultSyncs = data?.repoImport?.settings.defaultSyncTypes || []
+    const list = data?.repoSyncTypes?.nodes.map(st => ({ type: st.type, description: st.description, shortName: st.shortName, checked: defaultSyncs.includes(st.type) }))
+    setSyncsTypesArray(list || [])
+  }, [data])
+
+  const handleCheckBox = (type: string) => {
+    setSyncsTypesArray(
+      syncsTypesArray.map((st) => {
+        if (st.type === type) {
+          return { ...st, checked: !st.checked }
+        }
+        return st
+      })
+    )
+  }
+
+  const updateImport = () => {
+    const newDefaultSyncs = syncsTypesArray.filter(ds => ds.checked).map(ds => ds.type)
+    const newSettings = {
+      ...data?.repoImport?.settings,
+      defaultSyncTypes: newDefaultSyncs
+    }
+    updateAutoImport({ variables: { id: importInfo.id, settings: newSettings } })
+  }
+
+  return (
+    <Modal open onClose={close} size="lg">
+      <Modal.Header>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Left>
+            <Toolbar.Item>
+              <Modal.Title>Edit default syncs ({data?.repoImport?.settings[getVendorProp(importInfo.vendor)]})</Modal.Title>
+            </Toolbar.Item>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button
+                skin="borderless-muted"
+                onClick={close}
+                startIcon={<XIcon className="t-icon" />}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Header>
+      <Modal.Body>
+        {loading
+          ? <div className='h-96 my-40'><Loading /></div>
+          : <table className='t-table-default t-table-hover'>
+            <tbody className='bg-white'>
+              {syncsTypesArray.map((syncType, index) => (
+                <tr key={index} onClick={() => handleCheckBox(syncType.type)}>
+                  <td className='py-3 pl-8 pr-4 w-0'>
+                    <Checkbox
+                      checked={syncType.checked}
+                      onChange={() => handleCheckBox(syncType.type)}
+                    />
+                  </td>
+                  <td className='py-3 pl-4 pr-8'>
+                    <h4 className='font-medium mb-0.5'>{syncType.shortName}</h4>
+                    <p className='t-text-muted text-sm'>{syncType.description}</p>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>}
+      </Modal.Body>
+      <Modal.Footer>
+        <Toolbar className="h-16 px-6">
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button label='Cancel' className="my-3 mr-3" skin="secondary" onClick={close} />
+              <Button label='Save' className="my-3" skin="primary" onClick={updateImport} />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </Modal.Footer>
+    </Modal>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/tabs/default-repo-syncs.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/tabs/default-repo-syncs.tsx
@@ -1,0 +1,56 @@
+import { Alert, Button } from '@mergestat/blocks'
+import { CogIcon, TableIcon } from '@mergestat/icons'
+import { useRouter } from 'next/router'
+import React from 'react'
+import Loading from 'src/components/Loading'
+import { useDefaultRepoSyncsContext, useDefaultRepoSyncsSetState } from 'src/state/contexts/default-repo-syncs.context'
+import { EmptyData } from 'src/views/shared/empty-data'
+import { FilterFooter } from 'src/views/shared/filter-footer'
+import { FilterHeader } from 'src/views/shared/filter-header'
+import useDefaultRepoSyncs from '../../../hooks/gitSources/useDefaultRepoSyncs'
+import { DefaultSyncsTable } from '../components/default-syncs-table'
+
+export const DefaultRepoSyncs: React.FC = () => {
+  const [{ rows, page, total }] = useDefaultRepoSyncsContext()
+  const { setSearch, setRows, setPage } = useDefaultRepoSyncsSetState()
+  const { loading, records, defaultSyncs } = useDefaultRepoSyncs()
+  const router = useRouter()
+
+  return (
+    <>
+      <div className='py-6 pl-8 pr-5'>
+        <Alert type='default' theme='light' className='bg-gray-100'>
+          Default syncs are automatically enabled for all repos inside the git source. You can always override them on a per-repo basis. Learn more.{' '}
+          <a className='font-medium cursor-pointer text-blue-600' target='_blank' rel='noreferrer' href='https://docs.mergestat.com/mergestat/setup/repo-auto-imports'>Learn more</a>
+        </Alert>
+      </div>
+
+      <div className='flex flex-col flex-1'>
+        <div className='flex-1 overflow-auto'>
+          {records && <div className='flex'>
+            <FilterHeader setSearch={setSearch} />
+            <div className='flex px-5 items-center'>
+              <Button className='whitespace-nowrap'
+                skin="secondary"
+                label='Manage Syncs'
+                startIcon={<CogIcon className="t-icon" />}
+                onClick={() => router.push('/repos/repo-syncs')}
+              />
+            </div>
+          </div>}
+
+          {loading
+            ? <Loading />
+            : records
+              ? <DefaultSyncsTable defaultSyncs={defaultSyncs || []} />
+              : <EmptyData
+                message='No default repo syncs yet'
+                icon={<TableIcon className="t-icon" />}
+              />
+          }
+        </div>
+        {records && <FilterFooter total={total} rows={rows} page={page} setRows={setRows} setPage={setPage} />}
+      </div>
+    </>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/tabs/overview.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/tabs/overview.tsx
@@ -1,0 +1,29 @@
+import { useGitSourceDetailContext } from 'src/state/contexts/git-source-detail.context'
+import { VENDOR_TYPE } from 'src/utils/constants'
+import BitbucketAuth from '../components/auth/bitbucket'
+import GitHubOrLabAuth from '../components/auth/git-hub-lab'
+import ReposAutoManual from '../components/repos'
+import GitSourceStats from '../components/stats'
+
+const GitSourceOverviewTab: React.FC = () => {
+  const [{ loading, gsDetail: { totalAuto, totalManual, totalRepos, vendor } }] = useGitSourceDetailContext()
+
+  return (
+    <>
+      <GitSourceStats loading={loading}
+        totalAuto={totalAuto || 0}
+        totalManual={totalManual || 0}
+        totalRepos={totalRepos || 0}
+      />
+
+      {/** Auth */}
+      {(vendor === VENDOR_TYPE.GITHUB || vendor === VENDOR_TYPE.GITLAB) && <GitHubOrLabAuth />}
+      {vendor === VENDOR_TYPE.BITBUCKET && <BitbucketAuth />}
+
+      {/** Repo list */}
+      <ReposAutoManual />
+    </>
+  )
+}
+
+export default GitSourceOverviewTab

--- a/ui/src/views/repo-containers-git-sources/git-source-detail/tabs/settings.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-source-detail/tabs/settings.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@mergestat/blocks'
+import { TrashIcon } from '@mergestat/icons'
+import { useGitSourceDetailContext, useGitSourceDetailSetState } from 'src/state/contexts/git-source-detail.context'
+import { RemoveGitSourceModal } from '../modals/remove-git-source'
+
+const GitSourceSettingsTab: React.FC = () => {
+  const { setShowRemoveGitSourceModal } = useGitSourceDetailSetState()
+  const [{ showRemoveGitSourceModal }] = useGitSourceDetailContext()
+
+  return (
+    <div className='h-full'>
+      <Button
+        skin="danger"
+        startIcon={<TrashIcon className="t-icon" />}
+        onClick={() => setShowRemoveGitSourceModal(true)}
+      >
+        Remove Git Source
+      </Button>
+
+      {showRemoveGitSourceModal && <RemoveGitSourceModal />}
+    </div>
+  )
+}
+
+export default GitSourceSettingsTab

--- a/ui/src/views/repo-containers-git-sources/git-sources/components/git-sources-table.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-sources/components/git-sources-table.tsx
@@ -1,0 +1,59 @@
+import { ListItem } from '@mergestat/blocks'
+import { useRouter } from 'next/router'
+import React, { PropsWithChildren } from 'react'
+import { GitSourceData } from 'src/@types'
+import { getGitSourceIcon } from 'src/utils'
+import { NoDataFound } from 'src/views/shared/no-data-found'
+
+type GitSourcesTableProps = PropsWithChildren<{
+  gitSources: GitSourceData[]
+}>
+
+export const GitSourcesTable: React.FC<GitSourcesTableProps> = ({ gitSources }: GitSourcesTableProps) => {
+  const router = useRouter()
+
+  return (
+    <div className='flex flex-col flex-1 overflow-hidden'>
+      {gitSources.length < 1
+        ? <NoDataFound message='Couldn&#39;t find any git source.' />
+        : <>
+          <div className='flex flex-col min-w-0 bg-gray-50 h-full'>
+            <div className='flex-1 overflow-auto'>
+              <table className='t-table-default t-table-sticky-header t-table-hover border-b'>
+                <thead>
+                  <tr className='bg-white'>
+                    <th scope='col' key='name' className='whitespace-nowrap'>Name</th>
+                    <th scope='col' key='repos' className='whitespace-nowrap'>Repos</th>
+                    <th scope='col' key='remove' className='whitespace-nowrap px-4'></th>
+                  </tr>
+                </thead>
+
+                <tbody className='bg-white'>
+                  {gitSources.map((gs, index) => (
+                    <tr key={gs.id}>
+                      <td className='h-20'>
+                        <ListItem key={`git-source-${index}`}
+                          title={gs.name}
+                          subline={gs.description || ''}
+                          startIcon={getGitSourceIcon(gs.vendor)}
+                          onClick={() => router.push(`/repos/git-sources/${gs.id}`)}
+                        />
+                      </td>
+                      <td className='t-text-muted'>
+                        <span className='ml-1'>{gs.reposByProvider.totalCount}</span>
+                      </td>
+                      <td className='t-text-muted'>
+                        <div className='t-button-toolbar'>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      }
+    </div>
+  )
+}

--- a/ui/src/views/repo-containers-git-sources/git-sources/components/git-sources-table.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-sources/components/git-sources-table.tsx
@@ -36,7 +36,7 @@ export const GitSourcesTable: React.FC<GitSourcesTableProps> = ({ gitSources }: 
                           title={gs.name}
                           subline={gs.description || ''}
                           startIcon={getGitSourceIcon(gs.vendor)}
-                          onClick={() => router.push(`/repos/git-sources/${gs.id}`)}
+                          onClick={() => router.push(`/repos-containers/git-sources/${gs.id}`)}
                         />
                       </td>
                       <td className='t-text-muted'>

--- a/ui/src/views/repo-containers-git-sources/git-sources/index.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-sources/index.tsx
@@ -33,7 +33,7 @@ const GitSourcesView: React.FC = () => {
       {
         text: 'Repos',
         startIcon: <RepositoryIcon className='t-icon t-icon-default' />,
-        onClick: () => router.push('/repos'),
+        onClick: () => router.push('/repos-containers'),
       },
     ]
 

--- a/ui/src/views/repo-containers-git-sources/git-sources/index.tsx
+++ b/ui/src/views/repo-containers-git-sources/git-sources/index.tsx
@@ -1,0 +1,99 @@
+import { useQuery } from '@apollo/client'
+import { Button, Toolbar } from '@mergestat/blocks'
+import { BranchIcon, PlusIcon, RepositoryIcon } from '@mergestat/icons'
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+import { GetGitSourcesListQuery } from 'src/api-logic/graphql/generated/schema'
+import { GET_GIT_SOURCES_LIST } from 'src/api-logic/graphql/queries/get-git-sources'
+import Loading from 'src/components/Loading'
+import { useGlobalSetState } from 'src/state/contexts'
+import { useGitSourcesContext, useGitSourcesSetState } from 'src/state/contexts/git-sources.context'
+import { EmptyData } from 'src/views/shared/empty-data'
+import { FilterFooter } from 'src/views/shared/filter-footer'
+import { FilterHeader } from 'src/views/shared/filter-header'
+import { GitSourcesTable } from './components/git-sources-table'
+
+const GitSourcesView: React.FC = () => {
+  const router = useRouter()
+  const { setCrumbs } = useGlobalSetState()
+
+  const [{ search, rows, page, total }] = useGitSourcesContext()
+  const { setTotal, setSearch, setRows, setPage } = useGitSourcesSetState()
+
+  const [pageLoaded, setPageLoaded] = useState(false)
+  const [records, setRecords] = useState(false)
+
+  const { loading, data, refetch } = useQuery<GetGitSourcesListQuery>(GET_GIT_SOURCES_LIST, {
+    variables: { search, first: rows, offset: (page * rows) },
+    fetchPolicy: 'no-cache'
+  })
+
+  useEffect(() => {
+    const crumbs = [
+      {
+        text: 'Repos',
+        startIcon: <RepositoryIcon className='t-icon t-icon-default' />,
+        onClick: () => router.push('/repos'),
+      },
+    ]
+
+    setCrumbs(crumbs)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    setTotal(data?.providers?.totalCount || 0)
+
+    if (!pageLoaded && data?.all) {
+      setRecords(data?.all?.totalCount > 0)
+      setPageLoaded(true)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data])
+
+  useEffect(() => {
+    refetch({ search, first: rows, offset: (page * rows) })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refetch, search, rows, page])
+
+  useEffect(() => {
+    if (total) {
+      (page * rows) + 1 > total && setPage(0)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [total])
+
+  return (
+    <div className='flex flex-col flex-1 overflow-hidden'>
+      {/* Header */}
+      <div className='bg-white h-16 w-full border-b px-8 flex-none'>
+        <Toolbar className='h-full'>
+          <Toolbar.Left>
+            <h2 className='t-h2 mb-0'>Git Sources</h2>
+          </Toolbar.Left>
+          <Toolbar.Right>
+            <Toolbar.Item>
+              <Button className='whitespace-nowrap'
+                label='Add Repos'
+                startIcon={<PlusIcon className='t-icon' />}
+                onClick={() => router.push('/repos/add-git-source')}
+              />
+            </Toolbar.Item>
+          </Toolbar.Right>
+        </Toolbar>
+      </div>
+
+      {/* Body */}
+      {records && <FilterHeader setSearch={setSearch} />}
+      {loading
+        ? <Loading />
+        : records
+          ? <GitSourcesTable gitSources={data?.providers ? data?.providers.nodes : []} />
+          : <EmptyData message='No git sources yet' icon={<BranchIcon className="t-icon" />} />
+      }
+      {records && <FilterFooter total={total} rows={rows} page={page} setRows={setRows} setPage={setPage} />}
+    </div>
+  )
+}
+
+export default GitSourcesView

--- a/ui/src/views/repo-data-container/repository-data/components/sync-types-table/components/repository-sync-status.tsx
+++ b/ui/src/views/repo-data-container/repository-data/components/sync-types-table/components/repository-sync-status.tsx
@@ -53,7 +53,7 @@ export const RepositorySyncStatus: React.FC<RepositorySyncStatusProps> = (
     { length: 15 },
     (x, i) => (i in data)
       ? data[i]
-      : { id: '', repoId: '', syncId: '', runningTime: 3, runningTimeReadable: '', status: SYNC_STATUS.empty, doneAt: undefined }
+      : { id: '', repoId: '', syncId: '', durationMs: 0, runningTime: 3, runningTimeReadable: '', status: SYNC_STATUS.empty, doneAt: undefined }
   )
 
   const valueArray = chartArray.map((d: JobData) => d.runningTime)

--- a/ui/src/views/repo-sync-detail/components/git-sources.tsx
+++ b/ui/src/views/repo-sync-detail/components/git-sources.tsx
@@ -52,11 +52,15 @@ const GitSourcesContainer: React.FC<GitSourcesContainerProps> = ({ containerSync
           </div>
         </Panel.Header>
 
-        <Panel.Body className={cx(records ? 'bg-gray-50' : 'bg-white', { 'p-0': records })}>
+        <Panel.Body className={cx(
+          'flex flex-col',
+          records ? 'bg-gray-50' : 'bg-white',
+          { 'p-0': records })
+        }>
           {records && <FilterHeader setSearch={setSearch} />}
 
           {loading
-            ? <Loading />
+            ? <div className='py-8'><Loading /></div>
             : records
               ? <GitSourcesTable gitSources={gitSources} />
               : <div className='flex justify-center bg-white p-6'>


### PR DESCRIPTION
Resolves #1019 

- [x] Added udf for adding a new repo import for container syncs
- [x] Added udf to update default container images for repo 
- [x] Created new git-sources pages for container syncs that use the new udf's to manage the repo imports
  - It is accessed through `/repos-containers/git-sources/<id-gitsource>`
- [x] Updated worker to handle new `defaultContainerImages` in repo imports
- [x] Fix latest sync status bars and related status issues
- [x] Add container images seed values to DB
- [x] Fix priority issues with GitHub syncs and Repo Imports
