### PR TITLE
feat: add possibility to set scheduler and syncer interval

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -277,18 +277,18 @@ func main() {
 	syncerInterval := 3
 
 	if schedulerIntervalStr := os.Getenv("SCHEDULER_INTERVAL_MINUTES"); len(schedulerIntervalStr) != 0 {
-		if schedulerInterval, Err := strconv.Atoi(schedulerIntervalStr); Err != nil {
-			logger.Err(Err).Msgf("Incorrect value for SCHEDULER_INTERVAL_MINUTES")
+		if schedulerInterval, err = strconv.Atoi(schedulerIntervalStr); err != nil {
+			logger.Err(err).Msgf("Incorrect value for SCHEDULER_INTERVAL_MINUTES")
 		}
 	}
 	if syncerIntervalStr := os.Getenv("SYNCER_INTERVAL_SECONDS"); len(syncerIntervalStr) != 0 {
-		if syncerInterval, Err := strconv.Atoi(syncerIntervalStr); Err != nil {
-			logger.Err(Err).Msgf("Incorrect value for SYNCER_INTERVAL_SECONDS")
+		if syncerInterval, err = strconv.Atoi(syncerIntervalStr); err != nil {
+			logger.Err(err).Msgf("Incorrect value for SYNCER_INTERVAL_SECONDS")
 		}
 	}
-	go scheduler.New(&logger, pool).Start(ctx, schedulerInterval*time.Minute)
+	go scheduler.New(&logger, pool).Start(ctx, time.Duration(schedulerInterval)*time.Minute)
 	go timeout.New(&logger, pool).Start(ctx, time.Minute)
-	go syncer.New(pool, embedded, &logger, concurrency, syncerInterval*time.Second).Start(ctx)
+	go syncer.New(pool, embedded, &logger, concurrency, time.Duration(syncerInterval)*time.Second).Start(ctx)
 
 	// run a basic cron every minute to schedule a repos/auto-import job
 	// these jobs are idempotent, and so, multiple instances can run at same time without conflict

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -273,9 +273,17 @@ func main() {
 
 	// TODO all of the following "params" should be configurable
 	// either via the database/app or possibly with env vars
-	go scheduler.New(&logger, pool).Start(ctx, 1*time.Minute)
+	schedulerInterval := os.Getenv("SCHEDULER_INTERVAL_MINUTES")
+	if len(schedulerInterval) == 0 {
+		schedulerInterval = 1
+	}
+	syncerInterval := os.Getenv("SYNCER_INTERVAL_SECONDS")
+	if len(syncerInterval) == 0 {
+		syncerInterval = 3
+	}
+	go scheduler.New(&logger, pool).Start(ctx, schedulerInterval*time.Minute)
 	go timeout.New(&logger, pool).Start(ctx, time.Minute)
-	go syncer.New(pool, embedded, &logger, concurrency, 3*time.Second).Start(ctx)
+	go syncer.New(pool, embedded, &logger, concurrency, schedulerInterval*time.Second).Start(ctx)
 
 	// run a basic cron every minute to schedule a repos/auto-import job
 	// these jobs are idempotent, and so, multiple instances can run at same time without conflict


### PR DESCRIPTION
Asked on the [slack](https://mergestatcommunity.slack.com/archives/C02KEJ5M7RA/p1696672369445719) how to configure how often jobs are scheduled, so started looking at it. 

It seems that it was already mentioned in the code, so just adding env variable with default values to make it possible to run only once a day for example (In my case we have a lot of repos, running it more often doesn't really bring value but add a lot of computing). 

I didn't configure the timeout one, but can add it if you think it's necessary