### PR TITLE
feat: removing links to support podman-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -67,8 +67,6 @@ services:
       worker:
         # this is to ensure all migrations are run before the API starts up
         condition: service_healthy
-    links:
-      - worker
     ports:
       - 5433:5433
     command:


### PR DESCRIPTION
Removing links from compose file that is not needed and break support for podman-compose. Make file commands are still docker based only for now but base use case is covered now.

Resolves #1071 