### PR TITLE
fix: set container sync on the same schedule as scheduler

### DIFF
--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -295,7 +295,7 @@ func main() {
 	go cron.AutoImport(ctx, 15*time.Second, upstream)
 
 	// run container sync scheduler every minute
-	go cron.ContainerSync(ctx, 1*time.Minute, upstream)
+	go cron.ContainerSync(ctx, time.Duration(schedulerInterval)*time.Minute, upstream)
 
 	if os.Getenv("DEBUG") != "" {
 		go func() {


### PR DESCRIPTION
Previous PR #1122 wasn't working as I missed the cron, that I guess needs to be set as the same value as the scheduler ? 