### PR TITLE
feat: add `includeArchivedRepos ` auto import config flag

### DIFF
--- a/internal/jobs/repo/vendor_github.go
+++ b/internal/jobs/repo/vendor_github.go
@@ -36,6 +36,7 @@ func handleGithubImport(ctx context.Context, qry *db.Queries, imp db.FetchImport
 		Type                   string      `json:"type"`
 		Login                  string      `json:"userOrOrg"`
 		RemoveDeletedRepos     bool        `json:"removeDeletedRepos"`
+		IncludeArchivedRepos   bool        `json:"includeArchivedRepos"`
 		DefaultSyncTypes       []string    `json:"defaultSyncTypes"`
 		DefaultContainerImages []uuid.UUID `json:"defaultContainerImages"`
 	}
@@ -90,6 +91,12 @@ func handleGithubImport(ctx context.Context, qry *db.Queries, imp db.FetchImport
 
 	// upsert all fetched repositories
 	for _, repo := range repos {
+
+		// if the import is configured to ignore archived repos, skip them here
+		if !settings.IncludeArchivedRepos && repo.Archived != nil && *repo.Archived {
+			continue
+		}
+
 		var topics, _ = json.Marshal(repo.Topics)
 		var opts = db.UpsertRepoParams{
 			Repo:         fmt.Sprintf("https://github.com/%s/%s", *repo.Owner.Login, *repo.Name),


### PR DESCRIPTION
This changes the default behavior of GitHub repo auto imports to _skip_ archived repos. The prior behavior (including archived repos) can be configured by setting the `includeArchivedRepos` field to `true`.

There is currently no place in the UI where this is changeable,  so it will have to be done via direct SQL for now.

I've tested by creating an auto-import for the MergeStat org and observing that by default, no archived repos are imported. I then recreated the auto-import, except with the `includeArchivedRepos` flag set, and noted that the archived repos were imported.

Closes #1133 and #404 