### PR TITLE
fix(git-source) using new blocks version to allow tab on providers op…

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -11,7 +11,7 @@
         "@apollo/client": "^3.7.7",
         "@apollo/react-testing": "^4.0.0",
         "@blueprintjs/table": "^4.7.20",
-        "@mergestat/blocks": "^1.5.79",
+        "@mergestat/blocks": "^1.5.80",
         "@mergestat/icons": "1.2.18",
         "@monaco-editor/react": "^4.4.6",
         "@next/bundle-analyzer": "^12.3.4",
@@ -3387,9 +3387,9 @@
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA=="
     },
     "node_modules/@mergestat/blocks": {
-      "version": "1.5.79",
-      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.79.tgz",
-      "integrity": "sha512-HKCge2c5pAZJL6bcW8z9rlC2+DCSaUrrrhL4VyYRMS7iQW+WVleMT2kDA/xVchulPbo/YXk4rtQG99XW2XkvIg==",
+      "version": "1.5.80",
+      "resolved": "https://registry.npmjs.org/@mergestat/blocks/-/blocks-1.5.80.tgz",
+      "integrity": "sha512-nfXjJ38nCnSnKYRA2WA8BiGFAmsoWnovPgvaoYigwX3O0BswIaafD8ZMqh9hiNC34A3Gxz9Ff9gG94hZ95M/EQ==",
       "dependencies": {
         "@floating-ui/react": "0.19.2",
         "@headlessui/react": "1.7.11",

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "@apollo/client": "^3.7.7",
     "@apollo/react-testing": "^4.0.0",
     "@blueprintjs/table": "^4.7.20",
-    "@mergestat/blocks": "^1.5.79",
+    "@mergestat/blocks": "^1.5.80",
     "@mergestat/icons": "1.2.18",
     "@monaco-editor/react": "^4.4.6",
     "@next/bundle-analyzer": "^12.3.4",

--- a/ui/src/views/repo-explorer/components/header-explore.tsx
+++ b/ui/src/views/repo-explorer/components/header-explore.tsx
@@ -41,7 +41,15 @@ const HeaderExplore: React.FC = () => {
         </Toolbar.Left>
         <Toolbar.Right>
           <Toolbar.Item>
-            <Alert isInline type="info" className='text-gray-400'>100/1000 repos indexed</Alert>
+            <Alert isInline
+              type="info"
+              className='text-gray-400'
+              tooltip={<div className='w-80 font-thin leading-4 p-2'>
+                Not all repos have been index, please modify the repo explore sync to search across all repos
+              </div>}
+            >
+              100/1000 repos indexed
+            </Alert>
           </Toolbar.Item>
           <Toolbar.Item>
             <Button className='whitespace-nowrap'

--- a/ui/src/views/repo-explorer/components/stats-explore.tsx
+++ b/ui/src/views/repo-explorer/components/stats-explore.tsx
@@ -24,7 +24,7 @@ const StatsExplore: React.FC = () => {
           <Stat.Number>
             <MetricNumber loading={loading} metric={repos || 0}
               icon={<CircleInformationFilledIcon className="t-icon t-icon-info" />}
-              tooltip={<div className='w-80 font-thin'>
+              tooltip={<div className='w-80 font-thin leading-4 p-2'>
                 Not all repos have been index, please modify
                 the repo explore sync to search across all repos
               </div>}


### PR DESCRIPTION
using new `blocks` version for:

- Allowing do tab on providers options. (Resolves #1044)

![tab-on-providers](https://user-images.githubusercontent.com/109089565/235990874-fc248da4-f832-420d-b7c4-6c5e38290c05.png)

- Adding tooltip on `Alert` in repo explore page.

![tooltip-alert](https://user-images.githubusercontent.com/109089565/235991034-811ced59-8047-4ea5-881a-1c8c4fff47d7.png)
