### PR TITLE
Feature/save query charts

### DIFF
--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -255,6 +255,7 @@ export type ChartData = {
   yAxis?: string
   options?: ApexOptions
   series?: ApexSerie[]
+  chartType: string
 }
 
 export type SingleMetricData = {
@@ -273,6 +274,11 @@ export type ActionType = {
 
 export type TabsState = {
   [key: string]: SingleMetricData | ChartData
+}
+
+export function isChartData(maybeChart: SingleMetricData | ChartData | undefined): maybeChart is ChartData {
+  if (maybeChart === undefined) return false
+  return (maybeChart as ChartData).xAxis !== undefined
 }
 
 export interface TabData {

--- a/ui/src/@types.tsx
+++ b/ui/src/@types.tsx
@@ -1,6 +1,7 @@
 import { ApexOptions } from 'apexcharts'
 import { ReactElement } from 'react'
 import { RepoSyncQueue } from './api-logic/graphql/generated/schema'
+import { TAB_TYPE } from './utils/constants'
 
 export type RepoSyncStateT = 'disabled' | 'running' | 'queued' | 'succeeded' | 'warning' | 'error' | 'empty'
 
@@ -16,7 +17,7 @@ export type UserType = 'ADMIN' | 'USER' | 'READ_ONLY'
 
 export type ImportStatusType = 'SUCCESS' | 'FAILURE'
 
-export type ChartType = 'line' | 'bar'
+export type ChartType = TAB_TYPE.BAR | TAB_TYPE.LINE
 
 export type TagType = {
   title: string

--- a/ui/src/api-logic/graphql/mutations/saved-query.ts
+++ b/ui/src/api-logic/graphql/mutations/saved-query.ts
@@ -14,15 +14,16 @@ const ADD_SAVED_QUERY = gql`
 `
 
 const UPDATE_SAVED_QUERY = gql`
-  mutation updateSavedQuery($id: UUID!, $name: String, $description: String, $sql: String) {
+  mutation updateSavedQuery($id: UUID!, $name: String, $description: String, $sql: String, $metadata: JSON) {
     updateSavedQuery(
-      input: {patch: {name: $name, description: $description, sql: $sql}, id: $id}
+      input: {patch: {name: $name, description: $description, sql: $sql, metadata: $metadata}, id: $id}
     ) {
       savedQuery {
         id
         name
         description
         sql
+        metadata
       }
     }
   }

--- a/ui/src/utils/constants.ts
+++ b/ui/src/utils/constants.ts
@@ -143,8 +143,8 @@ export enum IMPORT_STATUS_TYPE {
 }
 
 export enum TAB_TYPE {
-  LINE = 'LINE',
-  BAR = 'BAR',
+  LINE = 'line',
+  BAR = 'bar',
   SINGLE_METRIC = 'SINGLE_METRIC'
 }
 

--- a/ui/src/views/hooks/useSavedQuery.ts
+++ b/ui/src/views/hooks/useSavedQuery.ts
@@ -49,8 +49,8 @@ const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps)
     const chartsData = tabIds.map((id) => tabsState[id]).filter(isChartData)
 
     return chartsData.map((chart) => {
-      const { xAxis, xAxisType, yAxis, chartType } = chart
-      return { xAxis, xAxisType, yAxis, chartType }
+      const { xAxis, xAxisType, yAxis, chartType, serie } = chart
+      return { xAxis, xAxisType, yAxis, chartType, serie }
     })
   }, [tabs, tabsState])
 

--- a/ui/src/views/hooks/useSavedQuery.ts
+++ b/ui/src/views/hooks/useSavedQuery.ts
@@ -14,9 +14,10 @@ type useSavedQueryProps = {
   title?: string
   desc?: string
   query?: string
+  saveChartMetadata?: boolean
 }
 
-const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps) => {
+const useSavedQuery = ({ savedQueryId, title, desc, query, saveChartMetadata }: useSavedQueryProps) => {
   const router = useRouter()
   const { data: userData } = useCurrentUser()
   const [titleError, setTitleError] = useState<boolean>(false)
@@ -45,6 +46,8 @@ const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps)
   })
 
   const chartsMetadata = useMemo(() => {
+    if (!saveChartMetadata) return data?.savedQuery?.metadata?.charts
+
     const tabIds = tabs.map(({ tabId }) => tabId)
     const chartsData = tabIds.map((id) => tabsState[id]).filter(isChartData)
 
@@ -52,7 +55,7 @@ const useSavedQuery = ({ savedQueryId, title, desc, query }: useSavedQueryProps)
       const { xAxis, xAxisType, yAxis, chartType, serie } = chart
       return { xAxis, xAxisType, yAxis, chartType, serie }
     })
-  }, [tabs, tabsState])
+  }, [saveChartMetadata, data, tabs, tabsState])
 
   const addSavedQueryHandler = () => {
     if (title) {

--- a/ui/src/views/hooks/useTabs.tsx
+++ b/ui/src/views/hooks/useTabs.tsx
@@ -9,22 +9,29 @@ import TabChart from '../sql-query-editor/tabs/tab-chart'
 import TabSingleMetric from '../sql-query-editor/tabs/tab-single-metric'
 import TabTable from '../sql-query-editor/tabs/tab-table'
 
-const useTabs = (rowLimit: number, rowLimitReached: boolean) => {
+const useTabs = (rowLimit: number, rowLimitReached: boolean, charts: ChartData[]) => {
   const [{ expanded, activeTab, tabs }] = useQueryContext()
   const { setExpanded, setActiveTab, setTabs } = useQuerySetState()
   const dispatch = useQueryTabsDispatch()
 
   useEffect(() => {
-    if (tabs.length === 0) {
-      setTabs([
-        {
-          tabId: uuidv4(),
-          title: <><TableIcon className='t-icon' /> <span className='ml-2'>Table</span></>,
-          content: <TabTable rowLimit={rowLimit} rowLimitReached={rowLimitReached} />
-        }
-      ])
+    const tableTab = {
+      tabId: uuidv4(),
+      title: <><TableIcon className='t-icon' /> <span className='ml-2'>Table</span></>,
+      content: <TabTable rowLimit={rowLimit} rowLimitReached={rowLimitReached} />
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    let tabData = [tableTab]
+
+    charts.forEach((chartData) => {
+      const { chartType } = chartData
+      const id = uuidv4()
+
+      dispatch({ tab: id, payload: chartData })
+      tabData = [...tabData, getTabData(chartType, id)]
+    })
+    setTabs(tabData)
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {

--- a/ui/src/views/hooks/useTabs.tsx
+++ b/ui/src/views/hooks/useTabs.tsx
@@ -38,14 +38,14 @@ const useTabs = (rowLimit: number, rowLimitReached: boolean) => {
         return {
           tabId,
           title: <><ChartBarIcon className='t-icon' /> <span className='ml-2'>Bar chart</span></>,
-          content: <TabChart chartType='bar' />,
+          content: <TabChart chartType={TAB_TYPE.BAR} />,
           closable: true
         }
       case TAB_TYPE.LINE:
         return {
           tabId,
           title: <><ChartLineIcon className='t-icon' /> <span className='ml-2'>Line chart</span></>,
-          content: <TabChart chartType='line' />,
+          content: <TabChart chartType={TAB_TYPE.LINE} />,
           closable: true
         }
       default:

--- a/ui/src/views/sql-query-editor/components/state-filled.tsx
+++ b/ui/src/views/sql-query-editor/components/state-filled.tsx
@@ -1,6 +1,7 @@
 import { Badge, Button, HoverCard, Menu, Tabs, Toolbar } from '@mergestat/blocks'
 import { ArrowCollapseIcon, ArrowExpandIcon, CaretDownIcon, ChartBarIcon, ChartLineIcon, CircleCheckFilledIcon, PlusIcon, SingleMetricIcon } from '@mergestat/icons'
 import { cloneElement } from 'react'
+import { ChartData } from 'src/@types'
 import { TAB_TYPE } from 'src/utils/constants'
 import useTabs from 'src/views/hooks/useTabs'
 
@@ -9,10 +10,11 @@ type QueryEditorFilledProps = {
   rowLimitReached: boolean
   time: string
   children?: React.ReactNode
+  charts: ChartData[]
 }
 
-const QueryEditorFilled: React.FC<QueryEditorFilledProps> = ({ rowLimit, rowLimitReached, time }: QueryEditorFilledProps) => {
-  const { tabs, expanded, activeTab, setActiveTab, setExpanded, addTab, removeTab } = useTabs(rowLimit, rowLimitReached)
+const QueryEditorFilled: React.FC<QueryEditorFilledProps> = ({ rowLimit, rowLimitReached, time, charts }: QueryEditorFilledProps) => {
+  const { tabs, expanded, activeTab, setActiveTab, setExpanded, addTab, removeTab } = useTabs(rowLimit, rowLimitReached, charts)
 
   return (
     <div className="flex flex-col flex-1 w-full bg-white" style={{ minHeight: '48px' }}>

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -142,7 +142,7 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
 
         {/* Filled state */}
         {!error && !loading && data && state === States.Filled &&
-          <QueryEditorFilled rowLimit={ROWS_LIMIT} rowLimitReached={rowLimitReached} time={time} />
+          <QueryEditorFilled charts={savedQuery?.metadata?.charts ?? []} rowLimit={ROWS_LIMIT} rowLimitReached={rowLimitReached} time={time} />
         }
       </div>
 

--- a/ui/src/views/sql-query-editor/index.tsx
+++ b/ui/src/views/sql-query-editor/index.tsx
@@ -27,7 +27,8 @@ const QueryEditor: React.FC<QueryEditorProps> = ({ savedQueryId }: QueryEditorPr
     loading, error, query, data, time, title, desc
   } = useQueryEditor(ROWS_LIMIT)
 
-  const { loadingSQ, savedQuery, titleError, setTitleError, addSavedQueryHandler, updateSavedQueryHandler } = useSavedQuery({ savedQueryId, title, desc, query })
+  const saveChartMetadata = state === States.Filled
+  const { loadingSQ, savedQuery, titleError, setTitleError, addSavedQueryHandler, updateSavedQueryHandler } = useSavedQuery({ savedQueryId, title, desc, query, saveChartMetadata })
 
   useEffect(() => {
     setTitle(savedQuery?.name || '')

--- a/ui/src/views/sql-query-editor/tabs/tab-chart.tsx
+++ b/ui/src/views/sql-query-editor/tabs/tab-chart.tsx
@@ -23,7 +23,11 @@ const TabChart: React.FC<TabChartProps> = ({ tabId = '', chartType }: TabChartPr
 
   const { serie, xAxis, yAxis, xAxisType, options, series } = (tabsState[tabId] as ChartData)
 
-  const setState = (payload: ChartData) => dispatch({ tab: tabId, payload })
+  const setState = (payload: Omit<ChartData, 'chartType'>, type?: string) => {
+    const tabChart = type ?? chartType
+    const tabData = { ...payload, chartType: tabChart }
+    dispatch({ tab: tabId, payload: tabData })
+  }
 
   useEffect(() => {
     if (xAxis && yAxis) {

--- a/ui/src/views/sql-query-editor/tabs/tab-chart.tsx
+++ b/ui/src/views/sql-query-editor/tabs/tab-chart.tsx
@@ -32,7 +32,7 @@ const TabChart: React.FC<TabChartProps> = ({ tabId = '', chartType }: TabChartPr
   useEffect(() => {
     if (xAxis && yAxis) {
       const series = mapToApexChart({ data, serie, xAxis, yAxis })
-      setState({ series })
+      setState({ series, serie })
 
       const typeX = xAxisType === XAXIS_TYPE_LABEL.DATE
         ? XAXIS_TYPE.DATETIME


### PR DESCRIPTION
This pull request allows the user to seamlessly save any charts they create associated with the query they save. If the user saves a query without running it, the previous session's charts remain unchanged.

When a chart is saved, only the attributes are saved, none of the underlying data. This minimizes the data necessary to save in the `metadata` JSON, but also leaves the web application to recalculate the chart.

These changes essentially collect the chart attributes from the stored tab state for the charts and collates that data into a `charts` attribute on the `metadata` JSON.

Let me know if there are any questions or concerns and thanks in advance for the review!