### PR TITLE
feat: adding support for multi-arch images

### DIFF
--- a/.github/workflows/publish-console-docker.yaml
+++ b/.github/workflows/publish-console-docker.yaml
@@ -54,6 +54,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:ui"
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-graphql-docker.yaml
+++ b/.github/workflows/publish-graphql-docker.yaml
@@ -54,6 +54,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
+          platforms: linux/amd64,linux/arm64
           context: "{{defaultContext}}:graphql"
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-worker-docker.yaml
+++ b/.github/workflows/publish-worker-docker.yaml
@@ -54,7 +54,6 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
-          context: .
           platforms: linux/amd64,linux/arm/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-worker-docker.yaml
+++ b/.github/workflows/publish-worker-docker.yaml
@@ -54,6 +54,8 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
+          context: .
+          platforms: linux/amd64,linux/arm/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-worker-docker.yaml
+++ b/.github/workflows/publish-worker-docker.yaml
@@ -54,7 +54,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
-          platforms: linux/amd64,linux/arm/v8
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Adding support for multi-arch images to address issues with new container syncs. When running the amd64 image an an M1 Mac we were seeing the following errors
```
cannot clone: Invalid argument
Error: cannot re-exec process
```
When running Mergestat on an image that matches the local arch this error went away. For now we are starting with adding `arm64` on top of the `amd64` image we were generating.