### PR TITLE
fix: check for PATs issued from old gitlab versions

### DIFF
--- a/ui/src/utils/index.tsx
+++ b/ui/src/utils/index.tsx
@@ -47,7 +47,7 @@ export function validateGitHubPAT(token: string) {
  * @returns true if token is a right GitLab PAT, otherwise return false
  */
 export function validateGitLabPAT(token: string) {
-  return /^glpat-[0-9a-zA-Z_-]{20}$/ig.test(token)
+  return /^(PAT_|glpat-)[0-9a-zA-Z_-]{20}$/ig.test(token)
 }
 
 /**


### PR DESCRIPTION
Closes #1086 